### PR TITLE
shahak/sn writer client/starknet gateway client

### DIFF
--- a/crates/starknet_client/src/writer/mod.rs
+++ b/crates/starknet_client/src/writer/mod.rs
@@ -1,7 +1,108 @@
-//! Client implementation for the [`Starknet`] gateway.
-//!
-//! This client can make changes to [`Starknet`] by adding transactions to the next block.
+//! This module contains clients that can request changes to [`Starknet`].
 //!
 //! [`Starknet`]: https://starknet.io/
 
 pub mod objects;
+
+#[cfg(test)]
+mod starknet_gateway_client_test;
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::writer::objects::response::{DeclareResponse, DeployAccountResponse, InvokeResponse};
+use crate::writer::objects::transaction::{
+    DeclareTransaction, DeployAccountTransaction, InvokeTransaction,
+};
+use crate::{ClientCreationError, ClientResult, RetryConfig, StarknetClient};
+
+/// A trait describing an object that can communicate with [`Starknet`] and make changes to it.
+///
+/// [`Starknet`]: https://starknet.io/
+#[async_trait]
+pub trait StarknetWriter {
+    /// Add an invoke transaction to [`Starknet`].
+    ///
+    /// [`Starknet`]: https://starknet.io/
+    async fn add_invoke_transaction(&self, tx: &InvokeTransaction) -> ClientResult<InvokeResponse>;
+
+    /// Add a declare transaction to [`Starknet`].
+    ///
+    /// [`Starknet`]: https://starknet.io/
+    async fn add_declare_transaction(
+        &self,
+        tx: &DeclareTransaction,
+    ) -> ClientResult<DeclareResponse>;
+
+    /// Add a deploy account transaction to [`Starknet`].
+    ///
+    /// [`Starknet`]: https://starknet.io/
+    async fn add_deploy_account_transaction(
+        &self,
+        tx: &DeployAccountTransaction,
+    ) -> ClientResult<DeployAccountResponse>;
+}
+
+const ADD_TRANSACTION_URL_SUFFIX: &str = "gateway/add_transaction";
+
+/// A client for the [`Starknet`] gateway.
+///
+/// [`Starknet`]: https://starknet.io/
+pub struct StarknetGatewayClient {
+    add_transaction_url: Url,
+    client: StarknetClient,
+}
+
+#[async_trait]
+impl StarknetWriter for StarknetGatewayClient {
+    async fn add_invoke_transaction(&self, tx: &InvokeTransaction) -> ClientResult<InvokeResponse> {
+        self.add_transaction(&tx).await
+    }
+
+    async fn add_deploy_account_transaction(
+        &self,
+        tx: &DeployAccountTransaction,
+    ) -> ClientResult<DeployAccountResponse> {
+        self.add_transaction(&tx).await
+    }
+
+    async fn add_declare_transaction(
+        &self,
+        tx: &DeclareTransaction,
+    ) -> ClientResult<DeclareResponse> {
+        self.add_transaction(&tx).await
+    }
+}
+
+impl StarknetGatewayClient {
+    pub fn new(
+        starknet_url: &str,
+        http_headers: Option<HashMap<String, String>>,
+        node_version: &'static str,
+        retry_config: RetryConfig,
+    ) -> Result<Self, ClientCreationError> {
+        Ok(StarknetGatewayClient {
+            add_transaction_url: Url::parse(starknet_url)?.join(ADD_TRANSACTION_URL_SUFFIX)?,
+            client: StarknetClient::new(http_headers, node_version, retry_config)?,
+        })
+    }
+
+    async fn add_transaction<Transaction: Serialize, Response: for<'a> Deserialize<'a>>(
+        &self,
+        tx: &Transaction,
+    ) -> ClientResult<Response> {
+        let response: String = self
+            .client
+            .request_with_retry(
+                self.client
+                    .internal_client
+                    .post(self.add_transaction_url.clone())
+                    .body(serde_json::to_string(&tx)?),
+            )
+            .await?;
+        Ok(serde_json::from_str::<Response>(&response)?)
+    }
+}

--- a/crates/starknet_client/src/writer/starknet_gateway_client_test.rs
+++ b/crates/starknet_client/src/writer/starknet_gateway_client_test.rs
@@ -1,0 +1,78 @@
+use std::fmt::Debug;
+use std::future::Future;
+
+use mockito::{mock, Matcher};
+use serde::{Deserialize, Serialize};
+use test_utils::read_json_file;
+
+use crate::test_utils::retry::get_test_config;
+use crate::writer::{StarknetGatewayClient, StarknetWriter};
+use crate::ClientError;
+
+const NODE_VERSION: &str = "NODE VERSION";
+
+async fn test_add_transaction<
+    Transaction: Serialize + for<'a> Deserialize<'a>,
+    Response: for<'a> Deserialize<'a> + Debug + Eq,
+    F: FnOnce(StarknetGatewayClient, Transaction) -> Fut,
+    Fut: Future<Output = Result<Response, ClientError>>,
+>(
+    resource_file_transaction_path: &str,
+    resource_file_response_path: &str,
+    add_transaction_function: F,
+) {
+    let client =
+        StarknetGatewayClient::new(&mockito::server_url(), None, NODE_VERSION, get_test_config())
+            .unwrap();
+    let tx_json_value = read_json_file(resource_file_transaction_path);
+    let tx = serde_json::from_value::<Transaction>(tx_json_value.clone()).unwrap();
+    let response_json_value = read_json_file(resource_file_response_path);
+    let mock_add_transaction = mock("POST", "/gateway/add_transaction")
+        .match_body(Matcher::Json(tx_json_value))
+        .with_status(200)
+        .with_body(serde_json::to_string(&response_json_value).unwrap())
+        .create();
+    let expected_response = serde_json::from_value::<Response>(response_json_value).unwrap();
+    assert_eq!(expected_response, add_transaction_function(client, tx).await.unwrap());
+    mock_add_transaction.assert();
+}
+
+#[tokio::test]
+async fn add_invoke_transaction() {
+    test_add_transaction(
+        "writer/invoke.json",
+        "writer/invoke_response.json",
+        |client, tx| async move { client.add_invoke_transaction(&tx).await },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn add_declare_v1_transaction() {
+    test_add_transaction(
+        "writer/declare_v1.json",
+        "writer/declare_response.json",
+        |client, tx| async move { client.add_declare_transaction(&tx).await },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn add_declare_v2_transaction() {
+    test_add_transaction(
+        "writer/declare_v2.json",
+        "writer/declare_response.json",
+        |client, tx| async move { client.add_declare_transaction(&tx).await },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn add_deploy_account_transaction() {
+    test_add_transaction(
+        "writer/deploy_account.json",
+        "writer/deploy_account_response.json",
+        |client, tx| async move { client.add_deploy_account_transaction(&tx).await },
+    )
+    .await;
+}


### PR DESCRIPTION
- move common client functionality to StarknetBaseClient
- change request_with_retry to receive a RequestBuilder instead of Url
- move writer client into reader client crate
- add StarknetGatewayClient

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/901)
<!-- Reviewable:end -->
