### PR TITLE
Add dump trait for sub configs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3866,6 +3866,10 @@ dependencies = [
 [[package]]
 name = "papyrus_config"
 version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "papyrus_gateway"
@@ -3879,6 +3883,7 @@ dependencies = [
  "hex",
  "hyper",
  "indexmap",
+ "insta",
  "jsonrpsee",
  "jsonschema",
  "papyrus_config",

--- a/config/default_config.json
+++ b/config/default_config.json
@@ -1,0 +1,18 @@
+{
+  "GatewayConfig.chain_id":{
+    "description":"The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id.",
+    "value":"SN_MAIN"
+  },
+  "GatewayConfig.max_events_chunk_size":{
+    "description":"Maximum chunk size supported by the node in get_events requests.",
+    "value":1000
+  },
+  "GatewayConfig.max_events_keys":{
+    "description":"Maximum number of keys supported by the node in get_events requests.",
+    "value":100
+  },
+  "GatewayConfig.server_address":{
+    "description":"IP:PORT of the node`s JSON-RPC server.",
+    "value":"0.0.0.0:8080"
+  }
+}

--- a/crates/papyrus_config/Cargo.toml
+++ b/crates/papyrus_config/Cargo.toml
@@ -4,5 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+serde.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]

--- a/crates/papyrus_config/src/lib.rs
+++ b/crates/papyrus_config/src/lib.rs
@@ -1,1 +1,44 @@
+use std::collections::HashMap;
+
+use serde::Serialize;
+use serde_json::{json, Map, Value};
+pub type ParamPath = String;
+pub type SerializedValue = String;
+pub type Description = String;
+
 pub const DEFAULT_CHAIN_ID: &str = "SN_MAIN";
+
+pub trait SubConfig: Serialize {
+    fn config_name() -> String;
+
+    /// A mapping between a param name to its description.
+    fn fields_description() -> HashMap<String, Description>;
+
+    fn param_path(param_name: &String) -> ParamPath {
+        let config_name = Self::config_name();
+        format!("{config_name}.{param_name}")
+    }
+
+    /// Serializes the sub-config into JSON.
+    fn dumps(&self) -> Map<String, Value> {
+        let descriptions = Self::fields_description();
+        let json_map: Map<String, Value> = serde_json::to_value(self)
+            .expect("Unable to serialize sub-config")
+            .as_object()
+            .expect("Unable to convert sub-config to map")
+            .clone();
+
+        let mut described_json_map = Map::<String, Value>::new();
+        for (key, value) in json_map {
+            let described_value = json!({
+                "description": descriptions
+                    .get(&key)
+                    .expect("Missing key from sub-config descriptions")
+                    .to_owned(),
+                "value": value
+            });
+            described_json_map.insert(Self::param_path(&key), described_value);
+        }
+        described_json_map
+    }
+}

--- a/crates/papyrus_gateway/Cargo.toml
+++ b/crates/papyrus_gateway/Cargo.toml
@@ -17,7 +17,6 @@ papyrus_proc_macros = { path = "../papyrus_proc_macros"}
 papyrus_storage = { path = "../papyrus_storage" }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-serde_yaml.workspace = true
 starknet_api.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full", "sync"] }
@@ -29,6 +28,7 @@ url.workspace = true
 [dev-dependencies]
 assert_matches.workspace = true
 hex.workspace = true
+insta = { workspace = true, features = ["json"] }
 jsonschema.workspace = true
 papyrus_storage = { path = "../papyrus_storage", features = ["testing"] }
 test_utils = { path = "../test_utils" }

--- a/crates/papyrus_gateway/Cargo.toml
+++ b/crates/papyrus_gateway/Cargo.toml
@@ -17,6 +17,7 @@ papyrus_proc_macros = { path = "../papyrus_proc_macros"}
 papyrus_storage = { path = "../papyrus_storage" }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+serde_yaml.workspace = true
 starknet_api.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full", "sync"] }

--- a/crates/papyrus_gateway/src/gateway_test.rs
+++ b/crates/papyrus_gateway/src/gateway_test.rs
@@ -8,15 +8,20 @@ use jsonrpsee::core::http_helpers::read_body;
 use jsonrpsee::core::{Error, RpcResult};
 use jsonrpsee::http_client::HttpClientBuilder;
 use jsonrpsee::types::ErrorObjectOwned;
+use papyrus_config::SubConfig;
 use papyrus_storage::test_utils::get_test_storage;
+use serde_json::{Map, Value};
 use starknet_api::block::BlockNumber;
+use test_utils::get_absolute_path;
 use tower::BoxError;
 
 use crate::api::version_config::{LATEST_VERSION_ID, VERSION_CONFIG};
 use crate::api::JsonRpcError;
 use crate::middleware::proxy_request;
 use crate::test_utils::get_test_gateway_config;
-use crate::{run_server, SERVER_MAX_BODY_SIZE};
+use crate::{run_server, GatewayConfig, SERVER_MAX_BODY_SIZE};
+
+const DEFAULT_CONFIG_FILE: &str = "config/default_config.json";
 
 #[tokio::test]
 async fn run_server_no_blocks() {
@@ -97,4 +102,14 @@ async fn test_version_middleware() {
     if let Ok(res) = call_proxy_request_get_method_in_out(bad_uri).await {
         panic!("expected failure got: {:?}", res);
     };
+}
+
+#[test]
+fn test_dump_default_config() {
+    let default_gateway = GatewayConfig::default();
+    let path = get_absolute_path(DEFAULT_CONFIG_FILE);
+    let file = std::fs::File::open(path).unwrap();
+    let deserialized_default_config: Map<String, Value> = serde_json::from_reader(file).unwrap();
+    let dumped = default_gateway.dumps();
+    assert_eq!(deserialized_default_config, dumped);
 }

--- a/crates/papyrus_gateway/src/gateway_test.rs
+++ b/crates/papyrus_gateway/src/gateway_test.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::panic;
 
 use assert_matches::assert_matches;
@@ -8,7 +9,7 @@ use jsonrpsee::core::http_helpers::read_body;
 use jsonrpsee::core::{Error, RpcResult};
 use jsonrpsee::http_client::HttpClientBuilder;
 use jsonrpsee::types::ErrorObjectOwned;
-use papyrus_config::SubConfig;
+use papyrus_config::{SerdeConfig, SerializedParam};
 use papyrus_storage::test_utils::get_test_storage;
 use serde_json::{Map, Value};
 use starknet_api::block::BlockNumber;
@@ -105,11 +106,26 @@ async fn test_version_middleware() {
 }
 
 #[test]
+/// Regression test which checks that the default config hasn't changed as well as dumping/parsing
+/// configs.
 fn test_dump_default_config() {
-    let default_gateway = GatewayConfig::default();
+    let dumped_default_gateway = GatewayConfig::default().dump_sub_config();
+    insta::assert_json_snapshot!(dumped_default_gateway);
+
     let path = get_absolute_path(DEFAULT_CONFIG_FILE);
     let file = std::fs::File::open(path).unwrap();
     let deserialized_default_config: Map<String, Value> = serde_json::from_reader(file).unwrap();
-    let dumped = default_gateway.dumps();
-    assert_eq!(deserialized_default_config, dumped);
+
+    let mut deserialized_map: BTreeMap<String, SerializedParam> = BTreeMap::new();
+    for (key, value) in deserialized_default_config {
+        deserialized_map.insert(
+            key.to_owned(),
+            SerializedParam {
+                description: value["description"].as_str().unwrap().to_owned(),
+                value: value["value"].to_owned(),
+            },
+        );
+    }
+
+    assert_eq!(deserialized_map, dumped_default_gateway);
 }

--- a/crates/papyrus_gateway/src/lib.rs
+++ b/crates/papyrus_gateway/src/lib.rs
@@ -9,7 +9,7 @@ mod state;
 mod test_utils;
 mod transaction;
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fmt::Display;
 use std::net::SocketAddr;
 
@@ -17,13 +17,14 @@ use jsonrpsee::server::{ServerBuilder, ServerHandle};
 use jsonrpsee::types::error::ErrorCode::InternalError;
 use jsonrpsee::types::error::INTERNAL_ERROR_MSG;
 use jsonrpsee::types::ErrorObjectOwned;
-use papyrus_config::{Description, SubConfig, DEFAULT_CHAIN_ID};
+use papyrus_config::{ParamPath, SerdeConfig, SerializedParam, DEFAULT_CHAIN_ID};
 use papyrus_storage::body::events::EventIndex;
 use papyrus_storage::body::BodyStorageReader;
 use papyrus_storage::db::TransactionKind;
 use papyrus_storage::header::HeaderStorageReader;
 use papyrus_storage::{StorageReader, StorageTxn};
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use starknet_api::block::BlockNumber;
 use starknet_api::core::ChainId;
 use tracing::{debug, error, info, instrument};
@@ -57,28 +58,40 @@ impl Default for GatewayConfig {
     }
 }
 
-impl SubConfig for GatewayConfig {
+impl SerdeConfig for GatewayConfig {
     fn config_name() -> String {
         String::from("GatewayConfig")
     }
 
-    fn fields_description() -> HashMap<String, Description> {
-        HashMap::from([
+    fn dump(&self) -> BTreeMap<ParamPath, SerializedParam> {
+        BTreeMap::from_iter([
             (
                 String::from("chain_id"),
-                String::from("The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id."),
+                SerializedParam {
+                    description: String::from("The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id."),
+                    value: json!(self.chain_id),
+                }
             ),
             (
                 String::from("server_address"),
-                String::from("IP:PORT of the node`s JSON-RPC server."),
+                SerializedParam {
+                    description: String::from("IP:PORT of the node`s JSON-RPC server."),
+                    value: json!(self.server_address),
+                }
             ),
             (
                 String::from("max_events_chunk_size"),
-                String::from("Maximum chunk size supported by the node in get_events requests."),
+                SerializedParam {
+                    description: String::from("Maximum chunk size supported by the node in get_events requests."),
+                    value: json!(self.max_events_chunk_size),
+                }
             ),
             (
                 String::from("max_events_keys"),
-                String::from("Maximum number of keys supported by the node in get_events requests."),
+                SerializedParam {
+                    description: String::from("Maximum number of keys supported by the node in get_events requests."),
+                    value: json!(self.max_events_keys),
+                }
             ),
         ])
     }

--- a/crates/papyrus_gateway/src/lib.rs
+++ b/crates/papyrus_gateway/src/lib.rs
@@ -9,6 +9,7 @@ mod state;
 mod test_utils;
 mod transaction;
 
+use std::collections::HashMap;
 use std::fmt::Display;
 use std::net::SocketAddr;
 
@@ -16,7 +17,7 @@ use jsonrpsee::server::{ServerBuilder, ServerHandle};
 use jsonrpsee::types::error::ErrorCode::InternalError;
 use jsonrpsee::types::error::INTERNAL_ERROR_MSG;
 use jsonrpsee::types::ErrorObjectOwned;
-use papyrus_config::DEFAULT_CHAIN_ID;
+use papyrus_config::{Description, SubConfig, DEFAULT_CHAIN_ID};
 use papyrus_storage::body::events::EventIndex;
 use papyrus_storage::body::BodyStorageReader;
 use papyrus_storage::db::TransactionKind;
@@ -37,7 +38,7 @@ use crate::transaction::Transaction;
 
 /// Maximum size of a supported transaction body - 10MB.
 pub const SERVER_MAX_BODY_SIZE: u32 = 10 * 1024 * 1024;
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct GatewayConfig {
     pub chain_id: ChainId,
     pub server_address: String,
@@ -53,6 +54,33 @@ impl Default for GatewayConfig {
             max_events_chunk_size: 1000,
             max_events_keys: 100,
         }
+    }
+}
+
+impl SubConfig for GatewayConfig {
+    fn config_name() -> String {
+        String::from("GatewayConfig")
+    }
+
+    fn fields_description() -> HashMap<String, Description> {
+        HashMap::from([
+            (
+                String::from("chain_id"),
+                String::from("The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id."),
+            ),
+            (
+                String::from("server_address"),
+                String::from("IP:PORT of the node`s JSON-RPC server."),
+            ),
+            (
+                String::from("max_events_chunk_size"),
+                String::from("Maximum chunk size supported by the node in get_events requests."),
+            ),
+            (
+                String::from("max_events_keys"),
+                String::from("Maximum number of keys supported by the node in get_events requests."),
+            ),
+        ])
     }
 }
 

--- a/crates/papyrus_gateway/src/snapshots/papyrus_gateway__gateway_test__dump_default_config.snap
+++ b/crates/papyrus_gateway/src/snapshots/papyrus_gateway__gateway_test__dump_default_config.snap
@@ -1,3 +1,7 @@
+---
+source: crates/papyrus_gateway/src/gateway_test.rs
+expression: dumped_default_gateway
+---
 {
   "GatewayConfig.chain_id": {
     "description": "The chain to follow. For more details see https://docs.starknet.io/documentation/architecture_and_concepts/Blocks/transactions/#chain-id.",
@@ -5,11 +9,15 @@
   },
   "GatewayConfig.max_events_chunk_size": {
     "description": "Maximum chunk size supported by the node in get_events requests.",
-    "value": 1000
+    "value": {
+      "$serde_json::private::Number": "1000"
+    }
   },
   "GatewayConfig.max_events_keys": {
     "description": "Maximum number of keys supported by the node in get_events requests.",
-    "value": 100
+    "value": {
+      "$serde_json::private::Number": "100"
+    }
   },
   "GatewayConfig.server_address": {
     "description": "IP:PORT of the node`s JSON-RPC server.",


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 496

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- A dump file for configurations with the default values and the members' descriptions.
- Currently only for the gateway config.

## Does this introduce a breaking change?

- [ ] Yes
- [ x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

The default config yaml file is flattened and structured as follows:
\- - variable path
\- variable Description
\- default value

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/723)
<!-- Reviewable:end -->
