### PR TITLE
Yair/simplify stream

### DIFF
--- a/crates/papyrus_sync/src/sources/central.rs
+++ b/crates/papyrus_sync/src/sources/central.rs
@@ -156,7 +156,8 @@ impl<TStarknetClient: StarknetClientTrait + Send + Sync + 'static> CentralSource
                     }
                 }
             }
-        }.boxed()
+        }
+        .boxed()
     }
 }
 


### PR DESCRIPTION
## Pull Request type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The central creates a new stream from the client each time it gets the next block, deleting the stream instance at the end of each iteration.

## What is the new behavior?

The stream is created once and is fully consumed.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/477)
<!-- Reviewable:end -->
