### PR TITLE
Get ommer header

### DIFF
--- a/crates/papyrus_storage/src/ommer/ommer_test.rs
+++ b/crates/papyrus_storage/src/ommer/ommer_test.rs
@@ -3,6 +3,7 @@ use starknet_api::core::ClassHash;
 use starknet_api::state::{ContractClass, StateNumber};
 use starknet_api::transaction::{Event, Transaction, TransactionOffsetInBlock, TransactionOutput};
 
+use super::OmmerStorageReader;
 use crate::body::events::ThinTransactionOutput;
 use crate::body::{BodyStorageReader, BodyStorageWriter};
 use crate::ommer::OmmerStorageWriter;
@@ -175,4 +176,26 @@ fn insert_raw_state_diff_to_ommer() {
         .unwrap()
         .commit()
         .unwrap();
+}
+
+#[test]
+fn get_ommer_header() {
+    let (reader, mut writer) = get_test_storage();
+    let block = get_test_block(7);
+    let block_hash = block.header.block_hash;
+
+    assert!(reader.begin_ro_txn().unwrap().get_ommer_header(block_hash).unwrap().is_none());
+
+    writer
+        .begin_rw_txn()
+        .unwrap()
+        .insert_ommer_header(block_hash, &block.header)
+        .unwrap()
+        .commit()
+        .unwrap();
+
+    assert_eq!(
+        reader.begin_ro_txn().unwrap().get_ommer_header(block_hash).unwrap().unwrap(),
+        block.header
+    );
 }


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

There is no way to get ommer headers.

Issue Number: N/A

## What is the new behavior?

You can get ommer headers using storage reader

-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/394)
<!-- Reviewable:end -->
