### PR TITLE
Move structs in starknet_api

### DIFF
--- a/crates/starknet_api/src/core.rs
+++ b/crates/starknet_api/src/core.rs
@@ -1,7 +1,50 @@
+#[cfg(test)]
+#[path = "core_test.rs"]
+mod core_test;
+
+use std::fmt::Debug;
+
 use serde::{Deserialize, Serialize};
 
-use super::state::PatriciaKey;
+use super::serde_utils::{HexAsBytes, PrefixedHexAsBytes};
 use super::{StarkFelt, StarkHash, StarknetApiError};
+
+/// 2**251
+pub const PATRICIA_KEY_UPPER_BOUND: &str =
+    "0x800000000000000000000000000000000000000000000000000000000000000";
+
+#[derive(Copy, Clone, Eq, PartialEq, Default, Hash, Deserialize, Serialize, PartialOrd, Ord)]
+#[serde(try_from = "PrefixedHexAsBytes<32_usize>", into = "PrefixedHexAsBytes<32_usize>")]
+pub(crate) struct PatriciaKey(StarkHash);
+impl PatriciaKey {
+    pub fn new(hash: StarkHash) -> Result<PatriciaKey, StarknetApiError> {
+        if hash >= StarkHash::from_hex(PATRICIA_KEY_UPPER_BOUND)? {
+            return Err(StarknetApiError::OutOfRange {
+                string: format!("[0x0, {PATRICIA_KEY_UPPER_BOUND})"),
+            });
+        }
+        Ok(PatriciaKey(hash))
+    }
+}
+impl TryFrom<PrefixedHexAsBytes<32_usize>> for PatriciaKey {
+    type Error = StarknetApiError;
+    fn try_from(val: PrefixedHexAsBytes<32_usize>) -> Result<Self, Self::Error> {
+        let hash = StarkHash::new(val.0)?;
+        PatriciaKey::new(hash)
+    }
+}
+
+impl From<PatriciaKey> for PrefixedHexAsBytes<32_usize> {
+    fn from(val: PatriciaKey) -> Self {
+        HexAsBytes(val.0.into_bytes())
+    }
+}
+
+impl Debug for PatriciaKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("PatriciaKey").field(&self.0).finish()
+    }
+}
 
 /// The address of a StarkNet contract.
 #[derive(

--- a/crates/starknet_api/src/core_test.rs
+++ b/crates/starknet_api/src/core_test.rs
@@ -1,0 +1,19 @@
+use assert_matches::assert_matches;
+
+use super::PatriciaKey;
+use crate::{shash, StarkHash, StarknetApiError};
+
+#[test]
+fn patricia_key_valid() {
+    let hash = shash!("0x123");
+    let patricia_key = PatriciaKey::new(hash).unwrap();
+    assert_eq!(patricia_key.0, hash);
+}
+
+#[test]
+fn patricia_key_out_of_range() {
+    // 2**251
+    let hash = shash!("0x800000000000000000000000000000000000000000000000000000000000000");
+    let err = PatriciaKey::new(hash);
+    assert_matches!(err, Err(StarknetApiError::OutOfRange { string: _err_str }));
+}

--- a/crates/starknet_api/src/state.rs
+++ b/crates/starknet_api/src/state.rs
@@ -6,15 +6,11 @@ use std::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
 
-use super::serde_utils::{HexAsBytes, PrefixedHexAsBytes};
+use super::core::PatriciaKey;
 use super::{
     BlockNumber, ClassHash, ContractAddress, ContractClass, Nonce, StarkFelt, StarkHash,
     StarknetApiError,
 };
-
-/// 2**251
-pub const PATRICIA_KEY_UPPER_BOUND: &str =
-    "0x800000000000000000000000000000000000000000000000000000000000000";
 
 /// The sequential numbering of the states between blocks in StarkNet.
 // Example:
@@ -41,39 +37,6 @@ impl StateNumber {
     }
     pub fn block_after(&self) -> BlockNumber {
         BlockNumber(self.0)
-    }
-}
-
-#[derive(Copy, Clone, Eq, PartialEq, Default, Hash, Deserialize, Serialize, PartialOrd, Ord)]
-#[serde(try_from = "PrefixedHexAsBytes<32_usize>", into = "PrefixedHexAsBytes<32_usize>")]
-pub(crate) struct PatriciaKey(StarkHash);
-impl PatriciaKey {
-    pub fn new(hash: StarkHash) -> Result<PatriciaKey, StarknetApiError> {
-        if hash >= StarkHash::from_hex(PATRICIA_KEY_UPPER_BOUND)? {
-            return Err(StarknetApiError::OutOfRange {
-                string: format!("[0x0, {PATRICIA_KEY_UPPER_BOUND})"),
-            });
-        }
-        Ok(PatriciaKey(hash))
-    }
-}
-impl TryFrom<PrefixedHexAsBytes<32_usize>> for PatriciaKey {
-    type Error = StarknetApiError;
-    fn try_from(val: PrefixedHexAsBytes<32_usize>) -> Result<Self, Self::Error> {
-        let hash = StarkHash::new(val.0)?;
-        PatriciaKey::new(hash)
-    }
-}
-
-impl From<PatriciaKey> for PrefixedHexAsBytes<32_usize> {
-    fn from(val: PatriciaKey) -> Self {
-        HexAsBytes(val.0.into_bytes())
-    }
-}
-
-impl Debug for PatriciaKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("PatriciaKey").field(&self.0).finish()
     }
 }
 

--- a/crates/starknet_api/src/state_test.rs
+++ b/crates/starknet_api/src/state_test.rs
@@ -1,9 +1,6 @@
-use assert_matches::assert_matches;
-
-use crate::state::PatriciaKey;
 use crate::{
     shash, ClassHash, ContractAddress, ContractClass, ContractNonce, DeclaredContract,
-    DeployedContract, Nonce, StarkHash, StarknetApiError, StateDiff, StorageDiff,
+    DeployedContract, Nonce, StarkHash, StateDiff, StorageDiff,
 };
 
 #[test]
@@ -60,19 +57,4 @@ fn state_sorted() {
         state_diff.destruct(),
         (sorted_deployed_contracts, sorted_storage_diffs, sorted_declared_contracts, sorted_nonces)
     );
-}
-
-#[test]
-fn patricia_key_valid() {
-    let hash = shash!("0x123");
-    let patricia_key = PatriciaKey::new(hash).unwrap();
-    assert_eq!(patricia_key.0, hash);
-}
-
-#[test]
-fn patricia_key_out_of_range() {
-    // 2**251
-    let hash = shash!("0x800000000000000000000000000000000000000000000000000000000000000");
-    let err = PatriciaKey::new(hash);
-    assert_matches!(err, Err(StarknetApiError::OutOfRange { string: _err_str }));
 }

