### PR TITLE
Storage table refactor

### DIFF
--- a/src/storage/components/block/mod.rs
+++ b/src/storage/components/block/mod.rs
@@ -4,11 +4,15 @@ mod state;
 #[cfg(test)]
 mod test_utils;
 
-use crate::starknet::{BlockHash, BlockNumber, ContractAddress};
-use crate::storage::db::DbConfig;
-use std::sync::Arc;
+use serde::{Deserialize, Serialize};
 
+use crate::starknet::{
+    BlockHash, BlockHeader, BlockNumber, ContractAddress, IndexedDeployedContract, StarkFelt,
+    StateDiffForward, StorageKey, Transaction, TransactionIndex,
+};
 use crate::storage::db::{open_env, DbError, DbReader, DbWriter, TableIdentifier};
+use crate::storage::db::{DbConfig, TableHandle};
+use std::sync::Arc;
 
 pub use self::header::{HeaderStorageReader, HeaderStorageWriter};
 pub use self::state::{StateStorageReader, StateStorageWriter};
@@ -34,14 +38,21 @@ pub enum BlockStorageError {
 }
 pub type BlockStorageResult<V> = std::result::Result<V, BlockStorageError>;
 
+#[derive(Copy, Clone, Serialize, Deserialize)]
+pub enum MarkerKind {
+    Header,
+    Body,
+    State,
+}
+pub type MarkersTable<'env> = TableHandle<'env, MarkerKind, BlockNumber>;
 pub struct Tables {
-    markers: TableIdentifier,
-    headers: TableIdentifier,
-    block_hash_to_number: TableIdentifier,
-    transactions: TableIdentifier,
-    state_diffs: TableIdentifier,
-    contracts: TableIdentifier,
-    contract_storage: TableIdentifier,
+    markers: TableIdentifier<MarkerKind, BlockNumber>,
+    headers: TableIdentifier<BlockNumber, BlockHeader>,
+    block_hash_to_number: TableIdentifier<BlockHash, BlockNumber>,
+    transactions: TableIdentifier<(BlockNumber, TransactionIndex), Transaction>,
+    state_diffs: TableIdentifier<BlockNumber, StateDiffForward>,
+    contracts: TableIdentifier<ContractAddress, IndexedDeployedContract>,
+    contract_storage: TableIdentifier<(ContractAddress, StorageKey, BlockNumber), StarkFelt>,
 }
 #[derive(Clone)]
 pub struct BlockStorageReader {


### PR DESCRIPTION
This refactor brings to type into the Table definition. Benefits:
1. No need to specify the type on each access to DB.
2. No fear of specifying the wrong type on DB access.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/85)
<!-- Reviewable:end -->
