### PR TITLE
shahak/sn writer client/remove transaction enum

### DIFF
--- a/crates/papyrus_gateway/src/v0_3_0/broadcasted_transaction.rs
+++ b/crates/papyrus_gateway/src/v0_3_0/broadcasted_transaction.rs
@@ -7,11 +7,11 @@
 //! [`Starknet specs`]: https://github.com/starkware-libs/starknet-specs/blob/master/api/starknet_api_openrpc.json
 
 use serde::{Deserialize, Serialize};
-use starknet_api::core::{CompiledClassHash, ContractAddress, Nonce};
-use starknet_api::transaction::{Fee, TransactionSignature, TransactionVersion};
-use starknet_reader_client::writer::objects::transaction::{
-    DeclareV1Transaction, DeployAccountTransaction, InvokeTransaction,
+use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
+use starknet_api::transaction::{
+    Calldata, ContractAddressSalt, Fee, TransactionSignature, TransactionVersion,
 };
+use starknet_reader_client::writer::objects::transaction::DeprecatedContractClass;
 
 use super::state::ContractClass;
 
@@ -50,7 +50,17 @@ pub enum BroadcastedDeclareTransaction {
 /// [`Starknet specs`].
 ///
 /// [`Starknet specs`]: https://github.com/starkware-libs/starknet-specs/blob/master/api/starknet_api_openrpc.json
-pub type BroadcastedDeployAccountTransaction = DeployAccountTransaction;
+#[derive(Debug, Default, Deserialize, Serialize, Clone, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct BroadcastedDeployAccountTransaction {
+    pub contract_address_salt: ContractAddressSalt,
+    pub class_hash: ClassHash,
+    pub constructor_calldata: Calldata,
+    pub nonce: Nonce,
+    pub max_fee: Fee,
+    pub signature: TransactionSignature,
+    pub version: TransactionVersion,
+}
 
 /// A broadcasted invoke transaction.
 ///
@@ -59,21 +69,34 @@ pub type BroadcastedDeployAccountTransaction = DeployAccountTransaction;
 /// type BROADCASTED_INVOKE_TXN_V1.
 ///
 /// [`Starknet specs`]: https://github.com/starkware-libs/starknet-specs/blob/master/api/starknet_api_openrpc.json
-pub type BroadcastedInvokeTransaction = InvokeTransaction;
+#[derive(Debug, Default, Deserialize, Serialize, Clone, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct BroadcastedInvokeTransaction {
+    pub calldata: Calldata,
+    pub sender_address: ContractAddress,
+    pub nonce: Nonce,
+    pub max_fee: Fee,
+    pub signature: TransactionSignature,
+    pub version: TransactionVersion,
+}
 
-// BroadcastedDeclareV2Transaction is not from starknet_writer_client because the broadcasted
-// declare v2 has slight alterations from the client declare v2. We define our own
-// BroadcastedDeclareV2Transaction further below.
 /// A broadcasted declare transaction of a Cairo-v0 contract.
 ///
 /// This transaction is equivalent to the component BROADCASTED_DECLARE_TXN_V1 in the
 /// [`Starknet specs`].
 ///
 /// [`Starknet specs`]: https://github.com/starkware-libs/starknet-specs/blob/master/api/starknet_api_openrpc.json
-pub type BroadcastedDeclareV1Transaction = DeclareV1Transaction;
+#[derive(Debug, Default, Deserialize, Serialize, Clone, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct BroadcastedDeclareV1Transaction {
+    pub contract_class: DeprecatedContractClass,
+    pub sender_address: ContractAddress,
+    pub nonce: Nonce,
+    pub max_fee: Fee,
+    pub version: TransactionVersion,
+    pub signature: TransactionSignature,
+}
 
-// The only difference between this and DeclareV2Transaction in starknet_writer_client is the
-// type of contract_class.
 /// A broadcasted declare transaction of a Cairo-v1 contract.
 ///
 /// This transaction is equivalent to the component BROADCASTED_DECLARE_TXN_V2 in the

--- a/crates/papyrus_gateway/src/v0_3_0/broadcasted_transaction_test.rs
+++ b/crates/papyrus_gateway/src/v0_3_0/broadcasted_transaction_test.rs
@@ -3,14 +3,16 @@ use std::collections::HashMap;
 use futures::executor::block_on;
 use jsonschema::JSONSchema;
 use lazy_static::lazy_static;
-use starknet_api::core::{CompiledClassHash, ContractAddress, Nonce};
+use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
 use starknet_api::deprecated_contract_class::{
     EntryPoint as DeprecatedEntryPoint, EntryPointType as DeprecatedEntryPointType, EventAbiEntry,
     FunctionAbiEntry, StructAbiEntry,
 };
 use starknet_api::hash::StarkFelt;
 use starknet_api::state::{EntryPoint, EntryPointType};
