### PR TITLE
Bug fix: filter out new contract classes from deployed_contract_class…

### DIFF
--- a/crates/papyrus_node/src/bin/central_source_integration_test.rs
+++ b/crates/papyrus_node/src/bin/central_source_integration_test.rs
@@ -12,9 +12,9 @@ async fn main() {
     ])
     .expect("Load config");
     let central_source = CentralSource::new(config.central).expect("Create new client");
-    let last_block_number = BlockNumber(203);
+    let last_block_number = BlockNumber(283414);
 
-    let mut block_marker = BlockNumber(200);
+    let mut block_marker = BlockNumber(283410);
     let block_stream = central_source.stream_new_blocks(block_marker, last_block_number).fuse();
     pin_mut!(block_stream);
     while let Some(Ok((block_number, _block))) = block_stream.next().await {
@@ -26,7 +26,7 @@ async fn main() {
     }
     assert!(block_marker == last_block_number);
 
-    let mut state_marker = BlockNumber(200);
+    let mut state_marker = BlockNumber(283410);
     let header_stream = central_source.stream_state_updates(state_marker, last_block_number).fuse();
     pin_mut!(header_stream);
     while let Some(Ok((block_number, _block_hash, _state_difff, _deployed_classes))) =

--- a/crates/papyrus_storage/src/state/mod.rs
+++ b/crates/papyrus_storage/src/state/mod.rs
@@ -66,6 +66,9 @@ where
         // TODO(anatg): Remove once there are no more deployed contracts with undeclared classes.
         // Class definitions of deployed contracts with classes that were not declared in this
         // state diff.
+        // Note: Since 0.11 only deprecated classes can be implicitly declared by contract
+        // deployment, so there is no need to pass the classes of deployed contracts if they are of
+        // the new version.
         deployed_contract_class_definitions: IndexMap<ClassHash, DeprecatedContractClass>,
     ) -> StorageResult<Self>;
 

--- a/crates/papyrus_sync/src/lib.rs
+++ b/crates/papyrus_sync/src/lib.rs
@@ -18,7 +18,7 @@ use papyrus_storage::{StorageError, StorageReader, StorageWriter};
 use serde::{Deserialize, Serialize};
 use starknet_api::block::{Block, BlockHash, BlockNumber};
 use starknet_api::core::ClassHash;
-use starknet_api::deprecated_contract_class::ContractClass;
+use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContractClass;
 use starknet_api::state::StateDiff;
 use tracing::{debug, error, info, trace, warn};
 
@@ -75,7 +75,8 @@ pub enum SyncEvent {
         // TODO(anatg): Remove once there are no more deployed contracts with undeclared classes.
         // Class definitions of deployed contracts with classes that were not declared in this
         // state diff.
-        deployed_contract_class_definitions: IndexMap<ClassHash, ContractClass>,
+        // Note: Since 0.11 new classes can not be implicitly declared.
+        deployed_contract_class_definitions: IndexMap<ClassHash, DeprecatedContractClass>,
     },
 }
 
@@ -210,7 +211,7 @@ impl<TCentralSource: CentralSourceTrait + Sync + Send + 'static> GenericStateSyn
         block_number: BlockNumber,
         block_hash: BlockHash,
         state_diff: StateDiff,
-        deployed_contract_class_definitions: IndexMap<ClassHash, ContractClass>,
+        deployed_contract_class_definitions: IndexMap<ClassHash, DeprecatedContractClass>,
     ) -> StateSyncResult {
         if !self.is_reverted_state_diff(block_number, block_hash)? {
             debug!("Storing state diff of block {block_number} with hash {block_hash}.");

--- a/crates/starknet_client/src/objects/state.rs
+++ b/crates/starknet_client/src/objects/state.rs
@@ -36,8 +36,7 @@ pub struct StateDiff {
 
 impl StateDiff {
     // Returns the declared class hashes in the following order:
-    // [declared classes, deprecated declared class, deprecated classes that were implicitly
-    // declared by contract deployment].
+    // [declared classes, deprecated declared class, class hashes of deployed contracts].
     pub fn class_hashes(&self) -> Vec<ClassHash> {
         let mut declared_class_hashes: Vec<ClassHash> = self
             .declared_classes


### PR DESCRIPTION
…_definitions instead of assuming there are'nt any.

## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

While syncing, when downloading the classes of deployed contracts, we expect all of the classes to be deprecated classes

## What is the new behavior?

Instead of expecting we filter out new classes

## Other information

Fixing application crash on block 283414 in the integration network.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/584)
<!-- Reviewable:end -->
