### PR TITLE
Remove block status from  gateway

### DIFF
--- a/crates/papyrus_gateway/src/objects/block.rs
+++ b/crates/papyrus_gateway/src/objects/block.rs
@@ -1,35 +1,9 @@
 use serde::{Deserialize, Serialize};
 use starknet_api::{
-    BlockHash, BlockHeader as StarknetBlockHeader, BlockNumber, BlockTimestamp, ContractAddress,
-    GlobalRoot, NodeBlockStatus,
+    BlockHash, BlockNumber, BlockStatus, BlockTimestamp, ContractAddress, GlobalRoot,
 };
 
 use super::transaction::Transactions;
-
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord)]
-pub enum BlockStatus {
-    #[serde(rename = "PENDING")]
-    Pending,
-    #[serde(rename = "PROVEN")]
-    Proven,
-    #[serde(rename = "ACCEPTED_ON_L2")]
-    AcceptedOnL2,
-    #[serde(rename = "ACCEPTED_ON_L1")]
-    AcceptedOnL1,
-    #[serde(rename = "REJECTED")]
-    Rejected,
-}
-
-impl From<NodeBlockStatus> for BlockStatus {
-    fn from(status: NodeBlockStatus) -> Self {
-        match status {
-            NodeBlockStatus::Pending => BlockStatus::Pending,
-            NodeBlockStatus::AcceptedOnL2 => BlockStatus::AcceptedOnL2,
-            NodeBlockStatus::AcceptedOnL1 => BlockStatus::AcceptedOnL1,
-            NodeBlockStatus::Rejected => BlockStatus::Rejected,
-        }
-    }
-}
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord)]
 pub struct BlockHeader {
@@ -37,27 +11,28 @@ pub struct BlockHeader {
     pub parent_hash: BlockHash,
     pub block_number: BlockNumber,
     pub status: BlockStatus,
-    pub sequencer: ContractAddress,
+    pub sequencer_address: ContractAddress,
     pub new_root: GlobalRoot,
-    pub accepted_time: BlockTimestamp,
+    pub timestamp: BlockTimestamp,
 }
 
-impl From<StarknetBlockHeader> for BlockHeader {
-    fn from(header: StarknetBlockHeader) -> Self {
+impl From<starknet_api::BlockHeader> for BlockHeader {
+    fn from(header: starknet_api::BlockHeader) -> Self {
         BlockHeader {
             block_hash: header.block_hash,
             parent_hash: header.parent_hash,
             block_number: header.block_number,
-            status: header.status.into(),
-            sequencer: header.sequencer,
+            status: header.status,
+            sequencer_address: header.sequencer,
             new_root: header.state_root,
-            accepted_time: header.timestamp,
+            timestamp: header.timestamp,
         }
     }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord)]
 pub struct Block {
+    #[serde(flatten)]
     pub header: BlockHeader,
     pub transactions: Transactions,
 }

--- a/crates/papyrus_gateway/src/objects/mod.rs
+++ b/crates/papyrus_gateway/src/objects/mod.rs
@@ -2,6 +2,6 @@ mod block;
 mod state;
 mod transaction;
 
-pub use self::block::{Block, BlockHeader, BlockStatus};
+pub use self::block::{Block, BlockHeader};
 pub use self::state::{from_starknet_storage_diffs, GateWayStateDiff, StateUpdate};
 pub use self::transaction::{TransactionWithType, Transactions};

--- a/crates/starknet_api/src/lib.rs
+++ b/crates/starknet_api/src/lib.rs
@@ -10,8 +10,8 @@ mod state;
 mod transaction;
 
 pub use self::block::{
-    BlockBody, BlockHash, BlockHeader, BlockNumber, BlockStatus as NodeBlockStatus, BlockTimestamp,
-    GasPrice, GlobalRoot,
+    BlockBody, BlockHash, BlockHeader, BlockNumber, BlockStatus, BlockTimestamp, GasPrice,
+    GlobalRoot,
 };
 pub use self::core::{ClassHash, ContractAddress, Nonce};
 pub use self::hash::{StarkFelt, StarkHash, GENESIS_HASH};

--- a/crates/starknet_client/src/objects/block.rs
+++ b/crates/starknet_client/src/objects/block.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use serde::{Deserialize, Serialize};
 use starknet_api::{
     BlockHash, BlockNumber, BlockTimestamp, ClassHash, ContractAddress, DeployedContract, GasPrice,
-    GlobalRoot, NodeBlockStatus, StorageDiff, StorageEntry,
+    GlobalRoot, StorageDiff, StorageEntry,
 };
 
 use super::transaction::{Transaction, TransactionReceipt};
@@ -55,14 +55,14 @@ impl Default for BlockStatus {
     }
 }
 
-impl From<BlockStatus> for NodeBlockStatus {
+impl From<BlockStatus> for starknet_api::BlockStatus {
     fn from(status: BlockStatus) -> Self {
         match status {
-            BlockStatus::Aborted => NodeBlockStatus::Rejected,
-            BlockStatus::AcceptedOnL1 => NodeBlockStatus::AcceptedOnL1,
-            BlockStatus::AcceptedOnL2 => NodeBlockStatus::AcceptedOnL2,
-            BlockStatus::Pending => NodeBlockStatus::Pending,
-            BlockStatus::Reverted => NodeBlockStatus::Rejected,
+            BlockStatus::Aborted => starknet_api::BlockStatus::Rejected,
+            BlockStatus::AcceptedOnL1 => starknet_api::BlockStatus::AcceptedOnL1,
+            BlockStatus::AcceptedOnL2 => starknet_api::BlockStatus::AcceptedOnL2,
+            BlockStatus::Pending => starknet_api::BlockStatus::Pending,
+            BlockStatus::Reverted => starknet_api::BlockStatus::Rejected,
         }
     }
 }


### PR DESCRIPTION
It changed in the gateway spec, and now it's the same as the block status in starknet_api, so we don't need it (for now).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/194)
<!-- Reviewable:end -->
