### PR TITLE
Use unstable-sort for performance

### DIFF
--- a/crates/starknet_api/src/state.rs
+++ b/crates/starknet_api/src/state.rs
@@ -203,10 +203,10 @@ impl StateDiff {
         mut declared_contracts: Vec<DeclaredContract>,
         mut nonces: Vec<ContractNonce>,
     ) -> Result<Self, StarknetApiError> {
-        deployed_contracts.sort_by_key(|dc| dc.address);
-        storage_diffs.sort_by_key(|sd| sd.address);
-        declared_contracts.sort_by_key(|dc| dc.class_hash);
-        nonces.sort_by_key(|n| n.contract_address);
+        deployed_contracts.sort_unstable_by_key(|dc| dc.address);
+        storage_diffs.sort_unstable_by_key(|sd| sd.address);
+        declared_contracts.sort_unstable_by_key(|dc| dc.class_hash);
+        nonces.sort_unstable_by_key(|n| n.contract_address);
 
         if !is_unique(&deployed_contracts, |dc| &dc.address) {
             return Err(StarknetApiError::DuplicateInStateDiff {


### PR DESCRIPTION
`sort_unstable_by_key` is generally faster than `stable`, since it doesn't allocate auxilliary memory (https://doc.rust-lang.org/std/vec/struct.Vec.html#method.sort_by_key).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/310)
<!-- Reviewable:end -->
