### PR TITLE
Add `ConnectionReset` gateway error type

### DIFF
--- a/crates/starknet_client/src/lib.rs
+++ b/crates/starknet_client/src/lib.rs
@@ -74,6 +74,8 @@ pub enum StarknetErrorCode {
     MalformedRequest = 32,
     #[serde(rename = "StarknetErrorCode.UNDECLARED_CLASS")]
     UndeclaredClass = 44,
+    #[serde(rename = "StarknetErrorCode.CONNECTION_RESET")]
+    ConnectionReset = 104,
 }
 
 /// A client error wrapping error codes returned by the starknet gateway.


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Error displayed in logs
```
2023-01-11 16:39:18.931 INFO papyrus_sync - Added block 531 with hash 0x04ead611122f66ca8510fc0560ac2c39be0b0f2e04168ad3d7e0fc93f8b7d06b.
2023-01-11 17:07:52.403 WARN starknet_client - Failed to get class with hash "\"0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33\"" from starknet server.
2023-01-11 17:07:52.408 WARN starknet_client - Failed to get class with hash "\"0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33\"" from starknet server.
2023-01-11 17:07:52.414 WARN starknet_client - Failed to get class with hash "\"0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33\"" from starknet server.
2023-01-11 17:07:52.427 WARN starknet_client - Failed to get class with hash "\"0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33\"" from starknet server.
2023-01-11 17:07:52.433 WARN starknet_client - Failed to get class with hash "\"0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33\"" from starknet server.
2023-01-11 17:07:52.433 WARN starknet_client - Failed to get class with hash "\"0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33\"" from starknet server.
2023-01-11 17:07:52.549 WARN starknet_client - Failed to get class with hash "\"0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33\"" from starknet server.
2023-01-11 17:07:52.556 WARN starknet_client - Failed to get class with hash "\"0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33\"" from starknet server.
2023-01-11 17:07:52.569 WARN starknet_client - Failed to get class with hash "\"0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33\"" from starknet server.
2023-01-11 17:07:52.574 WARN starknet_client - Failed to get class with hash "\"0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33\"" from starknet server.
2023-01-11 17:07:54.887 WARN papyrus_sync::sources::central - Received error for state diff 532: ClientError(RequestError(reqwest::Error { kind: Request, url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("alpha-mainnet.starknet.io")), port: None, path: "/feeder_gateway/get_class_by_hash", query: Some("classHash=0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33"), fragment: None }, source: hyper::Error(Io, Os { code: 104, kind: ConnectionReset, message: "Connection reset by peer" }) })).
2023-01-11 17:07:54.897 WARN papyrus_sync - error sending request for url (https://alpha-mainnet.starknet.io/feeder_gateway/get_class_by_hash?classHash=0x2c3348ad109f7f3967df6494b3c48741d61675d9a7915b265aa7101a631dc33): connection error: Connection reset by peer (os error 104)
2023-01-11 17:08:04.912 WARN starknet_client - Failed to get block number Some(BlockNumber(5797)) from starknet server.
2023-01-11 17:08:04.912 WARN papyrus_sync - error sending request for url (https://alpha-mainnet.starknet.io/feeder_gateway/get_block?blockNumber=5797): connection error: Connection reset by peer (os error 104)
2023-01-11 17:08:35.642 INFO papyrus_sync - Added block 532 with hash 0x00986a76ad1091d1d26f2e85ceea74e821d57293895fadccc12c2b3d3ba6f581.

```

Issue Number: N/A

## What is the new behavior?

No errors in the logs anymore, the request retry in the background
-

## Does this introduce a breaking change?

- [ ] Yes
- [ x] No

