### PR TITLE
fix: add check for address 1 in gateway:get_storage_at

### DIFF
--- a/crates/papyrus_gateway/Cargo.toml
+++ b/crates/papyrus_gateway/Cargo.toml
@@ -14,6 +14,7 @@ futures.workspace = true
 futures-util.workspace = true
 hyper = { workspace = true, features = ["full"] }
 jsonrpsee = { workspace = true, features = ["full"] }
+lazy_static.workspace = true
 metrics.workspace = true
 papyrus_common = { path = "../papyrus_common"}
 papyrus_config = { path = "../papyrus_config", version = "0.0.4" }

--- a/crates/papyrus_gateway/src/v0_3_0/api/api_impl.rs
+++ b/crates/papyrus_gateway/src/v0_3_0/api/api_impl.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::types::ErrorObjectOwned;
 use jsonrpsee::RpcModule;
+use lazy_static::lazy_static;
 use papyrus_common::BlockHashAndNumber;
 use papyrus_storage::body::events::{EventIndex, EventsReader};
 use papyrus_storage::body::{BodyStorageReader, TransactionIndex};
@@ -53,6 +54,11 @@ use crate::{
     internal_server_error,
     ContinuationTokenAsStruct,
 };
+
+// TODO(yael): implement address 0x1 as a const function in starknet_api.
+lazy_static! {
+    pub static ref BLOCK_HASH_TABLE_ADDRESS: ContractAddress = ContractAddress::from(1_u8);
+}
 
 /// Rpc server.
 pub struct JsonRpcServerV0_3Impl {
@@ -129,13 +135,19 @@ impl JsonRpcV0_3Server for JsonRpcServerV0_3Impl {
         let state = StateNumber::right_after_block(block_number);
         let state_reader = txn.get_state_reader().map_err(internal_server_error)?;
 
-        // Check that the contract exists.
-        state_reader
-            .get_class_hash_at(state, &contract_address)
-            .map_err(internal_server_error)?
-            .ok_or_else(|| ErrorObjectOwned::from(JsonRpcError::ContractNotFound))?;
-
-        state_reader.get_storage_at(state, &contract_address, &key).map_err(internal_server_error)
+        let res = state_reader
+            .get_storage_at(state, &contract_address, &key)
+            .map_err(internal_server_error)?;
+        // Contract address 0x1 is a special address, it stores the block
+        // hashes. Contracts are not deployed to this address.
+        if res == StarkFelt::default() && contract_address != *BLOCK_HASH_TABLE_ADDRESS {
+            // Check if the contract exists
+            state_reader
+                .get_class_hash_at(state, &contract_address)
+                .map_err(internal_server_error)?
+                .ok_or_else(|| ErrorObjectOwned::from(JsonRpcError::ContractNotFound))?;
+        }
+        Ok(res)
     }
 
     #[instrument(skip(self), level = "debug", err, ret)]

--- a/crates/papyrus_gateway/src/v0_3_0/api/test.rs
+++ b/crates/papyrus_gateway/src/v0_3_0/api/test.rs
@@ -24,7 +24,7 @@ use starknet_api::deprecated_contract_class::{
     FunctionStateMutability,
 };
 use starknet_api::hash::{StarkFelt, StarkHash};
-use starknet_api::state::StateDiff;
+use starknet_api::state::{StateDiff, StorageKey};
 use starknet_api::transaction::{
     EventIndexInTransactionOutput,
     EventKey,
@@ -54,7 +54,7 @@ use super::super::transaction::{
     TransactionWithHash,
     Transactions,
 };
-use super::api_impl::JsonRpcServerV0_3Impl;
+use super::api_impl::{JsonRpcServerV0_3Impl, BLOCK_HASH_TABLE_ADDRESS};
 use super::{ContinuationToken, EventFilter};
 use crate::api::{BlockHashOrNumber, BlockId, Tag};
 use crate::syncing_state::SyncStatus;
@@ -1051,6 +1051,21 @@ async fn get_storage_at() {
         .await
         .unwrap();
     assert_eq!(res, *expected_value);
+
+    // Ask for storage at address 1 - the block hash table contract address
+    let key = StorageKey(patricia_key!("0x1001"));
+    let res = module
+        .call::<_, StarkFelt>(
+            "starknet_V0_3_getStorageAt",
+            (
+                *BLOCK_HASH_TABLE_ADDRESS,
+                key,
+                BlockId::HashOrNumber(BlockHashOrNumber::Number(header.block_number)),
+            ),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res, StarkFelt::default());
 
     // Ask for an invalid contract.
     let err = module

--- a/crates/papyrus_gateway/src/v0_4_0/api/api_impl.rs
+++ b/crates/papyrus_gateway/src/v0_4_0/api/api_impl.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::types::ErrorObjectOwned;
 use jsonrpsee::RpcModule;
+use lazy_static::lazy_static;
 use papyrus_execution::{estimate_fee as exec_estimate_fee, execute_call, ExecutionError};
 use papyrus_storage::body::events::{EventIndex, EventsReader};
 use papyrus_storage::body::{BodyStorageReader, TransactionIndex};
@@ -92,6 +93,11 @@ use crate::{
     ContinuationTokenAsStruct,
 };
 
+// TODO(yael): implement address 0x1 as a const function in starknet_api.
+lazy_static! {
+    pub static ref BLOCK_HASH_TABLE_ADDRESS: ContractAddress = ContractAddress::from(1_u8);
+}
+
 /// Rpc server.
 pub struct JsonRpcServerV0_4Impl {
     pub chain_id: ChainId,
@@ -168,13 +174,19 @@ impl JsonRpcV0_4Server for JsonRpcServerV0_4Impl {
         let state = StateNumber::right_after_block(block_number);
         let state_reader = txn.get_state_reader().map_err(internal_server_error)?;
 
-        // Check that the contract exists.
-        state_reader
-            .get_class_hash_at(state, &contract_address)
-            .map_err(internal_server_error)?
-            .ok_or_else(|| ErrorObjectOwned::from(CONTRACT_NOT_FOUND))?;
-
-        state_reader.get_storage_at(state, &contract_address, &key).map_err(internal_server_error)
+        let res = state_reader
+            .get_storage_at(state, &contract_address, &key)
+            .map_err(internal_server_error)?;
+        // Contract address 0x1 is a special address, it stores the block
+        // hashes. Contracts are not deployed to this address.
+        if res == StarkFelt::default() && contract_address != *BLOCK_HASH_TABLE_ADDRESS {
+            // check if the contract exists
+            state_reader
+                .get_class_hash_at(state, &contract_address)
+                .map_err(internal_server_error)?
+                .ok_or_else(|| ErrorObjectOwned::from(CONTRACT_NOT_FOUND))?;
+        }
+        Ok(res)
     }
 
     #[instrument(skip(self), level = "debug", err, ret)]

--- a/crates/papyrus_gateway/src/v0_4_0/api/test.rs
+++ b/crates/papyrus_gateway/src/v0_4_0/api/test.rs
@@ -28,7 +28,7 @@ use starknet_api::deprecated_contract_class::{
     FunctionStateMutability,
 };
 use starknet_api::hash::{StarkFelt, StarkHash};
-use starknet_api::state::StateDiff;
+use starknet_api::state::{StateDiff, StorageKey};
 use starknet_api::transaction::{
     EventIndexInTransactionOutput,
     EventKey,
@@ -78,7 +78,7 @@ use super::super::write_api_result::{
     AddDeployAccountOkResult,
     AddInvokeOkResult,
 };
-use super::api_impl::JsonRpcServerV0_4Impl;
+use super::api_impl::{JsonRpcServerV0_4Impl, BLOCK_HASH_TABLE_ADDRESS};
 use super::{ContinuationToken, EventFilter};
 use crate::api::{BlockHashOrNumber, BlockId, Tag};
 use crate::syncing_state::SyncStatus;
@@ -986,6 +986,21 @@ async fn get_storage_at() {
         .await
         .unwrap();
     assert_eq!(res, *expected_value);
+
+    // Ask for storage at address 0x1 - the block hash table contract address
+    let key = StorageKey(patricia_key!("0x1001"));
+    let res = module
+        .call::<_, StarkFelt>(
+            "starknet_V0_4_getStorageAt",
+            (
+                *BLOCK_HASH_TABLE_ADDRESS,
+                key,
+                BlockId::HashOrNumber(BlockHashOrNumber::Number(header.block_number)),
+            ),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res, StarkFelt::default());
 
     // Ask for an invalid contract.
     let err = module


### PR DESCRIPTION
When handling a get_storage_at request in the gateway, need to check first if the contract address is 1,
the contract address for the block hash table.
If it is, we need to return a value and not a ContractNotFound error.

## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1000)
<!-- Reviewable:end -->
