### PR TITLE
remove unused function - get_rand_test_block

### DIFF
--- a/crates/test_utils/src/lib.rs
+++ b/crates/test_utils/src/lib.rs
@@ -222,11 +222,6 @@ pub fn get_test_body_with_events(transaction_count: usize, events_per_tx: usize)
     get_rand_test_body_with_events(&mut rng, transaction_count, events_per_tx, None, None)
 }
 
-// Returns a test block with a variable number of transactions.
-pub fn get_rand_test_block(rng: &mut ChaCha8Rng, transaction_count: usize) -> Block {
-    get_rand_test_block_with_events(rng, transaction_count, 0, None, None)
-}
-
 // Returns a test block body with a variable number of transactions.
 pub fn get_rand_test_body(rng: &mut ChaCha8Rng, transaction_count: usize) -> BlockBody {
     get_rand_test_body_with_events(rng, transaction_count, 0, None, None)
@@ -235,7 +230,7 @@ pub fn get_rand_test_body(rng: &mut ChaCha8Rng, transaction_count: usize) -> Blo
 // Returns a test block with a variable number of transactions.
 pub fn get_test_block(transaction_count: usize) -> Block {
     let mut rng = get_rng(Some(0));
-    get_rand_test_block(&mut rng, transaction_count)
+    get_rand_test_block_with_events(&mut rng, transaction_count, 0, None, None)
 }
 
 // Returns a test block body with a variable number of transactions.


### PR DESCRIPTION
**Stack**:
- #629
- #628
- #627
- #626
- #625
- #624
- #623
- #622 ⬅
- #621
- #620


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/622)
<!-- Reviewable:end -->
