### PR TITLE
Download deprecated classes not in storage

### DIFF
--- a/crates/papyrus_node/src/bin/central_source_integration_test.rs
+++ b/crates/papyrus_node/src/bin/central_source_integration_test.rs
@@ -20,7 +20,9 @@ async fn main() {
     ])
     .expect("Load config");
     let (storage_reader, _) = open_storage(config.storage.db_config).expect("Open storage");
-    let central_source = CentralSource::new(config.central, VERSION_FULL, storage_reader).expect("Create new client");
+    let central_source = CentralSource::new(config.central, VERSION_FULL, storage_reader)
+        .expect("Create new client");
+    let last_block_number = BlockNumber(283410);
 
     let mut block_marker = BlockNumber(283410);
     let block_stream = central_source.stream_new_blocks(block_marker, last_block_number).fuse();

--- a/crates/papyrus_node/src/main.rs
+++ b/crates/papyrus_node/src/main.rs
@@ -57,7 +57,7 @@ async fn run_threads(config: Config) -> anyhow::Result<()> {
 // TODO(dan): filter out logs from dependencies (happens when RUST_LOG=DEBUG)
 // TODO(yair): define and implement configurable filtering.
 fn configure_tracing() {
-    let fmt_layer = fmt::layer().compact().with_target(true);
+    let fmt_layer = fmt::layer().compact().with_target(false);
     let level_filter_layer =
         EnvFilter::builder().with_default_directive(DEFAULT_LEVEL.into()).from_env_lossy();
 

--- a/crates/papyrus_node/src/main.rs
+++ b/crates/papyrus_node/src/main.rs
@@ -41,8 +41,9 @@ async fn run_threads(config: Config) -> anyhow::Result<()> {
         storage_writer: StorageWriter,
     ) -> Result<(), StateSyncError> {
         if let Some(sync_config) = config.sync {
-            let central_source = CentralSource::new(config.central.clone(), VERSION_FULL)
-                .map_err(CentralError::ClientCreation)?;
+            let central_source =
+                CentralSource::new(config.central.clone(), VERSION_FULL, storage_reader.clone())
+                    .map_err(CentralError::ClientCreation)?;
             let mut sync =
                 StateSync::new(sync_config, central_source, storage_reader.clone(), storage_writer);
             return sync.run().await;
@@ -56,7 +57,7 @@ async fn run_threads(config: Config) -> anyhow::Result<()> {
 // TODO(dan): filter out logs from dependencies (happens when RUST_LOG=DEBUG)
 // TODO(yair): define and implement configurable filtering.
 fn configure_tracing() {
-    let fmt_layer = fmt::layer().compact().with_target(false);
+    let fmt_layer = fmt::layer().compact().with_target(true);
     let level_filter_layer =
         EnvFilter::builder().with_default_directive(DEFAULT_LEVEL.into()).from_env_lossy();
 

--- a/crates/papyrus_sync/src/sources/central.rs
+++ b/crates/papyrus_sync/src/sources/central.rs
@@ -9,11 +9,13 @@ use futures_util::StreamExt;
 use indexmap::IndexMap;
 #[cfg(test)]
 use mockall::automock;
+use papyrus_storage::state::StateStorageReader;
+use papyrus_storage::{StorageError, StorageReader};
 use serde::{Deserialize, Serialize};
 use starknet_api::block::{Block, BlockHash, BlockNumber};
 use starknet_api::core::ClassHash;
 use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContractClass;
-use starknet_api::state::StateDiff;
+use starknet_api::state::{StateDiff, StateNumber};
 use starknet_api::StarknetApiError;
 use starknet_client::{
     ClientCreationError, ClientError, GenericContractClass, RetryConfig, StarknetClient,
@@ -35,6 +37,7 @@ pub struct CentralSourceConfig {
 pub struct GenericCentralSource<TStarknetClient: StarknetClientTrait + Send + Sync> {
     pub concurrent_requests: usize,
     pub starknet_client: Arc<TStarknetClient>,
+    pub storage_reader: StorageReader,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -51,6 +54,8 @@ pub enum CentralError {
     BlockNotFound { block_number: BlockNumber },
     #[error(transparent)]
     StarknetApiError(#[from] Arc<StarknetApiError>),
+    #[error(transparent)]
+    StorageError(#[from] StorageError),
 }
 
 #[cfg_attr(test, automock)]
@@ -203,10 +208,7 @@ fn client_to_central_state_update(
                 declared_classes: declared_classes
                     .into_iter()
                     .map(|(class_hash, generic_class)| {
-                        (
-                            class_hash,
-                            generic_class.to_cairo1().expect("Expected Cairo1 class.").into(),
-                        )
+                        (class_hash, generic_class.to_cairo1().expect("Expected Cairo1 class."))
                     })
                     .zip(
                         declared_class_hashes
@@ -220,10 +222,7 @@ fn client_to_central_state_update(
                 deprecated_declared_classes: deprecated_classes
                     .into_iter()
                     .map(|(class_hash, generic_class)| {
-                        (
-                            class_hash,
-                            generic_class.to_cairo0().expect("Expected Cairo0 class.").into(),
-                        )
+                        (class_hash, generic_class.to_cairo0().expect("Expected Cairo0 class."))
                     })
                     .collect(),
                 nonces,
@@ -241,6 +240,10 @@ fn client_to_central_state_update(
                         Some((class_hash, deprecated_contract_class.into()))
                     }
                     GenericContractClass::Cairo1ContractClass(_) => None,
+                    GenericContractClass::APIContractClass(_) => None,
+                    GenericContractClass::APIDeprecatedContractClass(
+                        api_deprecated_contract_class,
+                    ) => Some((class_hash, api_deprecated_contract_class)),
                 })
                 .collect();
             let block_hash = state_update.block_hash;
@@ -282,6 +285,38 @@ fn client_to_central_block(
     }
 }
 
+// Given a class hash, returns the corresponding class definition.
+// First tries to retrieve the class from the storage.
+// If not found in the storage, the class is downloaded.
+async fn download_class_if_necessary<TStarknetClient: StarknetClientTrait>(
+    class_hash: ClassHash,
+    starknet_client: Arc<TStarknetClient>,
+    storage_reader: StorageReader,
+) -> CentralResult<Option<GenericContractClass>> {
+    let txn = storage_reader.begin_ro_txn()?;
+    let state_reader = txn.get_state_reader()?;
+    let block_number = txn.get_state_marker()?;
+    let state_number = StateNumber::right_after_block(block_number);
+
+    // Check declared classes.
+    if let Ok(Some(class)) = state_reader.get_class_definition_at(state_number, &class_hash) {
+        trace!("Class {:?} retrieved from storage.", class_hash);
+        return Ok(Some(GenericContractClass::APIContractClass(class)));
+    };
+
+    // Check deprecated classes.
+    if let Ok(Some(class)) =
+        state_reader.get_deprecated_class_definition_at(state_number, &class_hash)
+    {
+        trace!("Deprecated class {:?} retrieved from storage.", class_hash);
+        return Ok(Some(GenericContractClass::APIDeprecatedContractClass(class)));
+    }
+
+    // Class not found in storage - download.
+    trace!("Downloading class {:?}.", class_hash);
+    Ok(starknet_client.class_by_hash(class_hash).await.map_err(Arc::new)?)
+}
+
 impl<TStarknetClient: StarknetClientTrait + Send + Sync + 'static>
     GenericCentralSource<TStarknetClient>
 {
@@ -304,6 +339,7 @@ impl<TStarknetClient: StarknetClientTrait + Send + Sync + 'static>
 
         // Stream the declared and deployed classes.
         let starknet_client = self.starknet_client.clone();
+        let storage_reader = self.storage_reader.clone();
         let mut flat_classes = state_updates0
             // In case state_updates1 contains a ClientError, we yield it and break - without
             // evaluating flat_classes.
@@ -313,10 +349,10 @@ impl<TStarknetClient: StarknetClientTrait + Send + Sync + 'static>
             .flat_map(futures::stream::iter)
             .map(move |class_hash| {
                 let starknet_client = starknet_client.clone();
-                async move { (class_hash, starknet_client.class_by_hash(class_hash).await) }
+                let storage_reader = storage_reader.clone();
+                async move { (class_hash, download_class_if_necessary(class_hash, starknet_client, storage_reader).await) }
             })
-            .buffered(self.concurrent_requests)
-            .map(|(class_hash, class)| (class_hash, class.map_err(Arc::new)));
+            .buffered(self.concurrent_requests);
 
         let res_stream = stream! {
             while let Some(maybe_state_update) = state_updates1.next().await {
@@ -341,7 +377,7 @@ impl<TStarknetClient: StarknetClientTrait + Send + Sync + 'static>
                             .map(|(class_hash, class)| match class {
                                 Ok(Some(class)) => Ok((class_hash, class)),
                                 Ok(None) => Err(CentralError::StateUpdateNotFound),
-                                Err(err) => Err(CentralError::ClientError(err)),
+                                Err(err) => Err(err),
                             })
                             .collect()
                     });
@@ -362,6 +398,7 @@ impl CentralSource {
     pub fn new(
         config: CentralSourceConfig,
         node_version: &'static str,
+        storage_reader: StorageReader,
     ) -> Result<CentralSource, ClientCreationError> {
         let starknet_client = StarknetClient::new(
             &config.url,
@@ -369,9 +406,11 @@ impl CentralSource {
             node_version,
             config.retry_config,
         )?;
+
         Ok(CentralSource {
             concurrent_requests: config.concurrent_requests,
             starknet_client: Arc::new(starknet_client),
+            storage_reader,
         })
     }
 }

--- a/crates/papyrus_sync/src/sources/central_test.rs
+++ b/crates/papyrus_sync/src/sources/central_test.rs
@@ -4,6 +4,7 @@ use assert_matches::assert_matches;
 use futures_util::pin_mut;
 use indexmap::IndexMap;
 use mockall::predicate;
+use papyrus_storage::test_utils::get_test_storage;
 use reqwest::StatusCode;
 use starknet_api::block::{BlockHash, BlockNumber};
 use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce, PatriciaKey};
@@ -32,6 +33,7 @@ async fn last_block_number() {
     let central_source = GenericCentralSource {
         starknet_client: Arc::new(mock),
         concurrent_requests: TEST_CONCURRENT_REQUESTS,
+        storage_reader: get_test_storage().0,
     };
 
     let last_block_number = central_source.get_block_marker().await.unwrap().prev().unwrap();
@@ -54,6 +56,7 @@ async fn stream_block_headers() {
     let central_source = GenericCentralSource {
         concurrent_requests: TEST_CONCURRENT_REQUESTS,
         starknet_client: Arc::new(mock),
+        storage_reader: get_test_storage().0,
     };
 
     let mut expected_block_num = BlockNumber(START_BLOCK_NUMBER);
@@ -88,6 +91,7 @@ async fn stream_block_headers_some_are_missing() {
     let central_source = GenericCentralSource {
         concurrent_requests: TEST_CONCURRENT_REQUESTS,
         starknet_client: Arc::new(mock),
+        storage_reader: get_test_storage().0,
     };
 
     let mut expected_block_num = BlockNumber(START_BLOCK_NUMBER);
@@ -134,6 +138,7 @@ async fn stream_block_headers_error() {
     let central_source = GenericCentralSource {
         concurrent_requests: TEST_CONCURRENT_REQUESTS,
         starknet_client: Arc::new(mock),
+        storage_reader: get_test_storage().0,
     };
 
     let mut expected_block_num = BlockNumber(START_BLOCK_NUMBER);
@@ -264,6 +269,7 @@ async fn stream_state_updates() {
     let central_source = GenericCentralSource {
         concurrent_requests: TEST_CONCURRENT_REQUESTS,
         starknet_client: Arc::new(mock),
+        storage_reader: get_test_storage().0,
     };
     let initial_block_num = BlockNumber(START_BLOCK_NUMBER);
 

--- a/crates/papyrus_sync/src/sources/stream_utils.rs
+++ b/crates/papyrus_sync/src/sources/stream_utils.rs
@@ -17,7 +17,7 @@ pub trait MyStreamExt: StreamExt {
     async fn take_n(&mut self, n: usize) -> Option<Vec<Self::Item>>
     where
         Self: Sized + Unpin + Send + 'static,
-        Self::Item: Clone + Send + 'static;
+        Self::Item: Send + 'static;
 }
 #[async_trait]
 impl<T: StreamExt> MyStreamExt for T {
@@ -39,7 +39,7 @@ impl<T: StreamExt> MyStreamExt for T {
     async fn take_n(&mut self, n: usize) -> Option<Vec<Self::Item>>
     where
         Self: Sized + Unpin + Send + 'static,
-        Self::Item: Clone + Send + 'static,
+        Self::Item: Send + 'static,
     {
         if n == 0 {
             return Some(vec![]);

--- a/crates/starknet_client/src/lib.rs
+++ b/crates/starknet_client/src/lib.rs
@@ -343,19 +343,23 @@ impl StarknetClientTrait for StarknetClient {
 pub enum GenericContractClass {
     Cairo0ContractClass(DeprecatedContractClass),
     Cairo1ContractClass(ContractClass),
+    APIContractClass(starknet_api::state::ContractClass),
+    APIDeprecatedContractClass(starknet_api::deprecated_contract_class::ContractClass),
 }
 
 impl GenericContractClass {
-    pub fn to_cairo0(self) -> ClientResult<DeprecatedContractClass> {
+    pub fn to_cairo0(self) -> ClientResult<starknet_api::deprecated_contract_class::ContractClass> {
         match self {
-            Self::Cairo0ContractClass(class) => Ok(class),
+            Self::Cairo0ContractClass(class) => Ok(class.into()),
+            GenericContractClass::APIDeprecatedContractClass(class) => Ok(class),
             _ => Err(ClientError::BadContractClassType),
         }
     }
 
-    pub fn to_cairo1(self) -> ClientResult<ContractClass> {
+    pub fn to_cairo1(self) -> ClientResult<starknet_api::state::ContractClass> {
         match self {
-            Self::Cairo1ContractClass(class) => Ok(class),
+            Self::Cairo1ContractClass(class) => Ok(class.into()),
+            GenericContractClass::APIContractClass(class) => Ok(class),
             _ => Err(ClientError::BadContractClassType),
         }
     }

--- a/crates/starknet_client/src/lib.rs
+++ b/crates/starknet_client/src/lib.rs
@@ -51,7 +51,7 @@ pub trait StarknetClientTrait {
         &self,
         class_hash: ClassHash,
     ) -> ClientResult<Option<GenericContractClass>>;
-    /// Returns a [`starknet_clinet`][`StateUpdate`] corresponding to `block_number`.
+    /// Returns a [`starknet_client`][`StateUpdate`] corresponding to `block_number`.
     async fn state_update(&self, block_number: BlockNumber) -> ClientResult<Option<StateUpdate>>;
 }
 
@@ -123,7 +123,7 @@ pub enum ClientError {
     /// A client error representing errors that might be solved by retrying mechanism.
     #[error("Retry error code: {:?}, message: {:?}.", code, message)]
     RetryError { code: RetryErrorCode, message: String },
-    /// A client error representing deserialisation errors.
+    /// A client error representing deserialization errors.
     #[error(transparent)]
     SerdeError(#[from] serde_json::Error),
     /// A client error representing errors from [`starknet_api`].
@@ -135,8 +135,6 @@ pub enum ClientError {
     /// A client error representing transaction receipts errors.
     #[error(transparent)]
     TransactionReceiptsError(#[from] TransactionReceiptsError),
-    #[error("Wrong type of contract class")]
-    BadContractClassType,
     // TODO(yair): Add more info.
     #[error("Invalid transaction.")]
     BadTransaction,
@@ -343,24 +341,4 @@ impl StarknetClientTrait for StarknetClient {
 pub enum GenericContractClass {
     Cairo0ContractClass(DeprecatedContractClass),
     Cairo1ContractClass(ContractClass),
-    APIContractClass(starknet_api::state::ContractClass),
-    APIDeprecatedContractClass(starknet_api::deprecated_contract_class::ContractClass),
-}
-
-impl GenericContractClass {
-    pub fn to_cairo0(self) -> ClientResult<starknet_api::deprecated_contract_class::ContractClass> {
-        match self {
-            Self::Cairo0ContractClass(class) => Ok(class.into()),
-            GenericContractClass::APIDeprecatedContractClass(class) => Ok(class),
-            _ => Err(ClientError::BadContractClassType),
-        }
-    }
-
-    pub fn to_cairo1(self) -> ClientResult<starknet_api::state::ContractClass> {
-        match self {
-            Self::Cairo1ContractClass(class) => Ok(class.into()),
-            GenericContractClass::APIContractClass(class) => Ok(class),
-            _ => Err(ClientError::BadContractClassType),
-        }
-    }
 }

--- a/crates/starknet_client/src/starknet_client_test.rs
+++ b/crates/starknet_client/src/starknet_client_test.rs
@@ -23,7 +23,7 @@ use super::{
     Block, ClientError, RetryErrorCode, StarknetClient, StarknetClientTrait, BLOCK_NUMBER_QUERY,
     CLASS_HASH_QUERY, GET_BLOCK_URL, GET_STATE_UPDATE_URL,
 };
-use crate::ContractClass;
+use crate::{ContractClass, GenericContractClass};
 
 const NODE_VERSION: &str = "NODE VERSION";
 
@@ -152,11 +152,14 @@ async fn contract_class() {
         )))
         .await
         .unwrap()
-        .unwrap()
-        .to_cairo1()
         .unwrap();
+
+    let contract_class = match contract_class {
+        GenericContractClass::Cairo1ContractClass(class) => class,
+        _ => unreachable!("Expecting Cairo0ContractClass."),
+    };
     mock_by_hash.assert();
-    assert_eq!(contract_class, expected_contract_class.into());
+    assert_eq!(contract_class, expected_contract_class);
 }
 
 #[tokio::test]
@@ -233,11 +236,13 @@ async fn deprecated_contract_class() {
         )))
         .await
         .unwrap()
-        .unwrap()
-        .to_cairo0()
         .unwrap();
+    let contract_class = match contract_class {
+        GenericContractClass::Cairo0ContractClass(class) => class,
+        _ => unreachable!("Expecting deprecated contract class."),
+    };
     mock_by_hash.assert();
-    assert_eq!(contract_class, expected_contract_class.into());
+    assert_eq!(contract_class, expected_contract_class);
 
     // Undeclared class.
     let body = r#"{"code": "StarknetErrorCode.UNDECLARED_CLASS", "message": "Class with hash 0x7 is not declared."}"#;

--- a/crates/starknet_client/src/starknet_client_test.rs
+++ b/crates/starknet_client/src/starknet_client_test.rs
@@ -156,7 +156,7 @@ async fn contract_class() {
         .to_cairo1()
         .unwrap();
     mock_by_hash.assert();
-    assert_eq!(contract_class, expected_contract_class);
+    assert_eq!(contract_class, expected_contract_class.into());
 }
 
 #[tokio::test]
@@ -237,7 +237,7 @@ async fn deprecated_contract_class() {
         .to_cairo0()
         .unwrap();
     mock_by_hash.assert();
-    assert_eq!(contract_class, expected_contract_class);
+    assert_eq!(contract_class, expected_contract_class.into());
 
     // Undeclared class.
     let body = r#"{"code": "StarknetErrorCode.UNDECLARED_CLASS", "message": "Class with hash 0x7 is not declared."}"#;


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Downloads a class even if it was downloaded before.

## What is the new behavior?
Before downloading a deprecated class, try to retrieve it from the storage. 
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/603)
<!-- Reviewable:end -->
