### PR TITLE
Use `From` for casting `StateDiff` into Tuple

### DIFF
--- a/crates/papyrus_gateway/src/gateway_test.rs
+++ b/crates/papyrus_gateway/src/gateway_test.rs
@@ -251,9 +251,7 @@ async fn get_storage_at() -> Result<(), anyhow::Error> {
         .append_state_diff(header.block_number, diff.clone(), deployed_contract_class_definitions)?
         .commit()?;
 
-    let (_, storage_diffs, _, _) = diff.destruct();
-
-    let storage_diff = storage_diffs.index(0);
+    let storage_diff = diff.storage_diffs().index(0);
     let address = storage_diff.address;
     let storage_entry = storage_diff.storage_entries.index(0);
     let key = storage_entry.key.clone();
@@ -356,9 +354,7 @@ async fn get_class_hash_at() -> Result<(), anyhow::Error> {
         .append_state_diff(header.block_number, diff.clone(), deployed_contract_class_definitions)?
         .commit()?;
 
-    let (deployed_contracts, _, _, _) = diff.destruct();
-
-    let contract = deployed_contracts.index(0);
+    let contract = diff.deployed_contracts().index(0);
     let address = contract.address;
     let expected_class_hash = contract.class_hash;
 
@@ -444,8 +440,7 @@ async fn get_nonce() -> Result<(), anyhow::Error> {
         .append_state_diff(header.block_number, diff.clone(), deployed_contract_class_definitions)?
         .commit()?;
 
-    let (_, _, _, nonces) = diff.destruct();
-    let contract_nonce = nonces.index(0);
+    let contract_nonce = diff.nonces().index(0);
     let address = contract_nonce.contract_address;
     let expected_nonce = contract_nonce.nonce;
 
@@ -845,9 +840,7 @@ async fn get_class() -> Result<(), anyhow::Error> {
         .append_state_diff(header.block_number, diff.clone(), deployed_contract_class_definitions)?
         .commit()?;
 
-    let (_, _, declared_classes, _) = diff.destruct();
-
-    let declared_contract = declared_classes.index(1);
+    let declared_contract = diff.declared_contracts().index(1);
     let class_hash = declared_contract.class_hash;
     let expected_contract_class = declared_contract.contract_class.clone().try_into()?;
 
@@ -957,7 +950,7 @@ async fn get_class_at() -> Result<(), anyhow::Error> {
         )?
         .commit()?;
 
-    let (deployed_contracts, _, _, _) = diff.destruct();
+    let deployed_contracts = diff.deployed_contracts();
     let address = deployed_contracts.index(1).address;
     let hash = deployed_contracts.index(1).class_hash;
     let expected_contract_class = deployed_contract_class_definitions

--- a/crates/papyrus_storage/src/state/data.rs
+++ b/crates/papyrus_storage/src/state/data.rs
@@ -45,7 +45,7 @@ impl ThinStateDiff {
 
 impl From<StateDiff> for ThinStateDiff {
     fn from(diff: StateDiff) -> Self {
-        let (deployed_contracts, storage_diffs, declared_classes, nonces) = diff.destruct();
+        let (deployed_contracts, storage_diffs, declared_classes, nonces) = diff.into();
         Self {
             deployed_contracts,
             storage_diffs,

--- a/crates/papyrus_storage/src/state/state_test.rs
+++ b/crates/papyrus_storage/src/state/state_test.rs
@@ -84,7 +84,7 @@ fn append_state_diff() -> Result<(), anyhow::Error> {
     // Check for ClassAlreadyExists error when trying to declare a different class to an existing
     // class hash.
     let txn = writer.begin_rw_txn()?;
-    let (deployed_contracts, storage_diffs, mut declared_classes, nonces) = diff1.destruct();
+    let (deployed_contracts, storage_diffs, mut declared_classes, nonces) = diff1.into();
     let mut class = declared_classes[0].contract_class.clone();
     class.abi = Some(vec![ContractClassAbiEntry::Function(FunctionAbiEntryWithType {
         r#type: FunctionAbiEntryType::Regular,
@@ -102,7 +102,7 @@ fn append_state_diff() -> Result<(), anyhow::Error> {
     // Check for ContractAlreadyExists error when trying to deploy a different class hash to an
     // existing contract address.
     let txn = writer.begin_rw_txn()?;
-    let (mut deployed_contracts, storage_diffs, declared_classes, nonces) = diff0.destruct();
+    let (mut deployed_contracts, storage_diffs, declared_classes, nonces) = diff0.into();
     let mut contract = deployed_contracts[0].clone();
     contract.class_hash = cl2;
     deployed_contracts[0] = contract;

--- a/crates/papyrus_sync/src/sources/central_test.rs
+++ b/crates/papyrus_sync/src/sources/central_test.rs
@@ -238,7 +238,7 @@ async fn stream_state_updates() {
         deployed_contract_class_definitions,
     );
 
-    let (deployed_contracts, storage_diffs, declared_classes, nonces) = state_diff.destruct();
+    let (deployed_contracts, storage_diffs, declared_classes, nonces) = state_diff.into();
     assert_eq!(
         vec![
             DeployedContract { address: contract_address1, class_hash: class_hash2 },

--- a/crates/starknet_api/src/state.rs
+++ b/crates/starknet_api/src/state.rs
@@ -223,9 +223,6 @@ impl StateDiff {
         Ok(Self { deployed_contracts, storage_diffs, declared_classes: declared_contracts, nonces })
     }
 
-    pub fn destruct(self) -> StateDiffAsTuple {
-        (self.deployed_contracts, self.storage_diffs, self.declared_classes, self.nonces)
-    }
     pub fn deployed_contracts(&self) -> &[DeployedContract] {
         &self.deployed_contracts
     }
@@ -237,6 +234,12 @@ impl StateDiff {
     }
     pub fn nonces(&self) -> &[ContractNonce] {
         &self.nonces
+    }
+}
+
+impl From<StateDiff> for StateDiffAsTuple {
+    fn from(diff: StateDiff) -> StateDiffAsTuple {
+        (diff.deployed_contracts, diff.storage_diffs, diff.declared_classes, diff.nonces)
     }
 }
 

--- a/crates/starknet_api/src/state_test.rs
+++ b/crates/starknet_api/src/state_test.rs
@@ -1,5 +1,6 @@
 use assert_matches::assert_matches;
 
+use crate::state::StateDiffAsTuple;
 use crate::{
     shash, ClassHash, ContractAddress, ContractClass, ContractNonce, DeclaredContract,
     DeployedContract, Nonce, StarkHash, StarknetApiError, StateDiff, StorageDiff,
@@ -60,7 +61,7 @@ fn state_sorted() {
     let sorted_nonces = vec![nonce_0, nonce_1];
 
     assert_eq!(
-        state_diff.destruct(),
+        Into::<StateDiffAsTuple>::into(state_diff),
         (sorted_deployed_contracts, sorted_storage_diffs, sorted_declared_contracts, sorted_nonces)
     );
 }


### PR DESCRIPTION
Since `destruct` is essentially a tuple cast, it should use `From`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/304)
<!-- Reviewable:end -->
