### PR TITLE
Make tuple struct member public if possible.

### DIFF
--- a/crates/starknet_api/src/state.rs
+++ b/crates/starknet_api/src/state.rs
@@ -20,7 +20,7 @@ use super::{
 #[derive(
     Debug, Default, Copy, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord,
 )]
-pub struct StateNumber(BlockNumber);
+pub struct StateNumber(pub BlockNumber);
 impl StateNumber {
     // The state at the beginning of the block.
     pub fn right_before_block(block_number: BlockNumber) -> StateNumber {


### PR DESCRIPTION
Fields without any constraints on them should be made public: https://github.com/rust-lang/rust-analyzer/blob/master/docs/dev/style.md#getters--setters

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/307)
<!-- Reviewable:end -->