-use starknet_api::transaction::{Fee, TransactionSignature, TransactionVersion};
+use starknet_api::transaction::{
+    Calldata, ContractAddressSalt, Fee, TransactionSignature, TransactionVersion,
+};
 use starknet_reader_client::writer::objects::transaction::{
     DeprecatedContractClass, DeprecatedContractClassAbiEntry,
 };
@@ -26,6 +28,31 @@ use crate::test_utils::get_starknet_spec_api_schema;
 use crate::version_config::VERSION_0_3_0;
 
 auto_impl_get_test_instance! {
+    pub struct BroadcastedDeployAccountTransaction {
+        pub contract_address_salt: ContractAddressSalt,
+        pub class_hash: ClassHash,
+        pub constructor_calldata: Calldata,
+        pub nonce: Nonce,
+        pub max_fee: Fee,
+        pub signature: TransactionSignature,
+        pub version: TransactionVersion,
+    }
+    pub struct BroadcastedInvokeTransaction {
+        pub calldata: Calldata,
+        pub sender_address: ContractAddress,
+        pub nonce: Nonce,
+        pub max_fee: Fee,
+        pub signature: TransactionSignature,
+        pub version: TransactionVersion,
+    }
+    pub struct BroadcastedDeclareV1Transaction {
+        pub contract_class: DeprecatedContractClass,
+        pub sender_address: ContractAddress,
+        pub nonce: Nonce,
+        pub max_fee: Fee,
+        pub version: TransactionVersion,
+        pub signature: TransactionSignature,
+    }
     pub struct BroadcastedDeclareV2Transaction {
         pub contract_class: ContractClass,
         pub compiled_class_hash: CompiledClassHash,

--- a/crates/starknet_reader_client/src/writer/objects/response.rs
+++ b/crates/starknet_reader_client/src/writer/objects/response.rs
@@ -14,15 +14,6 @@ pub enum SuccessfulStarknetErrorCode {
     TransactionReceived,
 }
 
-/// The response of adding a transaction through the Starknet gateway successfully.
-#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
-#[serde(untagged)]
-pub enum AddTransactionResponse {
-    DeclareResponse(DeclareResponse),
-    DeployAccountResponse(DeployAccountResponse),
-    InvokeResponse(InvokeResponse),
-}
-
 /// The response of adding a declare transaction through the Starknet gateway successfully.
 #[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]

--- a/crates/starknet_reader_client/src/writer/objects/response_test.rs
+++ b/crates/starknet_reader_client/src/writer/objects/response_test.rs
@@ -1,25 +1,18 @@
-use assert_matches::assert_matches;
 use test_utils::validate_load_and_dump;
 
-use crate::writer::objects::response::AddTransactionResponse;
+use crate::writer::objects::response::{DeclareResponse, DeployAccountResponse, InvokeResponse};
 
 #[test]
 fn load_and_dump_deploy_account_same_string() {
-    validate_load_and_dump("writer/deploy_account_response.json", |response| {
-        assert_matches!(response, AddTransactionResponse::DeployAccountResponse(_));
-    });
+    validate_load_and_dump::<DeployAccountResponse>("writer/deploy_account_response.json");
 }
 
 #[test]
 fn load_and_dump_invoke_same_string() {
-    validate_load_and_dump("writer/invoke_response.json", |response| {
-        assert_matches!(response, AddTransactionResponse::InvokeResponse(_));
-    });
+    validate_load_and_dump::<InvokeResponse>("writer/invoke_response.json");
 }
 
 #[test]
-fn load_and_dump_declare_v1_same_string() {
-    validate_load_and_dump("writer/declare_response.json", |response| {
-        assert_matches!(response, AddTransactionResponse::DeclareResponse(_));
-    });
+fn load_and_dump_declare_same_string() {
+    validate_load_and_dump::<DeclareResponse>("writer/declare_response.json");
 }

--- a/crates/starknet_reader_client/src/writer/objects/test_utils.rs
+++ b/crates/starknet_reader_client/src/writer/objects/test_utils.rs
@@ -1,46 +1,16 @@
 use std::collections::HashMap;
 
-use starknet_api::core::{ClassHash, ContractAddress, Nonce};
 use starknet_api::deprecated_contract_class::{
     EntryPoint as DeprecatedEntryPoint, EntryPointType as DeprecatedEntryPointType, EventAbiEntry,
     FunctionAbiEntry, StructAbiEntry,
 };
-use starknet_api::transaction::{
-    Calldata, ContractAddressSalt, Fee, TransactionSignature, TransactionVersion,
-};
 use test_utils::{auto_impl_get_test_instance, get_number_of_variants, GetTestInstance};
 
 use crate::writer::objects::transaction::{
-    DeclareV1Transaction, DeployAccountTransaction, DeprecatedContractClass,
-    DeprecatedContractClassAbiEntry, InvokeTransaction,
+    DeprecatedContractClass, DeprecatedContractClassAbiEntry,
 };
 
 auto_impl_get_test_instance! {
-    pub struct DeployAccountTransaction {
-        pub contract_address_salt: ContractAddressSalt,
-        pub class_hash: ClassHash,
-        pub constructor_calldata: Calldata,
-        pub nonce: Nonce,
-        pub max_fee: Fee,
-        pub signature: TransactionSignature,
-        pub version: TransactionVersion,
-    }
-    pub struct InvokeTransaction {
-        pub calldata: Calldata,
-        pub sender_address: ContractAddress,
-        pub nonce: Nonce,
-        pub max_fee: Fee,
-        pub signature: TransactionSignature,
-        pub version: TransactionVersion,
-    }
-    pub struct DeclareV1Transaction {
-        pub contract_class: DeprecatedContractClass,
-        pub sender_address: ContractAddress,
-        pub nonce: Nonce,
-        pub max_fee: Fee,
-        pub version: TransactionVersion,
-        pub signature: TransactionSignature,
-    }
     pub struct DeprecatedContractClass {
         pub abi: Option<Vec<DeprecatedContractClassAbiEntry>>,
         pub compressed_program: String,

--- a/crates/starknet_reader_client/src/writer/objects/transaction.rs
+++ b/crates/starknet_reader_client/src/writer/objects/transaction.rs
@@ -19,23 +19,52 @@ use starknet_api::transaction::{
     Calldata, ContractAddressSalt, Fee, TransactionSignature, TransactionVersion,
 };
 
-/// A generic transaction that can be added to Starknet. When the transaction is serialized into a
-/// JSON object, it must be in the format that the Starknet gateway expects in the
-/// `add_transaction` HTTP method.
-#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
-#[serde(tag = "type")]
-pub enum Transaction {
+// Each transaction type has a field called `type`. This field needs to be of a type that
+// serializes to/deserializes from a constant string.
+//
+// The reason we don't solve this by having an enum of a generic transaction and let serde generate
+// the `type` field through #[serde(tag)] is because we want to serialize/deserialize from the
+// structs of the specific transaction types.
+
+/// The type field of a deploy account transaction. This enum serializes/deserializes into a
+/// constant string.
+#[derive(Debug, Deserialize, Serialize, Default, Clone, Copy, Eq, PartialEq)]
+pub enum DeployAccountType {
     #[serde(rename = "DEPLOY_ACCOUNT")]
-    DeployAccount(DeployAccountTransaction),
+    #[default]
+    DeployAccount,
+}
+
+/// The type field of an invoke transaction. This enum serializes/deserializes into a constant
+/// string.
+#[derive(Debug, Deserialize, Serialize, Default, Clone, Copy, Eq, PartialEq)]
+pub enum InvokeType {
     #[serde(rename = "INVOKE_FUNCTION")]
-    Invoke(InvokeTransaction),
+    #[default]
+    Invoke,
+}
+
+/// The type field of a declare V1 transaction. This enum serializes/deserializes into a constant
+/// string.
+#[derive(Debug, Deserialize, Serialize, Default, Clone, Copy, Eq, PartialEq)]
+pub enum DeclareV1Type {
     #[serde(rename = "DEPRECATED_DECLARE")]
-    DeclareV1(DeclareV1Transaction),
+    #[default]
+    DeclareV1,
+}
+
+/// The type field of a declare V2 transaction. This enum serializes/deserializes into a constant
+/// string.
+#[derive(Debug, Deserialize, Serialize, Default, Clone, Copy, Eq, PartialEq)]
+pub enum DeclareV2Type {
     #[serde(rename = "DECLARE")]
-    DeclareV2(DeclareV2Transaction),
+    #[default]
+    DeclareV2,
 }
 
 /// A deploy account transaction that can be added to Starknet through the Starknet gateway.
+/// It has a serialization format that the Starknet gateway accepts in the `add_transaction`
+/// HTTP method.
 #[derive(Debug, Default, Deserialize, Serialize, Clone, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct DeployAccountTransaction {
@@ -46,10 +75,13 @@ pub struct DeployAccountTransaction {
     pub max_fee: Fee,
     pub signature: TransactionSignature,
     pub version: TransactionVersion,
+    pub r#type: DeployAccountType,
 }
 
 /// An invoke account transaction that can be added to Starknet through the Starknet gateway.
 /// The invoke is a V1 transaction.
+/// It has a serialization format that the Starknet gateway accepts in the `add_transaction`
+/// HTTP method.
 #[derive(Debug, Default, Deserialize, Serialize, Clone, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct InvokeTransaction {
@@ -59,10 +91,13 @@ pub struct InvokeTransaction {
     pub max_fee: Fee,
     pub signature: TransactionSignature,
     pub version: TransactionVersion,
+    pub r#type: InvokeType,
 }
 
 /// A declare transaction of a Cairo-v0 (deprecated) contract class that can be added to Starknet
 /// through the Starknet gateway.
+/// It has a serialization format that the Starknet gateway accepts in the `add_transaction`
+/// HTTP method.
 #[derive(Debug, Default, Deserialize, Serialize, Clone, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct DeclareV1Transaction {
@@ -72,10 +107,13 @@ pub struct DeclareV1Transaction {
     pub max_fee: Fee,
     pub version: TransactionVersion,
     pub signature: TransactionSignature,
+    pub r#type: DeclareV1Type,
 }
 
 /// A declare transaction of a Cairo-v1 contract class that can be added to Starknet through the
 /// Starknet gateway.
+/// It has a serialization format that the Starknet gateway accepts in the `add_transaction`
+/// HTTP method.
 #[derive(Debug, Default, Deserialize, Serialize, Clone, Eq, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct DeclareV2Transaction {
@@ -86,6 +124,17 @@ pub struct DeclareV2Transaction {
     pub max_fee: Fee,
     pub version: TransactionVersion,
     pub signature: TransactionSignature,
+    pub r#type: DeclareV2Type,
+}
+
+/// A declare transaction that can be added to Starknet through the Starknet gateway.
+/// It has a serialization format that the Starknet gateway accepts in the `add_transaction`
+/// HTTP method.
+#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
+#[serde(untagged)]
+pub enum DeclareTransaction {
+    DeclareV1(DeclareV1Transaction),
+    DeclareV2(DeclareV2Transaction),
 }
 
 // The structs that are implemented here are the structs that have deviations from starknet_api.

--- a/crates/starknet_reader_client/src/writer/objects/transaction_test.rs
+++ b/crates/starknet_reader_client/src/writer/objects/transaction_test.rs
@@ -1,32 +1,25 @@
-use assert_matches::assert_matches;
 use test_utils::validate_load_and_dump;
 
-use crate::writer::objects::transaction::Transaction;
+use crate::writer::objects::transaction::{
+    DeclareV1Transaction, DeclareV2Transaction, DeployAccountTransaction, InvokeTransaction,
+};
 
 #[test]
 fn load_and_dump_deploy_account_same_string() {
-    validate_load_and_dump("writer/deploy_account.json", |transaction| {
-        assert_matches!(transaction, Transaction::DeployAccount(_));
-    });
+    validate_load_and_dump::<DeployAccountTransaction>("writer/deploy_account.json");
 }
 
 #[test]
 fn load_and_dump_invoke_same_string() {
-    validate_load_and_dump("writer/invoke.json", |transaction| {
-        assert_matches!(transaction, Transaction::Invoke(_));
-    });
+    validate_load_and_dump::<InvokeTransaction>("writer/invoke.json");
 }
 
 #[test]
 fn load_and_dump_declare_v1_same_string() {
-    validate_load_and_dump("writer/declare_v1.json", |transaction| {
-        assert_matches!(transaction, Transaction::DeclareV1(_));
-    });
+    validate_load_and_dump::<DeclareV1Transaction>("writer/declare_v1.json");
 }
 
 #[test]
 fn load_and_dump_declare_v2_same_string() {
-    validate_load_and_dump("writer/declare_v2.json", |transaction| {
-        assert_matches!(transaction, Transaction::DeclareV2(_));
-    });
+    validate_load_and_dump::<DeclareV2Transaction>("writer/declare_v2.json");
 }

--- a/crates/test_utils/src/lib.rs
+++ b/crates/test_utils/src/lib.rs
@@ -91,14 +91,10 @@ pub fn read_json_file(path_in_resource_dir: &str) -> serde_json::Value {
     serde_json::from_str(&json_str).unwrap()
 }
 
-pub fn validate_load_and_dump<T: Serialize + for<'a> Deserialize<'a>, F: Fn(&T)>(
-    path_in_resource_dir: &str,
-    validate_object: F,
-) {
+pub fn validate_load_and_dump<T: Serialize + for<'a> Deserialize<'a>>(path_in_resource_dir: &str) {
     let json_value = read_json_file(path_in_resource_dir);
     let load_result = serde_json::from_value::<T>(json_value.clone());
     assert_ok!(load_result);
-    validate_object(load_result.as_ref().unwrap());
     let dump_result = serde_json::to_value(&(load_result.unwrap()));
     assert_ok!(dump_result);
     assert_eq!(json_value, dump_result.unwrap());


### PR DESCRIPTION
- move writer client into reader client crate
- fix(starknet_client): Use crate instead of super
- refactor(starknet_client)!: remove Transaction and AddTransactionResponse (But keeping the variant structs)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/905)
<!-- Reviewable:end -->
