### PR TITLE
Fail config loading on unknown parameters

### DIFF
--- a/crates/papyrus_node/src/config/file_config.rs
+++ b/crates/papyrus_node/src/config/file_config.rs
@@ -18,6 +18,7 @@ use crate::config::ConfigBuilder;
 // doesn't have to specify parameters that he doesn't wish to override (in that case the previous
 // value remains).
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct FileConfigFormat {
     chain_id: Option<ChainId>,
     central: Option<Central>,
@@ -59,6 +60,7 @@ impl FileConfigFormat {
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[serde(deny_unknown_fields)]
 struct Central {
     concurrent_requests: Option<usize>,
     url: Option<String>,
@@ -91,6 +93,7 @@ impl Central {
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[serde(deny_unknown_fields)]
 struct Retry {
     retry_base_millis: Option<u64>,
     retry_max_delay_millis: Option<u64>,
@@ -112,6 +115,7 @@ impl Retry {
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[serde(deny_unknown_fields)]
 struct Gateway {
     server_address: Option<String>,
     max_events_chunk_size: Option<usize>,
@@ -133,6 +137,7 @@ impl Gateway {
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[serde(deny_unknown_fields)]
 struct MonitoringGateway {
     server_address: Option<String>,
 }
@@ -146,6 +151,7 @@ impl MonitoringGateway {
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[serde(deny_unknown_fields)]
 struct Storage {
     db: Option<Db>,
 }
@@ -159,6 +165,7 @@ impl Storage {
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[serde(deny_unknown_fields)]
 struct Db {
     path: Option<String>,
     max_size: Option<usize>,
@@ -176,6 +183,7 @@ impl Db {
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[serde(deny_unknown_fields)]
 struct Sync {
     block_propagation_sleep_duration_secs: Option<u64>,
     recoverable_error_sleep_duration_secs: Option<u64>,


### PR DESCRIPTION
Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Users can add unknown configuration parameters and the node will not produce an error. 
This is prone to spelling mistakes and other human errors.

## What is the new behavior?

Users will get an error when running the node

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/468)
<!-- Reviewable:end -->
