### PR TITLE
Prefer `crate::` over of `super::` + consistent import path

### DIFF
--- a/crates/starknet_api/src/state.rs
+++ b/crates/starknet_api/src/state.rs
@@ -7,11 +7,10 @@ use std::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
 
-use super::core::PatriciaKey;
-use super::{
-    BlockNumber, ClassHash, ContractAddress, EntryPointSelector, Nonce, StarkFelt, StarkHash,
-    StarknetApiError,
-};
+use crate::block::BlockNumber;
+use crate::core::{ClassHash, ContractAddress, EntryPointSelector, Nonce, PatriciaKey};
+use crate::hash::{StarkFelt, StarkHash};
+use crate::StarknetApiError;
 
 /// The sequential numbering of the states between blocks in StarkNet.
 // Example:


### PR DESCRIPTION
* prefer absolute path than relative for non-tests: https://github.com/rust-lang/rust-analyzer/blob/master/docs/dev/style.md#import-style
* PatriciaKey is re-exported in `lib.rs` so is available in `crate::`
      (using the re-export appears to be the convention in rust-analyzer and
      is what auto-import suggests)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/300)
<!-- Reviewable:end -->