--- a/et q
+++ b/et q
@@ -1,0 +1,1883 @@
+[33mcommit 47f64d2a4259d8a1d36a522b65a1960d5b473d50[m[33m ([m[1;36mHEAD -> [m[1;32manatg/program-compression[m[33m)[m
+Author: anatg <anatg@starkware.co>
+Date:   Sun Sep 11 15:55:05 2022 +0300
+
+    WIP
+
+[33mcommit bcdc3fe03107bb5a41522eaa040305b81e5c0982[m[33m ([m[1;31morigin/main[m[33m, [m[1;31morigin/HEAD[m[33m)[m
+Author: anatg <anatg@starkware.co>
+Date:   Sun Sep 11 15:03:41 2022 +0300
+
+    Return StarknetApiError from starknet_api crate (#248)
+    
+    * Return StarknetApiError from starknet_api crate
+
+[33mcommit caa08e1520ed549b1b2d65949b59c7ed0159b8b3[m
+Author: Yair <92672946+yair-starkware@users.noreply.github.com>
+Date:   Thu Sep 8 15:58:32 2022 +0300
+
+    Yair/patricia key (#229)
+    
+    * Patricia key struct
+
+[33mcommit ae75a1fc0c75252ed7c9280a9173ba1653c35df7[m
+Author: anatg <anatg@starkware.co>
+Date:   Wed Sep 7 15:24:47 2022 +0300
+
+    Stream from cental declared and deployed classes separately (#233)
+    
+    * Stream from cental declared and deployed classes separately
+    
+    * Fix CR
+
+[33mcommit 54514f3935f40f69c77df77fa36e9e9ad8b9891f[m
+Author: anatg <anatg@starkware.co>
+Date:   Wed Sep 7 11:59:37 2022 +0300
+
+    Change gateway error messages (#236)
+    
+    * Change gateway error messages
+
+[33mcommit 6a84113d797d5450a43b0514e3ffc7e16300ab3d[m
+Author: anatg <anatg@starkware.co>
+Date:   Wed Sep 7 11:54:11 2022 +0300
+
+    Remove 'class_hash' from declared contracts in gateway (#237)
+    
+    * Remove 'class_hash' from declared contracts in gateway
+
+[33mcommit db60093ade104a8d3ffb2e687742658e0bc80b8b[m
+Author: anatg <anatg@starkware.co>
+Date:   Wed Sep 7 11:23:24 2022 +0300
+
+    Move shash to testing (#235)
+    
+    * Move shash to testing
+
+[33mcommit 7fc0526cf42a130636864365bba5aa95a0018d09[m
+Author: Yair <92672946+yair-starkware@users.noreply.github.com>
+Date:   Tue Sep 6 10:54:14 2022 +0300
+
+    Test that the members of StateDiff are sorted (#228)
+    
+    * Test that the members of StateDiff are sorted
+    
+    * Fix naming
+
+[33mcommit a529e1c1c7e8c7ae7ffdc269435a5b66be127437[m
+Author: anatg <anatg@starkware.co>
+Date:   Tue Sep 6 10:36:50 2022 +0300
+
+    Update transaction outputs (#231)
+    
+    * Update transaction outputs
+
+[33mcommit 114d00a0c1c228ebfe653bb3383cea2acd116789[m
+Author: anatg <anatg@starkware.co>
+Date:   Mon Sep 5 18:29:17 2022 +0300
+
+    Add L1 handler transaction (#218)
+    
+    * Add L1 handler transaction
+    
+    * Add l1 handler transaction to client
+    
+    * Fix CR
+
+[33mcommit 2e7940ea192c789c9f0454d70f3170221b68fda1[m
+Author: anatg <anatg@starkware.co>
+Date:   Mon Sep 5 14:48:53 2022 +0300
+
+    Split invoke transaction in the gateway to 2 versions (#219)
+    
+    * Split invoke transaction in the gatewayto 2 versions
+    
+    * Fix CR
+
+[33mcommit 5335b3c62df14838d601e24e65f4b67b12d69ca8[m
+Author: Yair <92672946+yair-starkware@users.noreply.github.com>
+Date:   Mon Sep 5 09:58:53 2022 +0300
+
+    Revert sorting in class_hashes since we sort StateDiff anyways (#230)
+
+[33mcommit 92c22eac6efc0a1b7b7e09889a1ed5cd9daad10c[m
+Author: anatg <anatg@starkware.co>
+Date:   Sun Sep 4 16:27:29 2022 +0300
+
+    Change ClientStateDiff and BlockStateUpdate (#225)
+    
+    * Change ClientStateDiff and BlockStateUpdate to StateDiff and StateUpdate respectively
+
+[33mcommit 20004e23b5e86821961683ca678b8888cdc77ce4[m
+Author: anatg <anatg@starkware.co>
+Date:   Sun Sep 4 16:18:41 2022 +0300
+
+    Use DeclaredContract and ContractNonce (#227)
+    
+    * Use DeclaredContract and ContractNonce
+
+[33mcommit ab4d087315d8fb637fa875e30caaf9ccf7cfde9a[m
+Author: Yair <92672946+yair-starkware@users.noreply.github.com>
+Date:   Sun Sep 4 14:33:23 2022 +0300
+
+    Yair/enforce transactions vec length (#192)
+    
+    * Verify in block body that transactions and transactions_output have the same length
+
+[33mcommit 6eea7112bb7f1b9ddef983a85932f92567fc5251[m
+Author: ShahakShama <70578257+ShahakShama@users.noreply.github.com>
+Date:   Thu Sep 1 17:01:55 2022 +0300
+
+    fix bug in gateway's thread (#220)
+    
+    * fix bug in gateway's thread
+
+[33mcommit 37a0e889c8d743ad87ee971cb099040d861cd600[m
+Author: anatg <anatg@starkware.co>
+Date:   Tue Aug 30 16:01:39 2022 +0300
+
+    Update gateway StateUpdate (#209)
+    
+    * Update gateway StateUpdate
+
+[33mcommit 7b28bc9fb5aa30f52e8c8428e2db8fc975bbe22e[m
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Mon Aug 29 15:59:06 2022 +0300
+
+    StorageSerde trait (#213)
+    
+    * StorageSerde trait
+    
+    * Merge main into spapini/db_serder_trait
+    
+    * Merge main into spapini/db_serder_trait
+
+[33mcommit 0a6c579d736a3a9630572980de687d32715e33dd[m
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Mon Aug 29 15:26:56 2022 +0300
+
+    Enforce StarkHash range (#212)
+
+[33mcommit 8ce9f437811062be34d3919cd0a362e2d2011ba0[m
+Author: anatg <anatg@starkware.co>
+Date:   Mon Aug 29 13:08:41 2022 +0300
+
+    Return transaction receipt from gateway (#200)
+    
+    * Return transaction receipt from gateway
+    
+    * Fix CR
+
+[33mcommit 38d0711298d6761490ac550825df205da9d15ba1[m
+Author: Yair <92672946+yair-starkware@users.noreply.github.com>
+Date:   Sun Aug 28 14:33:31 2022 +0300
+
+    Sort members of StateDiff instead of assuming they are already sorted (#215)
+
+[33mcommit 14f27bac1c191424b07bedc7f3a7cbf1a8b6fdb3[m
+Author: anatg <anatg@starkware.co>
+Date:   Sun Aug 28 14:07:37 2022 +0300
+
+    Move status out of block header (#211)
+    
+    * Move status out of block header
+    
+    * Fix CR
+
+[33mcommit cde36fc9322287ffbb54b1049106cba61e586f00[m
+Author: anatg <anatg@starkware.co>
+Date:   Wed Aug 24 15:34:40 2022 +0300
+
+    Get nonces from storage in gateway (#208)
+    
+    * Get nonces from storage in gateway
+
+[33mcommit ca9d3122476c13c3d4788d6b859282a43522b9c3[m
+Author: anatg <anatg@starkware.co>
+Date:   Wed Aug 24 13:27:31 2022 +0300
+
+    Stream transaction outputs from central (#202)
+    
+    * Stream transaction outputs from central
+
+[33mcommit df15f8bd0b24fb60a4e32097c50b9a2628945f96[m
+Author: anatg <anatg@starkware.co>
+Date:   Wed Aug 24 12:54:59 2022 +0300
+
+    Translate client block to starknet_api block (#201)
+    
+    * Translate client block to starknet_api block
+    
+    * Fix CR
+
+[33mcommit e7c05e9bf7eb377dd2401c1311b29bfcc07fb5c0[m
+Author: ShahakShama <70578257+ShahakShama@users.noreply.github.com>
+Date:   Tue Aug 23 10:27:56 2022 +0300
+
+    Add a simple block hash test with a TODO to make it better (#198)
+    
+    * Add a simple block hash test with a TODO to make it better
+
+[33mcommit de05c7e0e2b57f80518dc4919cf23429de57e4cd[m
+Author: Yair <92672946+yair-starkware@users.noreply.github.com>
+Date:   Sun Aug 21 15:15:34 2022 +0300
+
+    Yair/enforce state update sorted (#185)
+    
+    * Enforce the invariant that StateDiff should be sorted by address
+    
+    * Improve comment
+    
+    * Extract stream_state_updates body to separate function
+    
+    * Fix conflict
+
+[33mcommit 129d4c1cc2eac30b9b3dd884c878b02b5cd0a119[m
+Author: ShahakShama <70578257+ShahakShama@users.noreply.github.com>
+Date:   Thu Aug 18 16:55:19 2022 +0300
+
+    add basic load test (#196)
+    
+    * add basic load test
+    
+    * CR fix + add CI support
+
+[33mcommit 171facb8d87ed9944e3b4f1250c842eb0a07ddea[m
+Author: ShahakShama <70578257+ShahakShama@users.noreply.github.com>
+Date:   Thu Aug 18 14:10:42 2022 +0300
+
+    shahak/source test/proper mocking (#190)
+    
+    * use mockall (in not test too)
+    
+    * WIP
+    
+    * WIP (pass to papini)
+    
+    * add comment
+
+[33mcommit 0d68d8a0760578c4c0861222090eea16d92ebf00[m
+Author: anatg <anatg@starkware.co>
+Date:   Wed Aug 17 17:38:08 2022 +0300
+
+    Remove block status from  gateway (#194)
+    
+    * Remove block status from  gateway
+
+[33mcommit cef1a15cc1834feab61ccfae8b3dc1dfa3d11865[m
+Author: anatg <anatg@starkware.co>
+Date:   Wed Aug 17 16:30:21 2022 +0300
+
+    Simplify CentralError BlockNotFound (#193)
+    
+    * Simplify CentralError BlockNotFound
+
+[33mcommit 322ddbe87feef7ef137942098467a5671099a661[m
+Author: ShahakShama <70578257+ShahakShama@users.noreply.github.com>
+Date:   Tue Aug 16 16:04:28 2022 +0300
+
+    sort dependencies (#191)
+    
+    * sort dependencies
+
+[33mcommit ce4a4222ce82e90b1b22909ea3335848aff6f6d2[m
+Author: ShahakShama <70578257+ShahakShama@users.noreply.github.com>
+Date:   Mon Aug 15 16:10:51 2022 +0300
+
+    implement state diff test (#189)
+    
+    * implement state diff test
+    
+    * CR fix
+
+[33mcommit 73d090737e828e236de8b4b23073aca1c7739815[m
+Author: ShahakShama <70578257+ShahakShama@users.noreply.github.com>
+Date:   Mon Aug 15 14:43:36 2022 +0300
+
+    fix bug in handling error in getting a block and adding a test for it (#164)
+    
+    * fix bug in handling error in getting a block and adding a test for it
+    
+    * CR fix (use assert_matches)
+
+[33mcommit 121cf55f2207b8090baad325e57638548d43a9ba[m
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Mon Aug 15 11:44:59 2022 +0300
+
+    Write tx output to storage (#188)
+    
+    * Write tx output to storage
+
+[33mcommit c64693b465037cbd7fc39b61a520cbd739b4c777[m
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Mon Aug 15 11:32:20 2022 +0300
+
+    Add different operation systems to CI (#186)
+    
+    * Add different operation systems to CI
+
+[33mcommit 135bdacfc7362edc1a094bf1605821af3f26140d[m
+Author: anatg <anatg@starkware.co>
+Date:   Mon Aug 15 11:07:40 2022 +0300
+
+    Disable delay test in retry (#187)
+    
+    * Disable delay test in retry
+
+[33mcommit 82d9dc57b4f20d836ac58a0126acb6b6d0446f42[m[33m ([m[1;32manatg/gateway/program[m[33m)[m
+Author: anatg <anatg@starkware.co>
+Date:   Sun Aug 14 17:24:15 2022 +0300
+
+    Add Starknet error codes in client (#184)
+    
+    * Add Starknet error codes in client
+
+[33mcommit 6cdd9e9528721ef9874748b037a63cdcc1f7ec91[m
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Sun Aug 14 15:38:44 2022 +0300
+
+    Consistent version on CI (#183)
+    
+    * Consistent version on CI
+
+[33mcommit dec52cb22715411d9b66642b2a42a14b4ffc910e[m
+Author: ShahakShama <70578257+ShahakShama@users.noreply.github.com>
+Date:   Sun Aug 14 13:58:16 2022 +0300
+
+    add stream_new_blocks test where some blocks are missing (#163)
+    
+    * add stream_new_blocks test where some blocks are missing
+    
+    * CR fix
+    
+    * CR fix
+
+[33mcommit 63e33e2e279bfe2e354f964c9fa8de50485cdb5b[m
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Sun Aug 14 12:59:23 2022 +0300
+
+    Add tx outputs to block body (#179)
+    
+    * Add tx outputs to block body
+
+[33mcommit 356a58a41c87c260ad79401bd42e45d52639aa30[m
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Sun Aug 14 12:36:04 2022 +0300
+
+    Add Eq when needed (#182)
+    
+    * Add Eq when needed
+
+[33mcommit 15181b97bcfeace3341d82764f77a5cfa3bcdf83[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Thu Aug 11 15:43:48 2022 +0300
+
+    Add DB stats (#180)
+    
+    * Add DB stats
+
+[33mcommit d306948285a1a40fc5fa9b66cf367fd8f8276d76[m
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Thu Aug 11 15:02:24 2022 +0300
+
+    Separate TransactionOutput from TransactionReceipt. (#177)
+    
+    * Separate TransactionOutput from TransactionReceipt.
+
+[33mcommit 927cca2e5eb76e0456abd883a909280132f01813[m
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Thu Aug 11 14:58:57 2022 +0300
+
+    Move state structs to a dedicated module (#178)
+    
+    * Move state structs to a dedicated module
+
+[33mcommit af444f32bb7f3e6e78089c9882324d40f961dde0[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Thu Aug 11 11:29:13 2022 +0300
+
+    Fix db table names (#175)
+    
+    * Fix db table names
+
+[33mcommit f18d21c5185e45bf12509cfd4bcf82c788f0edeb[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Thu Aug 11 11:21:50 2022 +0300
+
+    Make SN-client responses optional (#174)
+    
+    * Make SN-client responses optional
+
+[33mcommit 2090b1aab828e49be1965d5c78f9e92bc799aa97[m
+Author: Yair <92672946+yair-starkware@users.noreply.github.com>
+Date:   Thu Aug 11 09:59:23 2022 +0300
+
+    Starknet client: refactor get_block and get_block_number to share code (#172)
+    
+    * Starknet client: refactor get_block and get_block_number to share code
+    
+    * Starknet client: test get_block on non-existing block
+
+[33mcommit 7dee59d1b573544eaf17a27321e98cab1c7c6cae[m
+Author: anatg <anatg@starkware.co>
+Date:   Wed Aug 10 12:59:49 2022 +0300
+
+    Add nonce to every deployed contract address, and return None from ge… (#161)
+    
+    * Add nonce to every deployed contract address
+    
+    * CR fix
+
+[33mcommit 36b7313b28939ca6d378c978fe4d31895ac89f94[m
+Author: anatg <anatg@starkware.co>
+Date:   Wed Aug 10 10:13:48 2022 +0300
+
+    Update get_class and get_class_at in gateway (#167)
+    
+    * Update get_class and get_class_at in gateway
+    
+    * Fix CR
+
+[33mcommit 12710b7657452e7bb7f0ce020b434fedac14f687[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Wed Aug 10 09:59:55 2022 +0300
+
+    Add documentation to starknet API (#173)
+    
+    * Add documentation to starknet API
+
+[33mcommit e713a0095ba9050761e5e25148fbaa28bcd92a85[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Tue Aug 9 16:30:10 2022 +0300
+
+    Add documentation comments to starknet client (#171)
+    
+    * Add documentation comments to starknet client
+
+[33mcommit 9fdbc07de91faa42be20cce4e8b0def1bae8d41f[m
+Author: Yair <92672946+yair-starkware@users.noreply.github.com>
+Date:   Tue Aug 9 13:08:40 2022 +0300
+
+    Starknet client test - extract contract class body to a resource file (#169)
+
+[33mcommit 9ef078744e5f37798674f1f7cecbb0a2e1bd48cb[m
+Author: anatg <anatg@starkware.co>
+Date:   Tue Aug 9 10:02:53 2022 +0300
+
+    Change BadResponse error in client to include reqwest status errors (#170)
+    
+    * Change BadResponse error in client to include reqwest status errors
+
+[33mcommit 18779a6c636840321c285468ff054589f31cf463[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Mon Aug 8 13:10:37 2022 +0300
+
+    Concurrent state diff requests in central source (#166)
+    
+    * Concurrent state diff requests in central source
+
+[33mcommit 24a5830da4718a3ff0b29049b63721d26d3ff27b[m
+Author: anatg <anatg@starkware.co>
+Date:   Mon Aug 8 10:56:34 2022 +0300
+
+    Add request retries and connection error to client (#165)
+    
+    * Add request retries and connection error to client
+    
+    * Fix CR
+
+[33mcommit 679b03d4ac950f8854cc1f63bba330f1877ff283[m
+Author: anatg <anatg@starkware.co>
+Date:   Thu Aug 4 14:57:58 2022 +0300
+
+    Add retry to client test utils (#151)
+    
+    * Add retry to client test utils
+    
+    * CR fix
+
+[33mcommit 2747940bed2fd2769c867c0c0a54f4dae2af1273[m
+Author: Yair <92672946+yair-starkware@users.noreply.github.com>
+Date:   Thu Aug 4 11:03:00 2022 +0300
+
+    Separate test for precision in serialization. (#162)
+    
+    * Separate test for precision in serialization.
+
+[33mcommit 738891c71c30caf29f03969812b2cb5f2bdfc013[m
+Author: ShahakShama <70578257+ShahakShama@users.noreply.github.com>
+Date:   Wed Aug 3 16:24:29 2022 +0300
+
+    shahak/source test/refactor stream block headers test (#160)
+    
+    * mock StarknetClient in stream_block_headers test
+    
+    * refactor stream_block_headers test
+    
+    * CR fix
+
+[33mcommit 6d2c8df84906a185b7e34b9cd85f5e9d6fc9a1ea[m
+Author: ShahakShama <70578257+ShahakShama@users.noreply.github.com>
+Date:   Wed Aug 3 15:18:17 2022 +0300
+
+    took a better block for the json (#130)
+    
+    * took a better block for the json
+
+[33mcommit bfb16b4fb899c8d4455bdf4ab75bce7b7914005a[m
+Author: ShahakShama <70578257+ShahakShama@users.noreply.github.com>
+Date:   Tue Aug 2 10:03:17 2022 +0300
+
+    make CentralSource work with any StarknetClientTrait (#155)
+    
+    * add GenericCentralSource
+
+[33mcommit ab1c1abab74f803ba50cafeab522c3f4bc968109[m
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Mon Aug 1 16:09:14 2022 +0200
+
+    Fix CI (#159)
+
+[33mcommit e294a578df92fc2c0e4e781222346acefd7dc80a[m
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Mon Aug 1 14:25:02 2022 +0200
+
+    Split to more crates (#156)
+    
+    * Split to more crates
+
+[33mcommit 9b1ada9da6585bdae46fedbb81d430e8341fbd8d[m
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Mon Aug 1 13:28:40 2022 +0200
+
+    Fix rustfmt nightly version (#157)
+    
+    * Fix rustfmt nightly version
+
+[33mcommit 426d25590c5c0ccb67d243597da41315770d6388[m
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Mon Aug 1 12:42:27 2022 +0200
+
+    CI on PR base change (#158)
+    
+    * CI on PR base change
+
+[33mcommit d15163d89deab767749a8829f7bfda7188a2f724[m
+Author: ShahakShama <70578257+ShahakShama@users.noreply.github.com>
+Date:   Mon Aug 1 10:54:28 2022 +0300
+
+    add StarknetClientTrait (#153)
+    
+    * add StarknetClientTrait
+    
+    * CR fix
+
+[33mcommit e5feeed02e7f75811efebcf122b673dc23ff7a65[m
+Author: anatg <anatg@starkware.co>
+Date:   Mon Aug 1 10:48:21 2022 +0300
+
+    Add get_nonce to gateway (#149)
+    
+    * Add get_nonce to gateway
+
+[33mcommit 092f0b94d590215d3908a1ca46ae683db79e01d9[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Sun Jul 31 11:31:45 2022 +0300
+
+    Concurrent block requests in central source (#152)
+    
+    * Concurrent block requests in central source
+
+[33mcommit 71ea5063e6e91d716b55c71937880ddc4edefc09[m
+Author: ShahakShama <70578257+ShahakShama@users.noreply.github.com>
+Date:   Sun Jul 31 11:01:00 2022 +0300
+
+    add constants to starknet client queries (#145)
+    
+    * add constants to starknet client queries
+
+[33mcommit 87e7bae53e30d4bfa5ca6f674aa23908e2d735b0[m
+Author: ShahakShama <70578257+ShahakShama@users.noreply.github.com>
+Date:   Sun Jul 31 10:46:14 2022 +0300
+
+    change state_update test to use resource file (#139)
+    
+    * change state_update test to use resource file
+    
+    * move hard_coded state_update test to block_test
+
+[33mcommit cd182609ddfbd4065aebef71f4535f3ad398b642[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Sat Jul 30 20:27:33 2022 +0300
+
+    Add nonces to storage (#150)
+    
+    * Add nonces to storage
+
+[33mcommit 943805eb73363d22bf1838accbac4c2892d8539f[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Wed Jul 27 18:16:43 2022 +0300
+
+    Dan/central/contract class (#148)
+    
+    * Persist contract classes
+    
+    * Rename state diff structs
+    
+    * Split state diff
+
+[33mcommit 7faccadc85d579f3f91031baf543d3225ef62eef[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Wed Jul 27 17:56:35 2022 +0300
+
+    Use arbitrary_precision in serde_json (#146)
+    
+    * Use arbitrary_precision in serde_json
+
+[33mcommit 1ab389ef49f3ccb352e39bb1590ad2830af44946[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Mon Jul 25 13:55:53 2022 +0300
+
+    Move starknet_client_integration_test (#144)
+    
+    * Move starknet client & central source integration tests
+
+[33mcommit f1219ee26ed69c7007a0b9c24576246e7c54207a[m
+Author: anatg <anatg@starkware.co>
+Date:   Mon Jul 25 10:56:48 2022 +0300
+
+    Add block_hash_and_number to gateway (#143)
+    
+    * Add block_hash_and_number to gateway
+
+[33mcommit 173f89137da88aa66a5128c901be4ec4c917a407[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Mon Jul 25 10:06:23 2022 +0300
+
+    Rename streams in sync (#138)
+    
+    * Rename streams in sync
+
+[33mcommit 203f06a3740839897af0832362c60b538d6bce7f[m
+Author: anatg <anatg@starkware.co>
+Date:   Mon Jul 25 09:49:19 2022 +0300
+
+    Update starknet_api and gateway transactions according to rpc api (#136)
+    
+    * Update starknet_api and gateway transactions according to rpc api
+    
+    * Fix CR and return from get_transaction_by_ TransactionWithType
+
+[33mcommit cb4428d67ec10d45b4a7cdbb3767e61ac6513112[m
+Author: anatg <anatg@starkware.co>
+Date:   Mon Jul 25 09:23:32 2022 +0300
+
+    Anatg/storage reorg (#112)
+    
+    * Remove state, block, and components modules
+    
+    * Rename blockstorage storage
+    
+    * Fix CR
+
+[33mcommit 2b83ba38d7d34e055fe9f0f9492e2724ee7fb89d[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Sun Jul 24 17:03:30 2022 +0300
+
+    Add get class by hash (#137)
+    
+    * Add get class by hash
+
+[33mcommit 024b7dcf189dd364b1afde693bb8334895b21c1b[m
+Author: ShahakShama <70578257+ShahakShama@users.noreply.github.com>
+Date:   Sun Jul 24 16:46:45 2022 +0300
+
+    add transaction receipt test (#141)
+    
+    * add transaction receipt test
+
+[33mcommit b7b338b266856e230ecae999829e945b92d9d19a[m
+Author: ShahakShama <70578257+ShahakShama@users.noreply.github.com>
+Date:   Sun Jul 24 16:42:02 2022 +0300
+
+    add test for invoke transaction with l1 handler (#142)
+    
+    * add test for invoke transaction with l1 handler
+
+[33mcommit 666debd880c9214c2e5be2d517fb969a9a40a85b[m
+Author: ShahakShama <70578257+ShahakShama@users.noreply.github.com>
+Date:   Sun Jul 24 16:36:00 2022 +0300
+
+    add test for loading a generic transaction (#140)
+    
+    * add test for loading a generic transaction
+
+[33mcommit 45ff25a36de4f164e21cb889e2d192de0ed11281[m
+Author: anatg <anatg@starkware.co>
+Date:   Sun Jul 24 16:26:05 2022 +0300
+
+    Add get_class_hash_at to gateway (#108)
+    
+    * Add get_class_hash_at to gateway
+
+[33mcommit e28c64648b9512589328bc806c1ad825f2b459a3[m
+Author: ShahakShama <70578257+ShahakShama@users.noreply.github.com>
+Date:   Sun Jul 24 16:17:37 2022 +0300
+
+    add test where an unserializable block is returned (#118)
+    
+    * add test where an unserializable block is returned
+
+[33mcommit 2d034018ad459e5f03c96b9160b2097f8983df9c[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Sun Jul 24 16:00:02 2022 +0300
+
+    Remove INITIALIZE_BLOCK_INFO (#123)
+    
+    * Remove INITIALIZE_BLOCK_INFO
+
+[33mcommit fadc685d0f9defefdcc758ec83025d4184d12750[m
+Author: anatg <anatg@starkware.co>
+Date:   Sun Jul 24 10:40:21 2022 +0300
+
+    Add get_class_at and get_class to gateway (#124)
+    
+    * Add get_class_at and get_class to gateway
+
+[33mcommit de01d37c730530d24fa6af95e4dc37adb7ec1183[m
+Author: anatg <anatg@starkware.co>
+Date:   Sun Jul 24 10:21:33 2022 +0300
+
+    Fix serde of BlockId (#131)
+    
+    * Fix serde of BlockId
+
+[33mcommit 26e482bfd829ecdd7d8f5551e7844749618670ee[m
+Author: ShahakShama <70578257+ShahakShama@users.noreply.github.com>
+Date:   Sun Jul 24 07:47:42 2022 +0300
+
+    change assert_matches into a dev dependency (#129)
+    
+    * change assert_matches into a dev dependency
+
+[33mcommit 960c81d2f317fae2ffb2343922ccc1f2640a086e[m
+Author: ShahakShama <70578257+ShahakShama@users.noreply.github.com>
+Date:   Sun Jul 24 07:45:22 2022 +0300
+
+    add test for loading declare transaction (#135)
+    
+    * add test for loading declare transaction
+
+[33mcommit dec36e75c3ffda1dd2aae5c09de393e6a6b6003f[m
+Author: ShahakShama <70578257+ShahakShama@users.noreply.github.com>
+Date:   Sun Jul 24 07:36:35 2022 +0300
+
+    add test for loading invoke transaction (#133)
+    
+    * add test for loading invoke transaction
+
+[33mcommit ba9c3d83d44c27c5ae4a22645f3c92f47572bcab[m
+Author: ShahakShama <70578257+ShahakShama@users.noreply.github.com>
+Date:   Thu Jul 21 17:43:26 2022 +0300
+
+    add test for loading deploy transaction (#132)
+    
+    * add test for loading deploy transaction
+
+[33mcommit 0d0109eb9111ed0eee06c181a81bd8e07e58f133[m
+Author: ShahakShama <70578257+ShahakShama@users.noreply.github.com>
+Date:   Thu Jul 21 17:02:45 2022 +0300
+
+    shahak/sn client test/block state update resource (#128)
+    
+    * add block_state_update.json and load test
+
+[33mcommit 40f9d803f46ab3b52d3665db96c8aea79fdc21c5[m
+Author: ShahakShama <70578257+ShahakShama@users.noreply.github.com>
+Date:   Thu Jul 21 16:50:54 2022 +0300
+
+    use block resource in client test (#127)
+    
+    * use block resource in client test
+
+[33mcommit 15a9932494261c5eddeea2689ad1ab226976668b[m
+Author: ShahakShama <70578257+ShahakShama@users.noreply.github.com>
+Date:   Thu Jul 21 11:48:52 2022 +0300
+
+    add block.json and utility to read it (#126)
+    
+    * add block.json and utility to read it
+    
+    * CR fix
+
+[33mcommit 43b1a0b8399cd86206e7d4c6526fb6140063d1da[m
+Author: anatg <anatg@starkware.co>
+Date:   Thu Jul 21 10:37:57 2022 +0300
+
+    Add get_transaction_receipt to gateway (#119)
+    
+    * Add get_transaction_receipt to gateway
+
+[33mcommit 1db05f1ab0f5a7f2b1eafc2290cde86728060aa3[m
+Author: anatg <anatg@starkware.co>
+Date:   Wed Jul 20 15:16:41 2022 +0300
+
+    Add get_state_update to gateway (#117)
+    
+    * Add get_state_update to gateway
+    
+    * CR fix
+
+[33mcommit fca1b402447a39eda936661a091f4d91cb1e6ab9[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Wed Jul 20 15:12:41 2022 +0300
+
+    Fix examples. (#121)
+    
+    * Fix examples.
+
+[33mcommit 0df80aa18d97e362582cde58714df6d097b86a8a[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Wed Jul 20 14:55:15 2022 +0300
+
+    Fix class_hash (#122)
+    
+    * Fix class_hash
+
+[33mcommit 536694ca3f6c3cae04405ffc3de34780dfc277c1[m
+Author: anatg <anatg@starkware.co>
+Date:   Wed Jul 20 10:43:02 2022 +0300
+
+    Add get_block_transaction_count to gateway (#116)
+    
+    * Add get_block_transaction_count to gateway
+    
+    * CR fix
+
+[33mcommit ac9b1d808cfadcdaf9dacf57c3feb28f836a6b81[m
+Author: ShahakShama <70578257+ShahakShama@users.noreply.github.com>
+Date:   Wed Jul 20 09:22:54 2022 +0300
+
+    add HexAsBytes serde test (#105)
+    
+    * add HexAsBytes serde test
+
+[33mcommit 8501b8842b694aed899dca159357c85ba95663da[m
+Author: anatg <anatg@starkware.co>
+Date:   Tue Jul 19 09:52:05 2022 +0300
+
+    Change number in BlockHeader in starknet_api to block_number (#113)
+    
+    * Change number in BlockHeader in starknet_api to block_number
+
+[33mcommit 1a5211a619b72b590e194cbd821d1644d12977db[m
+Author: anatg <anatg@starkware.co>
+Date:   Tue Jul 19 09:43:33 2022 +0300
+
+    Create a test block fixture (#115)
+    
+    * Create a test block fixture
+
+[33mcommit 92675e67bc9cf65353ffd0a1fbfa0ba22d80b845[m
+Author: ShahakShama <70578257+ShahakShama@users.noreply.github.com>
+Date:   Mon Jul 18 16:52:13 2022 +0300
+
+    add test to constructor checking urls (#110)
+    
+    * add test to constructor checking urls
+    
+    * CR fix
+    
+    * add constant
+
+[33mcommit 7bf73148d2c1e93c8fe2650f57eaba058f00d1ef[m
+Author: anatg <anatg@starkware.co>
+Date:   Mon Jul 18 16:44:12 2022 +0300
+
+    Return the transactions in the get block of the gateway (#114)
+    
+    * Return the transactions in the get block of the gateway
+
+[33mcommit a3c862626e50b783561f486acd51cc25207e24ee[m
+Author: anatg <anatg@starkware.co>
+Date:   Mon Jul 18 15:04:08 2022 +0300
+
+    Change to BlockId (#111)
+    
+    * Change to BlockId
+    
+    * CR fix
+
+[33mcommit a7509ef86eec0d88c6be08be04886e321e5a3d1a[m
+Author: anatg <anatg@starkware.co>
+Date:   Sun Jul 17 10:58:13 2022 +0300
+
+    Remove block response scope from gateway (#109)
+    
+    * Remove block response scope from gateway
+
+[33mcommit 33056a65d67daf49eae2b4332a192bcda4656ff7[m
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Thu Jul 14 13:32:38 2022 +0300
+
+    Split to crates (#103)
+    
+    * Split to crates
+
+[33mcommit 95cff48dddf6d7477f082532104e5c20b4f2ed8e[m[33m ([m[1;32mall[m[33m)[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Wed Jul 13 13:08:13 2022 +0300
+
+    Fix get latest block number (#99)
+    
+    * Fix get latest block number
+
+[33mcommit 308ff148f88c8351733cd05bce3bb2c5f1ae6f15[m
+Author: anatg <anatg@starkware.co>
+Date:   Wed Jul 13 09:46:08 2022 +0300
+
+    Add get_transaction to gateway api (#100)
+    
+    * Add get_transaction to gateway api
+    
+    * CR fix
+
+[33mcommit 4b490cc61493ba94d0440ad18797e8acc606255d[m
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Tue Jul 12 11:46:37 2022 +0300
+
+    Storage txn refactor (#102)
+    
+    * Storage txn refactor
+
+[33mcommit baa2de86e40d799a493c0d72e80e61244e459194[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Tue Jul 12 08:58:01 2022 +0300
+
+    Serde by human_readable (#98)
+    
+    * Serde by human_readable
+
+[33mcommit dbdfc70cb727d3f9d3c00748ce418df0372c4c2c[m
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Mon Jul 11 23:15:00 2022 +0300
+
+    Db mode (#106)
+    
+    * Db mode
+
+[33mcommit aaaa2886b9b119ccf6aa87419d058fd2843b99d7[m
+Author: anatg <anatg@starkware.co>
+Date:   Sun Jul 10 16:49:27 2022 +0300
+
+    Change gateway server to http and addgateway config (#95)
+    
+    * Change gateway server to http and addgateway config
+    
+    * Fix CR
+
+[33mcommit 6d3a6b95f080b7cbf22ce1d02866cac896a0a817[m
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Thu Jul 7 12:06:04 2022 +0300
+
+    Read block transactions (#94)
+    
+    * Read block transactions
+
+[33mcommit ced8ca6ff1962b014a75ae2e6a462e8322a4fd3f[m
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Thu Jul 7 11:41:09 2022 +0300
+
+    Transaction hash to idx (#89)
+    
+    * Transaction hash to idx
+
+[33mcommit 8626a6dcb4b421c9b710df6bfa3e3ab9bca63260[m
+Author: anatg <anatg@starkware.co>
+Date:   Thu Jul 7 11:01:48 2022 +0300
+
+    Add get_storage_at to gateway (#83)
+    
+    * Add get_storage_at to gateway
+    
+    * Fix CR
+
+[33mcommit e57987fd410295484b9c23d8dd5e0e3ab37d342d[m
+Author: ShahakShama <70578257+ShahakShama@users.noreply.github.com>
+Date:   Thu Jul 7 09:51:42 2022 +0300
+
+    Add test for StarkHash serde_json (#97)
+    
+    * Add test for StarkHash serde_json
+    
+    * CR fix
+
+[33mcommit 8682e8fb441e374d456b0b4dbdb8b060bfe15da3[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Wed Jul 6 17:44:23 2022 +0300
+
+    Fix declare tx serde (#96)
+    
+    * Fix declare tx serde
+
+[33mcommit cde495d76997ec7f4d55af2cd37073330914412e[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Wed Jul 6 17:26:14 2022 +0300
+
+    Add execution resources (#92)
+    
+    * Add execution resources
+
+[33mcommit 08808b27ddc22c5787dab287e0bb4e346e53ae8a[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Wed Jul 6 16:41:32 2022 +0300
+
+    Use shash macro (#93)
+    
+    * Use shash macro
+
+[33mcommit 7246b93608612e444cd76534c32a1e529b3c4025[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Wed Jul 6 13:44:06 2022 +0300
+
+    Add block propagation sleep period config (#91)
+    
+    * Add block propagation sleep period config
+
+[33mcommit d0e501bff32b5a512f991c61023c32a0c93fc844[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Wed Jul 6 13:39:40 2022 +0300
+
+    Remove an already done todo (#90)
+    
+    * Remove an already done todo
+
+[33mcommit 6832f861600279c1ea05f1642df22b4f694b5a48[m
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Wed Jul 6 10:45:05 2022 +0300
+
+    DbCursor (#88)
+    
+    * DbCursor
+
+[33mcommit 0a0d66d4106435cf992aa5cd7534af3dad0d34c3[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Mon Jul 4 15:59:51 2022 +0300
+
+    Add stream state updates integration test (#87)
+    
+    * Add stream state updates integration test
+
+[33mcommit ea5836bad0e28bc38d4cfb7ad05604f7426e6ad7[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Mon Jul 4 15:55:04 2022 +0300
+
+    Dan/integration test/state diff (#81)
+    
+    * Add state diff to sn-client example
+
+[33mcommit e64897d1e7d639c57ca62dd90ae6b6fbfee2796a[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Mon Jul 4 14:16:36 2022 +0300
+
+    Store block transactions (#84)
+    
+    * Store block transactions
+
+[33mcommit ddc4f07c5897398b2bc0316942281840c2286f7b[m
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Mon Jul 4 13:11:01 2022 +0300
+
+    Storage table refactor (#85)
+    
+    * Storage table refactor
+
+[33mcommit 6935977cb45e0b3046477d7b7a30e52b289951a3[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Mon Jul 4 12:48:40 2022 +0300
+
+    Dan/sync/state diff (#80)
+    
+    * Sync also state diffs
+
+[33mcommit 8f749c2512888b1912f0fc3506762216d5e45418[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Mon Jul 4 10:41:20 2022 +0300
+
+    Dan/sources/central/state diff stream (#79)
+    
+    * Add state diff stream
+
+[33mcommit 31c4a035ec191286efb785a04b200b114be94657[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Sun Jul 3 11:12:38 2022 +0300
+
+    Remove mutability (#82)
+    
+    * Remove mutability
+
+[33mcommit 354e649f0a94bad76d22d9631f9500446bb47789[m
+Author: anatg <anatg@starkware.co>
+Date:   Sun Jul 3 09:51:23 2022 +0300
+
+    Add get block by hash to gateway (#76)
+    
+    * Add get block by hash to gateway
+    
+    * Fix CR
+
+[33mcommit e5831f563bdd2a4966a6c55d0985f47973f8d76b[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Sun Jul 3 09:25:08 2022 +0300
+
+    Use tmp class_hash in sn-client (#77)
+    
+    * Use non-prefixed class_hash in sn-client
+
+[33mcommit 649a30ed4b2b742ad59511fc57f90ed0e1163d88[m
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Thu Jun 30 14:31:20 2022 +0300
+
+    Append body (#75)
+    
+    * Append body
+
+[33mcommit 4e3c3dea7c6b8b6afc68b12c195f2578517f7c70[m
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Thu Jun 30 11:04:41 2022 +0300
+
+    BlockStorage: state reader (#70)
+    
+    * BlockStorage: state reader
+
+[33mcommit 16380b6b1cad5d3bbdd60e6d1f2823cca3ace6a0[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Wed Jun 29 11:31:54 2022 +0300
+
+    Use shash macro (#73)
+    
+    * Use shash macro
+
+[33mcommit 74431ec08a80ae39d26b46c140abfdc60c315029[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Wed Jun 29 10:41:43 2022 +0300
+
+    Test invoke transaction deserialization (#71)
+    
+    * Test invoke transaction deserialization
+
+[33mcommit a3908737da0e5c1f7d9231329940c3414d09688e[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Tue Jun 28 09:13:50 2022 +0300
+
+    Dan/integration test/sn client (#63)
+    
+    * Add sn_client integration test
+
+[33mcommit 16872661e65913dbf83ab77f376cc10e2f256342[m
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Tue Jun 28 09:08:22 2022 +0300
+
+    BlockStorage: state (#65)
+    
+    * BlockStorage: state
+
+[33mcommit 535da1d194857744b94bd95e9ce9670fcce316f0[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Tue Jun 28 08:36:18 2022 +0300
+
+    Refactor central source (#69)
+    
+    * Refactor central source
+
+[33mcommit 9aef7e59dc11311d12a369d063e6bb6d5abd6a12[m
+Author: anatg <anatg@starkware.co>
+Date:   Mon Jun 27 09:07:49 2022 +0300
+
+    Add transaction structs to starknet (#62)
+    
+    * Add transaction structs to starknet
+    
+    * Fix CR
+
+[33mcommit b3e30e0705946e3820f982230af55668ff960ddb[m
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Sun Jun 26 17:24:55 2022 +0300
+
+    Block storage: add hash -> number mapping (#66)
+    
+    * Block storage: add hash -> number mapping
+
+[33mcommit bc5fc576e8f6085ee2a2d626797335ef4dc60b57[m
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Sun Jun 26 13:32:41 2022 +0300
+
+    BlockStorage: statediff (#64)
+    
+    * BlockStorage: statediff
+
+[33mcommit 10d31d103172231c73d05fb4bcaa3e2211e19148[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Fri Jun 24 15:54:09 2022 +0300
+
+    Add load config test (#61)
+    
+    * Add load config test
+
+[33mcommit 959a5d7815ef4ff67eaf7511b4b790dea74699ce[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Thu Jun 23 17:26:03 2022 +0300
+
+    Use log4rs (#59)
+    
+    * Use log4rs
+
+[33mcommit afe5464a1883934bc8465a295e0fdd29ddb290be[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Thu Jun 23 09:40:21 2022 +0300
+
+    Dan/sn client/use core objects (#58)
+    
+    * Use core objects in sn-client state-diff
+
+[33mcommit d24c7a537d5004ebf5e3c9d4a7e327e7f7697852[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Wed Jun 22 12:38:40 2022 +0300
+
+    Use core objects for sn-client header (#57)
+    
+    * Use core objects for sn-client header
+
+[33mcommit c4f3a1d4a0eb2719dac7e7c85f4dfa7404a32cf7[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Wed Jun 22 09:05:06 2022 +0300
+
+    Make ClassHash a PrefixedHexAsBytes (#56)
+    
+    * Make ClassHash a PrefixedHexAsBytes
+
+[33mcommit c915d15e1e3dd2a2bb101c29eacaddcb0ed66f6e[m
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Tue Jun 21 22:23:32 2022 +0300
+
+    Add config (#55)
+    
+    * Add config
+
+[33mcommit 23a78033c3a2359fa25dc5d0f3ab389c0087fade[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Tue Jun 21 11:59:20 2022 +0300
+
+    Rename transactions.rs (#53)
+    
+    * Rename transactions.rs
+
+[33mcommit 0a6d47979636eabb4fe691b1d51ecb4cb150224d[m
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Tue Jun 21 11:07:18 2022 +0300
+
+    Refactoring (#54)
+    
+    * Refactoring
+
+[33mcommit 1d6a449cc468d2e0f7c068fdfa8a2e6a813dd4c9[m
+Author: anatg <anatg@starkware.co>
+Date:   Tue Jun 21 10:26:06 2022 +0300
+
+    Add block struct and get block by number to gateway. (#52)
+    
+    * Add block struct and get block by number to gateway.
+    
+    * Fix CR
+
+[33mcommit bed5a6466fb1ac1c0b5c601922d43347029f5f0b[m
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Tue Jun 21 09:21:09 2022 +0300
+
+    State objects (#51)
+    
+    * State objects
+
+[33mcommit 67a06e3ef525c4c58c50b0ae06cff98576cb2aa8[m
+Author: Shahar Papini <spapini@starkware.co>
+Date:   Mon Jun 20 08:00:27 2022 +0300
+
+    Refactor block storage
+
+[33mcommit 8c848b04f621ab5f65e4c2c80f40b4d4e2cb3656[m
+Merge: 99a4b65 d11a1b5
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Mon Jun 20 10:26:10 2022 +0300
+
+    Merge pull request #46 from starkware-libs/dan/central/sync-test
+    
+    Add a positive test for stream_new_blocks
+
+[33mcommit d11a1b527eb61920d99fb65509aa76907f3dc15a[m
+Author: Dan Brownstein <dan@starkware.co>
+Date:   Wed Jun 15 23:07:03 2022 +0300
+
+    Add a positive test for stream_new_blocks
+
+[33mcommit 99a4b6596df3b2d45093eced38c29bb2e5ce6e44[m
+Merge: ac2355c d854c28
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Mon Jun 20 09:31:01 2022 +0300
+
+    Merge pull request #45 from starkware-libs/dan/sn-client/state-diff
+    
+    Add state-diff to SN-client
+
+[33mcommit d854c28854fabfc5f3eb7b23747ee0dd65cde5dd[m
+Author: Dan Brownstein <dan@starkware.co>
+Date:   Wed Jun 15 17:07:33 2022 +0300
+
+    Add state-diff to SN-client
+
+[33mcommit ac2355c332a725546827ef8fc4b9e935b47feb92[m
+Merge: cfd7278 3db59d9
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Sun Jun 19 20:38:19 2022 +0300
+
+    Merge pull request #42 from starkware-libs/dan/CI/lint-groups
+    
+    Apply a comprehensive list of lint groups
+
+[33mcommit 3db59d9d4f12eab2ba68c790d53b9dbae245aacb[m
+Author: Dan Brownstein <dan@starkware.co>
+Date:   Wed Jun 15 10:14:58 2022 +0300
+
+    Apply a comprehensive list of lint groups
+
+[33mcommit cfd72786958120fff2f96211d482e6ed122491d8[m
+Merge: 3066de4 e113a01
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Sun Jun 19 20:34:32 2022 +0300
+
+    Merge pull request #49 from starkware-libs/dan/sn-client/default_nonce
+    
+    Add defualt L1ToL2Nonce
+
+[33mcommit e113a01209b0a4b9f23a8282e704d6ecb965a4ea[m
+Author: Dan Brownstein <dan@starkware.co>
+Date:   Fri Jun 17 22:46:25 2022 +0300
+
+    Add defualt L1ToL2Nonce
+
+[33mcommit 3066de436ea680125d5e55d7566ba2a0f9892995[m
+Author: anatg <anatg@starkware.co>
+Date:   Sun Jun 19 09:39:25 2022 +0300
+
+    Fix gateway error tests. (#44)
+    
+    * Fix gateway error tests.
+    
+    * Fix CR.
+
+[33mcommit a07441dc30761ebab3f52fae3fe80c88843fb3b7[m
+Author: anatg <anatg@starkware.co>
+Date:   Sun Jun 19 09:33:24 2022 +0300
+
+    Move url parsing to sn client constructor. (#47)
+    
+    * Move url parsing to sn client constructor.
+    
+    * Fix CR.
+
+[33mcommit ac8dabcc746d1098287a045ebbad4649325d233d[m
+Merge: 3703bb1 97e3e24
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Wed Jun 15 13:58:53 2022 +0300
+
+    Merge pull request #43 from starkware-libs/dan/sn-client/fix-argument
+    
+    Use BlockNumber instead of u32
+
+[33mcommit 97e3e246f61b3da63d55f9cc6a879fea65204abc[m
+Author: Dan Brownstein <dan@starkware.co>
+Date:   Wed Jun 15 11:15:53 2022 +0300
+
+    Use BlockNumber instead of u32
+
+[33mcommit 3703bb125322ea0fd9134237ca87719566c66c99[m
+Author: anatg <anatg@starkware.co>
+Date:   Wed Jun 15 11:54:31 2022 +0300
+
+    Change SN client error (#37)
+    
+    * Change SN client error
+    
+    * Fix CR.
+
+[33mcommit d295a2739fd3fcad1cfcc3587c6fd31d4f7be255[m
+Merge: 74ea78d 2f0b5cc
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Wed Jun 15 11:21:59 2022 +0300
+
+    Merge pull request #41 from starkware-libs/dan/gateway/block_number_test
+    
+    Add positive flow
+
+[33mcommit 2f0b5cc85cbfc5e193767187c81b0b1e374fb12f[m[33m ([m[1;31morigin/dan/gateway/block_number_test[m[33m)[m
+Author: Dan Brownstein <dan@starkware.co>
+Date:   Tue Jun 14 19:58:44 2022 +0300
+
+    Add positive flow
+
+[33mcommit 74ea78df8760cf73469e5a68bade0c0a0ff51dc2[m
+Merge: d16f7ec 6faebc3
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Wed Jun 15 09:09:11 2022 +0300
+
+    Merge pull request #35 from starkware-libs/dan/sn-client/serde-txs
+    
+    Add structs for SN-client
+
+[33mcommit 6faebc312786d967efdf6bd1951526d506a3ebe8[m
+Author: Dan Brownstein <dan@starkware.co>
+Date:   Mon Jun 13 21:17:34 2022 +0300
+
+    Split SN-client objects file
+
+[33mcommit ad2f6fbeba0a9b85af8b1019dcc14e6f9951e96c[m
+Author: Dan Brownstein <dan@starkware.co>
+Date:   Mon Jun 13 09:30:52 2022 +0300
+
+    Add structs for SN-client
+
+[33mcommit d16f7ecb71241daa4f1598e81edafac20fe0078e[m
+Merge: 9cbe23e 82ed88e
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Tue Jun 14 13:26:08 2022 +0300
+
+    Merge pull request #39 from starkware-libs/dan/misc/anyhow
+    
+    Remove anyhow usage from sn-client
+
+[33mcommit 82ed88ef473bbe5e10a9971528e96753b28c08eb[m
+Author: Dan Brownstein <dan@starkware.co>
+Date:   Tue Jun 14 12:51:56 2022 +0300
+
+    Remove anyhow usage from sn-client
+
+[33mcommit 9cbe23eea70d31340a98b8d032f9d9dd45a38f9a[m
+Merge: 698ab97 d98ffee
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Tue Jun 14 09:32:41 2022 +0300
+
+    Merge pull request #38 from starkware-libs/dan/sn-client/format_string
+    
+    Use format and ro_string instead of to_owned
+
+[33mcommit d98ffeea67df2886fa1ce445b2bdb5e4d5de3b72[m
+Author: Dan Brownstein <dan@starkware.co>
+Date:   Mon Jun 13 22:36:48 2022 +0300
+
+    Use format and ro_string instead of to_owned
+
+[33mcommit 698ab977fe51734042b9d747ba2cee9e71b3de6b[m
+Merge: 23f7478 e400789
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Mon Jun 13 11:06:05 2022 +0300
+
+    Merge pull request #36 from starkware-libs/dan/misc/cleaning
+    
+    Align dependencies style
+
+[33mcommit e4007895f64bf201eb836e8e5229d9341175bf07[m
+Author: Dan Brownstein <dan@starkware.co>
+Date:   Mon Jun 13 10:27:30 2022 +0300
+
+    Align dependencies style
+
+[33mcommit 23f74782f87b91692c298e2d1d43e609aff05440[m
+Merge: aaab5d3 f360b2e
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Sun Jun 12 17:28:23 2022 +0300
+
+    Merge pull request #34 from starkware-libs/dan/central/move-tests
+    
+    Dan/central/move tests
+
+[33mcommit f360b2ec51c5332dbd6a3369ae21aacb2ed850bd[m
+Author: Dan Brownstein <dan@starkware.co>
+Date:   Sun Jun 12 17:20:26 2022 +0300
+
+    Rename object test to serde util test
+
+[33mcommit aaab5d3690731e56c37b02f3605ecd4c806700ec[m
+Merge: 39a1982 70bd405
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Sun Jun 12 17:14:12 2022 +0300
+
+    Merge pull request #32 from starkware-libs/dan/sn-client/serialization
+    
+    Dan/sn client/serialization
+
+[33mcommit 70bd405e3fcd824f8142a1a2f3bd40b0ea175356[m[33m ([m[1;31morigin/dan/sn-client/serialization[m[33m)[m
+Author: Dan Brownstein <dan@starkware.co>
+Date:   Thu Jun 9 19:23:41 2022 +0300
+
+    Add SN-client objects serialization
+
+[33mcommit 39a198269a3a2935fea40b1edf284fcc7bd5c94e[m
+Merge: db547bf 8db867c
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Sun Jun 12 11:41:19 2022 +0300
+
+    Merge pull request #31 from starkware-libs/dan/sn-client/hex_str_from_bytes
+    
+    Add hex_str_from_bytes
+
+[33mcommit 8db867ceedec534d8d2ed481d58804bb92272e5c[m
+Author: Dan Brownstein <dan@starkware.co>
+Date:   Fri Jun 10 11:40:05 2022 +0300
+
+    Fix CR comments
+
+[33mcommit 8649671c38075a21e290aaf757adf0b34523e3f2[m
+Author: Dan Brownstein <dan@starkware.co>
+Date:   Thu Jun 9 19:17:15 2022 +0300
+
+    Add hex_str_from_bytes
+
+[33mcommit db547bfdce229976f82bdfc7456b7e671eae016a[m
+Author: anatg <anatg@starkware.co>
+Date:   Fri Jun 10 07:23:46 2022 +0300
+
+    Anatg/gateway (#21)
+    
+    * Read block number in gateway from storage.
+    
+    * Test run_server in gateway.
+    
+    * Fix CR.
+    
+    * Adapt to new storage.
+    
+    * Fix CR.
+    
+    * Adapt to new storage.
+    
+    * Change BlockNumber prev.
+
+[33mcommit 25d902b06c235fac9523c711a38aca96e8d32d94[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Wed Jun 8 16:51:27 2022 +0300
+
+    Move PrefixedHexAsBytes to serde_utils (#30)
+
+[33mcommit 1a85fcc33b7f4625cf1826ea0f7d35d7a5c01a0e[m
+Merge: cecdd67 534e5cf
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Wed Jun 8 15:49:55 2022 +0300
+
+    Merge pull request #28 from starkware-libs/dan/sn-client/objects
+    
+    Dan/sn client/objects
+
+[33mcommit 534e5cff37ff1d10c379f5d0b8cb7cf826d19f0e[m
+Author: Dan Brownstein <dan@starkware.co>
+Date:   Tue Jun 7 15:43:05 2022 +0300
+
+    Add SN-client get_block and related objects
+
+[33mcommit cecdd6716ddfa8c723c3641c1010ec1df6ee7c00[m
+Merge: e63d579 16fa6d7
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Wed Jun 8 11:36:53 2022 +0300
+
+    Merge pull request #29 from starkware-libs/spapini/fix_db_size
+    
+    Lower db size
+
+[33mcommit 16fa6d720c40796b2937a4ad413d7905c8ee07ec[m
+Author: Shahar Papini <spapini@starkware.co>
+Date:   Wed Jun 8 11:32:04 2022 +0300
+
+    Lower db size
+
+[33mcommit e63d57907faef5fd4fec9eccac28b1a03b3037d8[m
+Merge: ee770b4 032e4a9
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Wed Jun 8 10:48:00 2022 +0300
+
+    Merge pull request #25 from starkware-libs/spapini/storage/block_header
+    
+    Block storage add_header
+
+[33mcommit 032e4a9a098688ca2a6a23396e556b591acea4e0[m
+Author: Shahar Papini <spapini@starkware.co>
+Date:   Sat Jun 4 19:41:49 2022 +0300
+
+    Block storage add_header
+
+[33mcommit ee770b40a268e2b65fcd4d8b129eb6b3d49a8c16[m
+Merge: e201072 ac814ac
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Wed Jun 8 10:35:50 2022 +0300
+
+    Merge pull request #27 from starkware-libs/dan/sn-client/bytes_from_hex_str
+    
+    Add bytes from hex
+
+[33mcommit ac814acf1ecb49f0ff4cb02d1f6aa1fa2933e393[m
+Author: Dan Brownstein <dan@starkware.co>
+Date:   Tue Jun 7 13:02:14 2022 +0300
+
+    Add bytes from hex
+
+[33mcommit e201072bdeb0ff7649b1ce6c4f9243bb0c63915a[m
+Merge: 2e2e9f0 24ff545
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Tue Jun 7 11:30:55 2022 +0300
+
+    Merge pull request #26 from starkware-libs/anatg/test-utils
+    
+    Add storage_test_utils.
+
+[33mcommit 24ff545f994308c80c8fb82fbf62636aab62f1ee[m
+Author: anatg <anatg@starkware.co>
+Date:   Tue Jun 7 11:19:48 2022 +0300
+
+    Add storage_test_utils.
+
+[33mcommit 2e2e9f045cbe5e7a9f86d5fdf0d3e566b1d2bcdb[m
+Merge: 289097a 6464ddc
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Mon Jun 6 08:56:31 2022 +0300
+
+    Merge pull request #24 from starkware-libs/spapini/storage/mdbx
+    
+    Block storage
+
+[33mcommit 6464ddc867c2b3a705311b22b5b550cfba163581[m
+Author: Shahar Papini <spapini@starkware.co>
+Date:   Mon May 30 15:39:33 2022 +0300
+
+    Block storage
+
+[33mcommit 289097aa67d99421f7b17b867cf7c86f19d1b270[m
+Merge: 25f9f7f 79d7c60
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Mon Jun 6 08:52:47 2022 +0300
+
+    Merge pull request #23 from starkware-libs/spapini/storage/mdbx1
+    
+    Database using libmdbx
+
+[33mcommit 79d7c60c54018024c2a0f47feff519e09a981452[m
+Author: Shahar Papini <spapini@starkware.co>
+Date:   Sat Jun 4 09:07:11 2022 +0300
+
+    Database using libmdbx
+
+[33mcommit 25f9f7f493ac6aaa9275c1749aa955a4debff7a7[m
+Merge: f6d4780 8ba1ce1
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Thu Jun 2 13:22:35 2022 +0300
+
+    Merge pull request #19 from starkware-libs/spapini/central_source
+    
+    CentralSource
+
+[33mcommit 8ba1ce1f55ad3e9a9e0aae9334c21d671f0bc455[m
+Author: Shahar Papini <spapini@starkware.co>
+Date:   Wed Jun 1 14:28:00 2022 +0300
+
+    CentralSource
+
+[33mcommit f6d4780d3f8fd961d580b35f1aa67f219588b905[m
+Author: lior-stark <77265175+lior-stark@users.noreply.github.com>
+Date:   Wed Jun 1 17:17:12 2022 +0300
+
+    ADR 2: implementing as a single process (#17)
+
+[33mcommit 2d2963bd9619f17670c1baf6ef55b3575179399c[m[33m ([m[1;32mmain[m[33m)[m
+Author: lior-stark <77265175+lior-stark@users.noreply.github.com>
+Date:   Sun May 29 12:38:27 2022 +0300
+
+    Liors/storage obj (#14)
+    
+    * wip: draft implementation for storage
+    * refactoring data store access
+    * concrete implementation for storage
+    * organize imports
+    * adding standard error implementation
+    * add documentation + reference in cargo.toml
+    * removing unwrap in application code
+    * Central client skeleton (#11)
+    * changing interface of data store handle
+    * making storage error an enum
+    * wip: draft implementation for storage
+    * Actually testing the storage implementation
+    * async access method
+       also using tokio mutex
+    * refactored api definitions to api.rs
+    * renaming tests.rs to storage_tests.rs
+    * removing DataStoreHandle
+    * moving storage implementation to storage_impl
+    * cleanup - renaming
+    StarknetStorage{Reader,Writer} to Storage{Reader,Writer}
+    * moved create store access to impl
+       renamed TheDataStore to NodeDataStore
+    * tests -> test
+
+[33mcommit f3b66ed401ec74af248711651f266e541a13027c[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Fri May 27 21:56:50 2022 +0300
+
+    Rename central client to starknet_client (#16)
+    
+    * Rename central client to starknet_client
+
+[33mcommit 6797de135048d809227a5c9ff85db2da6e40733c[m
+Merge: 3f30627 4caa882
+Author: anatg <anatg@starkware.co>
+Date:   Thu May 26 18:12:41 2022 +0300
+
+    Merge pull request #15 from starkware-libs/anatg/separate-central-client-test
+    
+    Separate central client test.
+
+[33mcommit 4caa8825d03f1330a4d10c7c8696a5bbdf8073d5[m
+Author: anatg <anatg@starkware.co>
+Date:   Thu May 26 10:16:31 2022 +0300
+
+    Fix CR.
+
+[33mcommit 2db2a6150a54d9e2cc48e8b4634cff5362aec332[m
+Author: anatg <anatg@starkware.co>
+Date:   Tue May 24 17:19:12 2022 +0300
+
+    Separate central client test.
+
+[33mcommit 3f30627ff17f16dae215c6c1b6141ff10bf2f9fd[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Tue May 24 13:35:46 2022 +0300
+
+    Central client skeleton (#11)
+    
+    * Central client skeleton
+    
+    * Fix CR comments
+
+[33mcommit 4ae07c0729bcc5e438d125e0cff915dc112987d2[m
+Merge: 00cf35b c187ee8
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Mon May 23 14:57:33 2022 +0300
+
+    Merge pull request #12 from starkware-libs/spapini/gateway0
+    
+    Add common block objects
+
+[33mcommit c187ee8e5be7c83fb60fad787d4a3edafe688f43[m
+Author: Shahar Papini <spapini@starkware.co>
+Date:   Wed May 18 13:44:50 2022 +0300
+
+    Add common block objects
+
+[33mcommit 00cf35bd4ca37c7216f1a4478405461177faed00[m
+Merge: 74ab023 43cf28e
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Thu May 19 13:51:43 2022 +0300
+
+    Merge pull request #10 from starkware-libs/spapini/gateway1
+    
+    Basic gateway with blockNumber() implementation.
+
+[33mcommit 43cf28ee8ee57eb6b93d3d379ae28d7b8dd9d09a[m
+Author: Shahar Papini <spapini@starkware.co>
+Date:   Wed May 18 14:58:26 2022 +0300
+
+    Basic gateway with blockNumber() implementation.
+
+[33mcommit 74ab023ca3371a74679b6a4f88da26a17c8a9a2f[m
+Author: lior-stark <77265175+lior-stark@users.noreply.github.com>
+Date:   Mon May 16 09:36:48 2022 +0300
+
+    adding diagram for block lifecycle (#7)
+
+[33mcommit aa89cb2496db515a92bdaed6e532c19dd0c0c35d[m
+Merge: 1d6057f d118f25
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Sun May 15 15:26:52 2022 +0300
+
+    Merge pull request #6 from starkware-libs/spapini/logging
+    
+    Logging library
+
+[33mcommit d118f2565abd48cf91ddc7288498cb9bd5a67205[m
+Author: Shahar Papini <spapini@starkware.co>
+Date:   Thu May 12 13:28:55 2022 +0300
+
+    Logging library
+
+[33mcommit 1d6057f94749c91a093767e679454e03f305356f[m
+Author: lior-stark <77265175+lior-stark@users.noreply.github.com>
+Date:   Thu May 12 09:09:58 2022 +0300
+
+    sending block to peers w/ the network interface (#4)
+
+[33mcommit 8aa318c95a574fc03fa3acc44eca217b8d56d102[m
+Merge: 525cf09 cd89524
+Author: Shahar Papini <43779613+spapinistarkware@users.noreply.github.com>
+Date:   Wed May 11 15:16:17 2022 +0300
+
+    Merge pull request #5 from starkware-libs/spapini/initial_structure
+    
+    Initial project structure
+
+[33mcommit cd8952432b7f3168a196dca54cb8e6c99309e4e9[m
+Author: Shahar Papini <spapini@starkware.co>
+Date:   Wed May 11 11:33:34 2022 +0300
+
+    Initial project structure
+
+[33mcommit 525cf091789045d8c320668fa3e2fb1539ace338[m
+Author: lior-stark <77265175+lior-stark@users.noreply.github.com>
+Date:   Tue May 10 18:00:47 2022 +0300
+
+    initializing ADR dir (#3)
+
+[33mcommit 157b8f55ba3290317fceb77f63d12e30f7eca431[m
+Merge: cde13ef c7adc79
+Author: lior-stark <77265175+lior-stark@users.noreply.github.com>
+Date:   Tue May 10 12:16:39 2022 +0300
+
+    Merge pull request #2 from starkware-libs/liors/diagrams
+    
+    adding sync apis flow diagram
+
+[33mcommit c7adc794999cb6f2912caf69cc19a0f9de4a4f77[m[33m ([m[1;31morigin/liors/diagrams[m[33m)[m
+Author: Lior Schejter <liors@starkware.co>
+Date:   Tue May 10 10:29:48 2022 +0300
+
+    adding sync apis flow diagram
+
+[33mcommit cde13ef73b0128f000ce4f097c64f03174f10a1f[m
+Merge: 22d3959 51a0eb8
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Mon May 9 16:01:11 2022 +0300
+
+    Merge pull request #1 from starkware-libs/dan/ci/clippy
+    
+    Add rust clippy to the CI
+
+[33mcommit 51a0eb879bf7c8f697e30216d060396a0008038b[m[33m ([m[1;31morigin/dan/ci/clippy[m[33m)[m
+Author: Dan Brownstein <dan@starkware.co>
+Date:   Mon May 9 15:46:23 2022 +0300
+
+    Add rust clippy to the CI
+
+[33mcommit 22d3959b55d787b1e06242c2bc65bfc8e43aab44[m
+Author: Dan Brownstein <dan@starkware.co>
+Date:   Mon May 9 15:01:38 2022 +0300
+
+    Add ci.yml
+
+[33mcommit de476e2d870efb18dc086c3a2acc3fbc3d61c078[m
+Author: dan-starkware <56217775+dan-starkware@users.noreply.github.com>
+Date:   Mon May 9 14:40:34 2022 +0300
+
+    Initial lib


### PR DESCRIPTION
Move PatriciaKey to Core (used in both state and core)
Move EntryPointSelector to core (used in both transaction and state)
Move ContractClass (and the structs within) to state (used only there)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/249)
<!-- Reviewable:end -->
