### PR TITLE
Add user-agent in HTTP request

### DIFF
--- a/crates/starknet_client/Cargo.toml
+++ b/crates/starknet_client/Cargo.toml
@@ -20,6 +20,7 @@ tokio-retry = { version = "0.3" }
 tracing = { version = "0.1.37" }
 url = { version = "2.2.2" }
 http = {version= "0.2.8"}
+os_info = { version = "3.6.0" }
 
 [dev-dependencies]
 assert = { version = "0.0.4" }

--- a/crates/starknet_client/Cargo.toml
+++ b/crates/starknet_client/Cargo.toml
@@ -8,8 +8,10 @@ testing = ["mockall"]
 
 [dependencies]
 async-trait = { version = "0.1.56" }
+http = {version= "0.2.8"}
 indexmap = { version = "1.9.2", features = ["serde"] }
 mockall = { version = "0.11.2" , optional = true }
+os_info = { version = "3.6.0" }
 reqwest = { version = "0.11", features = ["json", "blocking"] }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = { version = "1.0.81" , features = ["arbitrary_precision"]}
@@ -19,8 +21,6 @@ tokio = { version = "1.18.2", features = ["full","sync"] }
 tokio-retry = { version = "0.3" }
 tracing = { version = "0.1.37" }
 url = { version = "2.2.2" }
-http = {version= "0.2.8"}
-os_info = { version = "3.6.0" }
 
 [dev-dependencies]
 assert = { version = "0.0.4" }

--- a/crates/starknet_client/src/lib.rs
+++ b/crates/starknet_client/src/lib.rs
@@ -167,10 +167,19 @@ impl StarknetClient {
             Some(inner) => (&inner).try_into()?,
             None => HeaderMap::new(),
         };
+        let info = os_info::get();
+        let system_information =
+            format!("{}; {}; {}", info.os_type(), info.version(), info.bitness());
+        let app_user_agent = format!(
+            "{product_name}/{product_version} ({system_information})",
+            product_name = "papyrus",
+            product_version = "pre-release",
+            system_information = system_information
+        );
         Ok(StarknetClient {
             urls: StarknetUrls::new(url_str)?,
             http_headers: header_map,
-            internal_client: Client::builder().build()?,
+            internal_client: Client::builder().user_agent(app_user_agent).build()?,
             retry_config,
         })
     }


### PR DESCRIPTION
## Pull Request type

This PR add [User-Agent](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent) 

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #497 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
HTTP request now contains [User-Agent](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent), e.g.:
```
GET /feeder_gateway/get_block HTTP/1.1
accept: */*
user-agent: papyrus/pre-release (Arch Linux; Rolling Release; 64-bit)
host: localhost:5555
```

Operating system informations are retrieved with [os_info](https://docs.rs/crate/os_info/latest)

Please not that version is hardcoded to `pre-release`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/556)
<!-- Reviewable:end -->
