### PR TITLE
Remove the option to dynamically pass seed to rng generator

### DIFF
--- a/crates/papyrus_gateway/src/gateway_test.rs
+++ b/crates/papyrus_gateway/src/gateway_test.rs
@@ -87,7 +87,7 @@ async fn block_hash_and_number() {
     ));
 
     // Add a block and check again.
-    let block = get_test_block(Some(0), 1, None, None, None);
+    let block = get_test_block(1, None, None, None);
     storage_writer
         .begin_rw_txn()
         .unwrap()
@@ -112,7 +112,7 @@ async fn block_hash_and_number() {
 async fn get_block_w_transaction_hashes() {
     let (module, mut storage_writer) = get_test_rpc_server_and_storage_writer();
 
-    let block = get_test_block(Some(0), 1, None, None, None);
+    let block = get_test_block(1, None, None, None);
     storage_writer
         .begin_rw_txn()
         .unwrap()
@@ -205,7 +205,7 @@ async fn verify_serialization_deserialization_of_block() {
 async fn get_block_w_full_transactions() {
     let (module, mut storage_writer) = get_test_rpc_server_and_storage_writer();
 
-    let block = get_test_block(Some(0), 1, None, None, None);
+    let block = get_test_block(1, None, None, None);
     storage_writer
         .begin_rw_txn()
         .unwrap()
@@ -551,7 +551,7 @@ async fn get_nonce() {
 #[tokio::test]
 async fn get_transaction_by_hash() {
     let (module, mut storage_writer) = get_test_rpc_server_and_storage_writer();
-    let block = get_test_block(Some(0), 1, None, None, None);
+    let block = get_test_block(1, None, None, None);
     storage_writer
         .begin_rw_txn()
         .unwrap()
@@ -588,7 +588,7 @@ async fn get_transaction_by_hash() {
 #[tokio::test]
 async fn get_transaction_by_block_id_and_index() {
     let (module, mut storage_writer) = get_test_rpc_server_and_storage_writer();
-    let block = get_test_block(Some(0), 1, None, None, None);
+    let block = get_test_block(1, None, None, None);
     storage_writer
         .begin_rw_txn()
         .unwrap()
@@ -673,7 +673,7 @@ async fn get_transaction_by_block_id_and_index() {
 async fn get_block_transaction_count() {
     let (module, mut storage_writer) = get_test_rpc_server_and_storage_writer();
     let transaction_count = 5;
-    let block = get_test_block(Some(0), transaction_count, None, None, None);
+    let block = get_test_block(transaction_count, None, None, None);
     storage_writer
         .begin_rw_txn()
         .unwrap()
@@ -832,7 +832,7 @@ async fn get_state_update() {
 #[tokio::test]
 async fn get_transaction_receipt() {
     let (module, mut storage_writer) = get_test_rpc_server_and_storage_writer();
-    let block = get_test_block(Some(0), 1, None, None, None);
+    let block = get_test_block(1, None, None, None);
     storage_writer
         .begin_rw_txn()
         .unwrap()
@@ -1204,7 +1204,6 @@ async fn get_events_chunk_size_2_with_address() {
     let key0 = EventKey(stark_felt!("0x6"));
     let key1 = EventKey(stark_felt!("0x7"));
     let block = get_test_block(
-        None,
         2,
         Some(5),
         Some(vec![address, ContractAddress(patricia_key!("0x23"))]),
@@ -1285,7 +1284,6 @@ async fn get_events_chunk_size_2_without_address() {
     let key0 = EventKey(stark_felt!("0x6"));
     let key1 = EventKey(stark_felt!("0x7"));
     let block = get_test_block(
-        None,
         2,
         Some(5),
         None,
@@ -1434,7 +1432,7 @@ async fn get_events_no_blocks_in_filter() {
             block_number: BlockNumber(1),
             ..BlockHeader::default()
         },
-        body: get_test_body(Some(0), 1, None, None, None),
+        body: get_test_body(1, None, None, None),
     };
     storage_writer
         .begin_rw_txn()
@@ -1513,7 +1511,7 @@ async fn run_server_no_blocks() {
 #[tokio::test]
 async fn serialize_returns_valid_json() {
     let (storage_reader, mut storage_writer) = get_test_storage();
-    let mut rng = get_rng(None);
+    let mut rng = get_rng();
     let parent_block = starknet_api::block::Block::default();
     let block = starknet_api::block::Block {
         header: BlockHeader {
@@ -1522,7 +1520,7 @@ async fn serialize_returns_valid_json() {
             block_number: BlockNumber(1),
             ..BlockHeader::default()
         },
-        body: get_test_body(None, 5, Some(5), None, None),
+        body: get_test_body(5, Some(5), None, None),
     };
     let mut state_diff = StateDiff::get_test_instance(&mut rng);
     // In the test instance both declared_classes and deprecated_declared_classes have an entry

--- a/crates/papyrus_gateway/src/gateway_test.rs
+++ b/crates/papyrus_gateway/src/gateway_test.rs
@@ -190,7 +190,7 @@ async fn get_block_w_transaction_hashes() {
 
 #[tokio::test]
 async fn verify_serialization_deserialization_of_block() {
-    let api_block: starknet_api::block::Block = get_test_block(Some(0), 1, None, None, None);
+    let api_block: starknet_api::block::Block = get_test_block(1, None, None, None);
     let block = Block {
         status: BlockStatus::AcceptedOnL2,
         header: api_block.header.into(),

--- a/crates/papyrus_storage/src/body/body_test.rs
+++ b/crates/papyrus_storage/src/body/body_test.rs
@@ -183,32 +183,30 @@ async fn get_reverted_body_returns_none() {
     append_2_bodies(&mut writer);
 
     // Verify that we can get block 1's transactions before the revert.
-    assert!(reader
-        .begin_ro_txn()
-        .unwrap()
-        .get_block_transactions(BlockNumber(1))
-        .unwrap()
-        .is_some());
-    assert!(reader
-        .begin_ro_txn()
-        .unwrap()
-        .get_block_transaction_outputs(BlockNumber(1))
-        .unwrap()
-        .is_some());
+    assert!(
+        reader.begin_ro_txn().unwrap().get_block_transactions(BlockNumber(1)).unwrap().is_some()
+    );
+    assert!(
+        reader
+            .begin_ro_txn()
+            .unwrap()
+            .get_block_transaction_outputs(BlockNumber(1))
+            .unwrap()
+            .is_some()
+    );
 
     writer.begin_rw_txn().unwrap().revert_body(BlockNumber(1)).unwrap().0.commit().unwrap();
-    assert!(reader
-        .begin_ro_txn()
-        .unwrap()
-        .get_block_transactions(BlockNumber(1))
-        .unwrap()
-        .is_none());
-    assert!(reader
-        .begin_ro_txn()
-        .unwrap()
-        .get_block_transaction_outputs(BlockNumber(1))
-        .unwrap()
-        .is_none());
+    assert!(
+        reader.begin_ro_txn().unwrap().get_block_transactions(BlockNumber(1)).unwrap().is_none()
+    );
+    assert!(
+        reader
+            .begin_ro_txn()
+            .unwrap()
+            .get_block_transaction_outputs(BlockNumber(1))
+            .unwrap()
+            .is_none()
+    );
 }
 
 #[tokio::test]

--- a/crates/papyrus_storage/src/body/body_test.rs
+++ b/crates/papyrus_storage/src/body/body_test.rs
@@ -11,7 +11,7 @@ use crate::{StorageError, StorageWriter};
 #[tokio::test]
 async fn append_body() {
     let (reader, mut writer) = get_test_storage();
-    let body = get_test_block(Some(0), 10, None, None, None).body;
+    let body = get_test_block(10, None, None, None).body;
     let txs = body.transactions;
     let tx_outputs = body.transaction_outputs;
 
@@ -183,36 +183,38 @@ async fn get_reverted_body_returns_none() {
     append_2_bodies(&mut writer);
 
     // Verify that we can get block 1's transactions before the revert.
-    assert!(
-        reader.begin_ro_txn().unwrap().get_block_transactions(BlockNumber(1)).unwrap().is_some()
-    );
-    assert!(
-        reader
-            .begin_ro_txn()
-            .unwrap()
-            .get_block_transaction_outputs(BlockNumber(1))
-            .unwrap()
-            .is_some()
-    );
+    assert!(reader
+        .begin_ro_txn()
+        .unwrap()
+        .get_block_transactions(BlockNumber(1))
+        .unwrap()
+        .is_some());
+    assert!(reader
+        .begin_ro_txn()
+        .unwrap()
+        .get_block_transaction_outputs(BlockNumber(1))
+        .unwrap()
+        .is_some());
 
     writer.begin_rw_txn().unwrap().revert_body(BlockNumber(1)).unwrap().0.commit().unwrap();
-    assert!(
-        reader.begin_ro_txn().unwrap().get_block_transactions(BlockNumber(1)).unwrap().is_none()
-    );
-    assert!(
-        reader
-            .begin_ro_txn()
-            .unwrap()
-            .get_block_transaction_outputs(BlockNumber(1))
-            .unwrap()
-            .is_none()
-    );
+    assert!(reader
+        .begin_ro_txn()
+        .unwrap()
+        .get_block_transactions(BlockNumber(1))
+        .unwrap()
+        .is_none());
+    assert!(reader
+        .begin_ro_txn()
+        .unwrap()
+        .get_block_transaction_outputs(BlockNumber(1))
+        .unwrap()
+        .is_none());
 }
 
 #[tokio::test]
 async fn revert_transactions() {
     let (reader, mut writer) = get_test_storage();
-    let body = get_test_body(Some(0), 10, None, None, None);
+    let body = get_test_body(10, None, None, None);
     writer
         .begin_rw_txn()
         .unwrap()

--- a/crates/papyrus_storage/src/body/events_test.rs
+++ b/crates/papyrus_storage/src/body/events_test.rs
@@ -15,7 +15,7 @@ async fn iter_events_by_key() {
     let (storage_reader, mut storage_writer) = get_test_storage();
     let from_addresses =
         vec![ContractAddress(patricia_key!("0x22")), ContractAddress(patricia_key!("0x23"))];
-    let block = get_test_block(None, 2, Some(5), Some(from_addresses), None);
+    let block = get_test_block(2, Some(5), Some(from_addresses), None);
     let block_number = block.header.block_number;
     storage_writer
         .begin_rw_txn()
@@ -62,7 +62,7 @@ async fn iter_events_by_key() {
 #[tokio::test]
 async fn iter_events_by_index() {
     let (storage_reader, mut storage_writer) = get_test_storage();
-    let block = get_test_block(Some(0), 2, Some(5), None, None);
+    let block = get_test_block(2, Some(5), None, None);
     let block_number = block.header.block_number;
     storage_writer
         .begin_rw_txn()
@@ -102,7 +102,7 @@ async fn iter_events_by_index() {
 #[tokio::test]
 async fn revert_events() {
     let (storage_reader, mut storage_writer) = get_test_storage();
-    let block = get_test_block(Some(0), 2, Some(5), None, None);
+    let block = get_test_block(2, Some(5), None, None);
     let block_number = block.header.block_number;
     storage_writer
         .begin_rw_txn()

--- a/crates/papyrus_storage/src/ommer/ommer_test.rs
+++ b/crates/papyrus_storage/src/ommer/ommer_test.rs
@@ -12,7 +12,7 @@ use crate::test_utils::get_test_storage;
 #[test]
 fn insert_header_to_ommer() {
     let (_, mut writer) = get_test_storage();
-    let block = get_test_block(Some(0), 7, None, None, None);
+    let block = get_test_block(7, None, None, None);
     let block_hash = block.header.block_hash;
 
     writer
@@ -27,7 +27,7 @@ fn insert_header_to_ommer() {
 #[test]
 fn insert_body_to_ommer() {
     let (_, mut writer) = get_test_storage();
-    let block = get_test_block(Some(0), 7, None, None, None);
+    let block = get_test_block(7, None, None, None);
 
     fn split_tx_output(tx_output: TransactionOutput) -> (ThinTransactionOutput, Vec<EventContent>) {
         let events = tx_output.events().iter().map(|e| e.content.clone()).collect();
@@ -73,7 +73,7 @@ fn insert_raw_state_diff_to_ommer() {
 #[test]
 fn get_ommer_header() {
     let (reader, mut writer) = get_test_storage();
-    let block = get_test_block(Some(0), 7, None, None, None);
+    let block = get_test_block(7, None, None, None);
     let block_hash = block.header.block_hash;
 
     assert!(reader.begin_ro_txn().unwrap().get_ommer_header(block_hash).unwrap().is_none());

--- a/crates/papyrus_storage/src/serializers_test.rs
+++ b/crates/papyrus_storage/src/serializers_test.rs
@@ -16,7 +16,7 @@ pub trait StorageSerdeTest: StorageSerde {
 // implements the [`StorageSerde`] and [`GetTestInstance`] traits.
 impl<T: StorageSerde + GetTestInstance + Eq + Debug> StorageSerdeTest for T {
     fn storage_serde_test() {
-        let mut rng = get_rng(None);
+        let mut rng = get_rng();
         let item = T::get_test_instance(&mut rng);
         let mut serialized: Vec<u8> = Vec::new();
         item.serialize_into(&mut serialized).unwrap();

--- a/crates/test_utils/src/lib.rs
+++ b/crates/test_utils/src/lib.rs
@@ -75,12 +75,9 @@ pub fn read_json_file(path_in_resource_dir: &str) -> serde_json::Value {
 }
 
 /// Used in random test to create a random generator, see for example storage_serde_test.
-/// Randomness can be seeded by passing a seed parameter or by setting and env variable `SEED` or by
-/// the OS (the rust default).
-pub fn get_rng(seed: Option<u64>) -> ChaCha8Rng {
-    let seed: u64 = if let Some(seed) = seed {
-        seed
-    } else if let Ok(seed_str) = env::var("SEED") {
+/// Randomness can be seeded by setting and env variable `SEED` or by the OS (the rust default).
+pub fn get_rng() -> ChaCha8Rng {
+    let seed: u64 = if let Ok(seed_str) = env::var("SEED") {
         seed_str.parse().unwrap()
     } else {
         let mut rng = rand::thread_rng();
@@ -212,13 +209,12 @@ fn set_transaction_hash(tx: &mut Transaction, hash: TransactionHash) {
 
 // Returns a test block with a variable number of transactions and events.
 pub fn get_test_block(
-    seed: Option<u64>,
     transaction_count: usize,
     events_per_tx: Option<usize>,
     from_addresses: Option<Vec<ContractAddress>>,
     keys: Option<Vec<Vec<EventKey>>>,
 ) -> Block {
-    let mut rng = get_rng(seed);
+    let mut rng = get_rng();
     let events_per_tx = if let Some(events_per_tx) = events_per_tx { events_per_tx } else { 0 };
     get_rand_test_block_with_events(
         &mut rng,
@@ -231,13 +227,12 @@ pub fn get_test_block(
 
 // Returns a test block body with a variable number of transactions.
 pub fn get_test_body(
-    seed: Option<u64>,
     transaction_count: usize,
     events_per_tx: Option<usize>,
     from_addresses: Option<Vec<ContractAddress>>,
     keys: Option<Vec<Vec<EventKey>>>,
 ) -> BlockBody {
-    let mut rng = get_rng(seed);
+    let mut rng = get_rng();
     let events_per_tx = if let Some(events_per_tx) = events_per_tx { events_per_tx } else { 0 };
     get_rand_test_body_with_events(&mut rng, transaction_count, events_per_tx, from_addresses, keys)
 }
@@ -245,7 +240,7 @@ pub fn get_test_body(
 // Returns a state diff with one item in each IndexMap.
 // For a random test state diff call StateDiff::get_test_instance.
 pub fn get_test_state_diff() -> StateDiff {
-    let mut rng = ChaCha8Rng::seed_from_u64(0);
+    let mut rng = get_rng();
     let mut res = StateDiff::get_test_instance(&mut rng);
     // TODO(anatg): fix StateDiff::get_test_instance so the declared_classes will have different
     // hashes than the deprecated_contract_classes.

--- a/crates/test_utils/src/lib.rs
+++ b/crates/test_utils/src/lib.rs
@@ -77,11 +77,9 @@ pub fn read_json_file(path_in_resource_dir: &str) -> serde_json::Value {
 /// Used in random test to create a random generator, see for example storage_serde_test.
 /// Randomness can be seeded by setting and env variable `SEED` or by the OS (the rust default).
 pub fn get_rng() -> ChaCha8Rng {
-    let seed: u64 = if let Ok(seed_str) = env::var("SEED") {
-        seed_str.parse().unwrap()
-    } else {
-        let mut rng = rand::thread_rng();
-        rng.gen()
+    let seed: u64 = match env::var("SEED") {
+        Ok(seed_str) => seed_str.parse().unwrap(),
+        _ => rand::thread_rng().gen(),
     };
     // Will be printed if the test failed.
     println!("Testing with seed: {seed:?}");


### PR DESCRIPTION
dibatable lose of functionality but simplifies the code so I think it worth it.
also, there's still the ability to pass the seed as env var in order to debug when needed.

commit-id:a694971d

---

**Stack**:
- #639 ⬅
- #638
- #637
- #636
- #635
- #634


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/639)
<!-- Reviewable:end -->
