### PR TITLE
feat(JSON-RPC): use JsonRpcError for write_api errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1943,6 +1943,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7add3873b5dd076766ee79c8e406ad1a472c385476b9e38849f8eec24f1be689"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eecf8589574ce9b895052fa12d69af7a233f99e6107f5cb8dd1044f2a17bfdcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4290,6 +4310,7 @@ dependencies = [
  "cairo-lang-starknet",
  "camelpaste",
  "derive_more",
+ "enum-iterator",
  "futures",
  "futures-util",
  "hex",
@@ -5913,6 +5934,7 @@ dependencies = [
  "assert_matches",
  "async-trait",
  "cairo-lang-starknet",
+ "enum-iterator",
  "http",
  "indexmap 1.9.3",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ camelpaste = "0.1.0"
 clap = { version = "4.3.10" }
 const_format = "0.2.30"
 derive_more = "0.99.16"
+enum-iterator = "1.4.1"
 ethers = "2.0.3"
 flate2 = "1.0.24"
 futures = "0.3.21"

--- a/crates/papyrus_gateway/Cargo.toml
+++ b/crates/papyrus_gateway/Cargo.toml
@@ -36,6 +36,7 @@ cairo-lang-casm.workspace = true
 cairo-lang-starknet.workspace = true
 camelpaste.workspace = true
 derive_more.workspace = true
+enum-iterator.workspace = true
 hex.workspace = true
 jsonschema.workspace = true
 lazy_static.workspace = true

--- a/crates/papyrus_gateway/src/v0_4_0/error.rs
+++ b/crates/papyrus_gateway/src/v0_4_0/error.rs
@@ -59,67 +59,54 @@ pub const PENDING_BLOCKS_NOT_SUPPORTED: JsonRpcError = JsonRpcError {
     data: None,
 };
 
-#[allow(dead_code)]
 pub const CLASS_ALREADY_DECLARED: JsonRpcError =
     JsonRpcError { code: 51, message: "Class already declared", data: None };
 
-#[allow(dead_code)]
 pub const INVALID_TRANSACTION_NONCE: JsonRpcError =
     JsonRpcError { code: 52, message: "Invalid transaction nonce", data: None };
 
-#[allow(dead_code)]
 pub const INSUFFICIENT_MAX_FEE: JsonRpcError = JsonRpcError {
     code: 53,
     message: "Max fee is smaller than the minimal transaction cost (validation plus fee transfer)",
     data: None,
 };
 
-#[allow(dead_code)]
 pub const INSUFFICIENT_ACCOUNT_BALANCE: JsonRpcError = JsonRpcError {
     code: 54,
     message: "Account balance is smaller than the transaction's max_fee",
     data: None,
 };
 
-#[allow(dead_code)]
 pub const VALIDATION_FAILURE: JsonRpcError =
     JsonRpcError { code: 55, message: "Account validation failed", data: None };
 
-#[allow(dead_code)]
 pub const COMPILATION_FAILED: JsonRpcError =
     JsonRpcError { code: 56, message: "Compilation failed", data: None };
 
-#[allow(dead_code)]
 pub const CONTRACT_CLASS_SIZE_IS_TOO_LARGE: JsonRpcError =
     JsonRpcError { code: 57, message: "Contract class size it too large", data: None };
 
-#[allow(dead_code)]
 pub const NON_ACCOUNT: JsonRpcError =
     JsonRpcError { code: 58, message: "Sender address in not an account contract", data: None };
 
-#[allow(dead_code)]
 pub const DUPLICATE_TX: JsonRpcError = JsonRpcError {
     code: 59,
     message: "A transaction with the same hash already exists in the mempool",
     data: None,
 };
 
-#[allow(dead_code)]
 pub const COMPILED_CLASS_HASH_MISMATCH: JsonRpcError = JsonRpcError {
     code: 60,
     message: "the compiled class hash did not match the one supplied in the transaction",
     data: None,
 };
 
-#[allow(dead_code)]
 pub const UNSUPPORTED_TX_VERSION: JsonRpcError =
     JsonRpcError { code: 61, message: "the transaction version is not supported", data: None };
 
-#[allow(dead_code)]
 pub const UNSUPPORTED_CONTRACT_CLASS_VERSION: JsonRpcError =
     JsonRpcError { code: 62, message: "the contract class version is not supported", data: None };
 
-#[allow(dead_code)]
 pub fn unexpected_error(data: String) -> JsonRpcError {
     JsonRpcError { code: 63, message: "An unexpected error occured", data: Some(data) }
 }

--- a/crates/papyrus_gateway/src/v0_4_0/write_api_error.rs
+++ b/crates/papyrus_gateway/src/v0_4_0/write_api_error.rs
@@ -1,331 +1,84 @@
-use serde::de::Error;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use starknet_client::starknet_error::{KnownStarknetErrorCode, StarknetError, StarknetErrorCode};
+
+use crate::v0_4_0::error::{
+    unexpected_error, JsonRpcError, CLASS_ALREADY_DECLARED, CLASS_HASH_NOT_FOUND,
+    COMPILATION_FAILED, COMPILED_CLASS_HASH_MISMATCH, CONTRACT_CLASS_SIZE_IS_TOO_LARGE,
+    DUPLICATE_TX, INSUFFICIENT_ACCOUNT_BALANCE, INSUFFICIENT_MAX_FEE, INVALID_TRANSACTION_NONCE,
+    NON_ACCOUNT, UNSUPPORTED_CONTRACT_CLASS_VERSION, UNSUPPORTED_TX_VERSION, VALIDATION_FAILURE,
+};
 
 #[cfg(test)]
 #[path = "write_api_error_test.rs"]
 mod write_api_error_test;
 
-#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
-pub enum AddInvokeError {
-    InsufficientAccountBalance(InsufficientAccountBalance),
-    InsufficientMaxFee(InsufficientMaxFee),
-    InvalidTransactionNonce(InvalidTransactionNonce),
-    ValidationFailure(ValidationFailure),
-    NonAccount(NonAccount),
-    DuplicateTx(DuplicateTx),
-    UnsupportedTxVersion(UnsupportedTxVersion),
-    UnexpectedError(UnexpectedError),
+// TODO(shahak): Remove allow dead code once this function is used.
+#[allow(dead_code)]
+pub(crate) fn starknet_error_to_invoke_error(error: StarknetError) -> JsonRpcError {
+    let StarknetErrorCode::KnownErrorCode(known_error_code) = error.code else {
+        return unexpected_error(
+            error.message
+        );
+    };
+    match known_error_code {
+        KnownStarknetErrorCode::DuplicatedTransaction => DUPLICATE_TX,
+        // EntryPointNotFoundInContract is not thrown in __execute__ since that is
+        // considered as a reverted transaction. It is also not thrown in __validate__ since
+        // every error there is considered a ValidateFailure. This means that if
+        // EntryPointNotFoundInContract is thrown then it failed because it couldn't find
+        // __validate__ or __execute__ and that means the contract is not an account contract.
+        KnownStarknetErrorCode::EntryPointNotFoundInContract => NON_ACCOUNT,
+        KnownStarknetErrorCode::InsufficientAccountBalance => INSUFFICIENT_ACCOUNT_BALANCE,
+        KnownStarknetErrorCode::InsufficientMaxFee => INSUFFICIENT_MAX_FEE,
+        KnownStarknetErrorCode::InvalidTransactionNonce => INVALID_TRANSACTION_NONCE,
+        KnownStarknetErrorCode::InvalidTransactionVersion => UNSUPPORTED_TX_VERSION,
+        KnownStarknetErrorCode::ValidateFailure => VALIDATION_FAILURE,
+        _ => unexpected_error(error.message),
+    }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
-pub enum AddDeclareError {
-    ClassAlreadyDeclared(ClassAlreadyDeclared),
-    CompilationFailed(CompilationFailed),
-    CompiledClassHashMismatch(CompiledClassHashMismatch),
-    InsufficientAccountBalance(InsufficientAccountBalance),
-    InsufficientMaxFee(InsufficientMaxFee),
-    InvalidTransactionNonce(InvalidTransactionNonce),
-    ValidationFailure(ValidationFailure),
-    NonAccount(NonAccount),
-    DuplicateTx(DuplicateTx),
-    ContractClassSizeIsTooLarge(ContractClassSizeIsTooLarge),
-    UnsupportedTxVersion(UnsupportedTxVersion),
-    UnsupportedContractClassVersion(UnsupportedContractClassVersion),
-    UnexpectedError(UnexpectedError),
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
-pub enum AddDeployAccountError {
-    InsufficientAccountBalance(InsufficientAccountBalance),
-    InsufficientMaxFee(InsufficientMaxFee),
-    InvalidTransactionNonce(InvalidTransactionNonce),
-    ValidationFailure(ValidationFailure),
-    NonAccount(NonAccount),
-    ClassHashNotFound(ClassHashNotFound),
-    DuplicateTx(DuplicateTx),
-    UnsupportedTxVersion(UnsupportedTxVersion),
-    UnexpectedError(UnexpectedError),
-}
-
-impl From<StarknetError> for AddInvokeError {
-    fn from(error: StarknetError) -> Self {
-        let StarknetErrorCode::KnownErrorCode(known_error_code) = error.code else {
-            return Self::UnexpectedError(UnexpectedError::Error(
-                ErrorCodeWithData { data: error.message, ..Default::default() }
-            ));
+// TODO(shahak): Remove allow dead code once this function is used.
+#[allow(dead_code)]
+pub(crate) fn starknet_error_to_declare_error(error: StarknetError) -> JsonRpcError {
+    let StarknetErrorCode::KnownErrorCode(known_error_code) = error.code else {
+            return unexpected_error(
+                error.message
+            );
         };
-        match known_error_code {
-            KnownStarknetErrorCode::DuplicatedTransaction => {
-                Self::DuplicateTx(DuplicateTx::Error(ErrorCode::default()))
-            }
-            // EntryPointNotFoundInContract is not thrown in __execute__ since that is
-            // considered as a reverted transaction. It is also not thrown in __validate__ since
-            // every error there is considered a ValidateFailure. This means that if
-            // EntryPointNotFoundInContract is thrown then it failed because it couldn't find
-            // __validate__ or __execute__ and that means the contract is not an account contract.
-            KnownStarknetErrorCode::EntryPointNotFoundInContract => {
-                Self::NonAccount(NonAccount::Error(ErrorCode::default()))
-            }
-            KnownStarknetErrorCode::InsufficientAccountBalance => Self::InsufficientAccountBalance(
-                InsufficientAccountBalance::Error(ErrorCode::default()),
-            ),
-            KnownStarknetErrorCode::InsufficientMaxFee => {
-                Self::InsufficientMaxFee(InsufficientMaxFee::Error(ErrorCode::default()))
-            }
-            KnownStarknetErrorCode::InvalidTransactionNonce => {
-                Self::InvalidTransactionNonce(InvalidTransactionNonce::Error(ErrorCode::default()))
-            }
-            KnownStarknetErrorCode::InvalidTransactionVersion => {
-                Self::UnsupportedTxVersion(UnsupportedTxVersion::Error(ErrorCode::default()))
-            }
-            KnownStarknetErrorCode::ValidateFailure => {
-                Self::ValidationFailure(ValidationFailure::Error(ErrorCode::default()))
-            }
-            _ => Self::UnexpectedError(UnexpectedError::Error(ErrorCodeWithData {
-                data: error.message,
-                ..Default::default()
-            })),
-        }
+    match known_error_code {
+        KnownStarknetErrorCode::ClassAlreadyDeclared => CLASS_ALREADY_DECLARED,
+        KnownStarknetErrorCode::CompilationFailed => COMPILATION_FAILED,
+        KnownStarknetErrorCode::ContractBytecodeSizeTooLarge => CONTRACT_CLASS_SIZE_IS_TOO_LARGE,
+        KnownStarknetErrorCode::ContractClassObjectSizeTooLarge => CONTRACT_CLASS_SIZE_IS_TOO_LARGE,
+        KnownStarknetErrorCode::DuplicatedTransaction => DUPLICATE_TX,
+        // See explanation on this mapping in AddInvokeError.
+        KnownStarknetErrorCode::EntryPointNotFoundInContract => NON_ACCOUNT,
+        KnownStarknetErrorCode::InsufficientAccountBalance => INSUFFICIENT_ACCOUNT_BALANCE,
+        KnownStarknetErrorCode::InsufficientMaxFee => INSUFFICIENT_MAX_FEE,
+        KnownStarknetErrorCode::InvalidCompiledClassHash => COMPILED_CLASS_HASH_MISMATCH,
+        KnownStarknetErrorCode::InvalidContractClassVersion => UNSUPPORTED_CONTRACT_CLASS_VERSION,
+        KnownStarknetErrorCode::InvalidTransactionNonce => INVALID_TRANSACTION_NONCE,
+        KnownStarknetErrorCode::InvalidTransactionVersion => UNSUPPORTED_TX_VERSION,
+        KnownStarknetErrorCode::ValidateFailure => VALIDATION_FAILURE,
+        _ => unexpected_error(error.message),
     }
 }
 
-impl From<StarknetError> for AddDeclareError {
-    fn from(error: StarknetError) -> Self {
-        let StarknetErrorCode::KnownErrorCode(known_error_code) = error.code else {
-            return Self::UnexpectedError(UnexpectedError::Error(
-                ErrorCodeWithData { data: error.message, ..Default::default() }
-            ));
+// TODO(shahak): Remove allow dead code once this function is used.
+#[allow(dead_code)]
+pub(crate) fn starknet_error_to_deploy_account_error(error: StarknetError) -> JsonRpcError {
+    let StarknetErrorCode::KnownErrorCode(known_error_code) = error.code else {
+            return unexpected_error(error.message);
         };
-        match known_error_code {
-            KnownStarknetErrorCode::ClassAlreadyDeclared => {
-                Self::ClassAlreadyDeclared(ClassAlreadyDeclared::Error(ErrorCode::default()))
-            }
-            KnownStarknetErrorCode::CompilationFailed => {
-                Self::CompilationFailed(CompilationFailed::Error(ErrorCode::default()))
-            }
-            KnownStarknetErrorCode::ContractBytecodeSizeTooLarge => {
-                Self::ContractClassSizeIsTooLarge(ContractClassSizeIsTooLarge::Error(
-                    ErrorCode::default(),
-                ))
-            }
-            KnownStarknetErrorCode::ContractClassObjectSizeTooLarge => {
-                Self::ContractClassSizeIsTooLarge(ContractClassSizeIsTooLarge::Error(
-                    ErrorCode::default(),
-                ))
-            }
-            KnownStarknetErrorCode::DuplicatedTransaction => {
-                Self::DuplicateTx(DuplicateTx::Error(ErrorCode::default()))
-            }
-            // See explanation on this mapping in AddInvokeError.
-            KnownStarknetErrorCode::EntryPointNotFoundInContract => {
-                Self::NonAccount(NonAccount::Error(ErrorCode::default()))
-            }
-            KnownStarknetErrorCode::InsufficientAccountBalance => Self::InsufficientAccountBalance(
-                InsufficientAccountBalance::Error(ErrorCode::default()),
-            ),
-            KnownStarknetErrorCode::InsufficientMaxFee => {
-                Self::InsufficientMaxFee(InsufficientMaxFee::Error(ErrorCode::default()))
-            }
-            KnownStarknetErrorCode::InvalidCompiledClassHash => Self::CompiledClassHashMismatch(
-                CompiledClassHashMismatch::Error(ErrorCode::default()),
-            ),
-            KnownStarknetErrorCode::InvalidContractClassVersion => {
-                Self::UnsupportedContractClassVersion(UnsupportedContractClassVersion::Error(
-                    ErrorCode::default(),
-                ))
-            }
-            KnownStarknetErrorCode::InvalidTransactionNonce => {
-                Self::InvalidTransactionNonce(InvalidTransactionNonce::Error(ErrorCode::default()))
-            }
-            KnownStarknetErrorCode::InvalidTransactionVersion => {
-                Self::UnsupportedTxVersion(UnsupportedTxVersion::Error(ErrorCode::default()))
-            }
-            KnownStarknetErrorCode::ValidateFailure => {
-                Self::ValidationFailure(ValidationFailure::Error(ErrorCode::default()))
-            }
-            _ => Self::UnexpectedError(UnexpectedError::Error(ErrorCodeWithData {
-                data: error.message,
-                ..Default::default()
-            })),
-        }
-    }
-}
-
-impl From<StarknetError> for AddDeployAccountError {
-    fn from(error: StarknetError) -> Self {
-        let StarknetErrorCode::KnownErrorCode(known_error_code) = error.code else {
-            return Self::UnexpectedError(UnexpectedError::Error(
-                ErrorCodeWithData { data: error.message, ..Default::default() }
-            ));
-        };
-        match known_error_code {
-            KnownStarknetErrorCode::DuplicatedTransaction => {
-                Self::DuplicateTx(DuplicateTx::Error(ErrorCode::default()))
-            }
-            // See explanation on this mapping in AddInvokeError.
-            KnownStarknetErrorCode::EntryPointNotFoundInContract => {
-                Self::NonAccount(NonAccount::Error(ErrorCode::default()))
-            }
-            KnownStarknetErrorCode::InsufficientAccountBalance => Self::InsufficientAccountBalance(
-                InsufficientAccountBalance::Error(ErrorCode::default()),
-            ),
-            KnownStarknetErrorCode::InsufficientMaxFee => {
-                Self::InsufficientMaxFee(InsufficientMaxFee::Error(ErrorCode::default()))
-            }
-            KnownStarknetErrorCode::InvalidTransactionNonce => {
-                Self::InvalidTransactionNonce(InvalidTransactionNonce::Error(ErrorCode::default()))
-            }
-            KnownStarknetErrorCode::InvalidTransactionVersion => {
-                Self::UnsupportedTxVersion(UnsupportedTxVersion::Error(ErrorCode::default()))
-            }
-            KnownStarknetErrorCode::UndeclaredClass => {
-                Self::ClassHashNotFound(ClassHashNotFound::Error(ErrorCode::default()))
-            }
-            KnownStarknetErrorCode::ValidateFailure => {
-                Self::ValidationFailure(ValidationFailure::Error(ErrorCode::default()))
-            }
-            _ => Self::UnexpectedError(UnexpectedError::Error(ErrorCodeWithData {
-                data: error.message,
-                ..Default::default()
-            })),
-        }
-    }
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
-#[serde(tag = "message")]
-pub enum ClassHashNotFound {
-    #[serde(rename = "Class hash not found")]
-    Error(ErrorCode<28>),
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
-#[serde(tag = "message")]
-pub enum ClassAlreadyDeclared {
-    #[serde(rename = "Class already declared")]
-    Error(ErrorCode<51>),
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
-#[serde(tag = "message")]
-pub enum InvalidTransactionNonce {
-    #[serde(rename = "Invalid transaction nonce")]
-    Error(ErrorCode<52>),
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
-#[serde(tag = "message")]
-pub enum InsufficientMaxFee {
-    #[serde(rename = "\
-        Max fee is smaller than the minimal transaction cost (validation plus fee transfer)")]
-    Error(ErrorCode<53>),
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
-#[serde(tag = "message")]
-pub enum InsufficientAccountBalance {
-    #[serde(rename = "Account balance is smaller than the transaction's max_fee")]
-    Error(ErrorCode<54>),
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
-#[serde(tag = "message")]
-pub enum ValidationFailure {
-    #[serde(rename = "Account validation failed")]
-    Error(ErrorCode<55>),
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
-#[serde(tag = "message")]
-pub enum CompilationFailed {
-    #[serde(rename = "Compilation failed")]
-    Error(ErrorCode<56>),
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
-#[serde(tag = "message")]
-pub enum ContractClassSizeIsTooLarge {
-    #[serde(rename = "Contract class size it too large")]
-    Error(ErrorCode<57>),
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
-#[serde(tag = "message")]
-pub enum NonAccount {
-    #[serde(rename = "Sender address in not an account contract")]
-    Error(ErrorCode<58>),
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
-#[serde(tag = "message")]
-pub enum DuplicateTx {
-    #[serde(rename = "A transaction with the same hash already exists in the mempool")]
-    Error(ErrorCode<59>),
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
-#[serde(tag = "message")]
-pub enum CompiledClassHashMismatch {
-    #[serde(rename = "the compiled class hash did not match the one supplied in the transaction")]
-    Error(ErrorCode<60>),
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
-#[serde(tag = "message")]
-pub enum UnsupportedTxVersion {
-    #[serde(rename = "the transaction version is not supported")]
-    Error(ErrorCode<61>),
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
-#[serde(tag = "message")]
-pub enum UnsupportedContractClassVersion {
-    #[serde(rename = "the contract class version is not supported")]
-    Error(ErrorCode<62>),
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
-#[serde(tag = "message")]
-pub enum UnexpectedError {
-    #[serde(rename = "An unexpected error occured")]
-    Error(ErrorCodeWithData<63>),
-}
-
-#[derive(Debug, Default, Deserialize, Serialize, Clone, Eq, PartialEq)]
-pub struct ErrorCode<const CODE: usize> {
-    code: ConstInt<CODE>,
-}
-
-#[derive(Debug, Default, Deserialize, Serialize, Clone, Eq, PartialEq)]
-pub struct ErrorCodeWithData<const CODE: usize> {
-    #[serde(flatten)]
-    code: ErrorCode<CODE>,
-    data: String,
-}
-
-#[derive(Debug, Default, Clone, Eq, PartialEq)]
-pub struct ConstInt<const VALUE: usize>;
-
-impl<const VALUE: usize> Serialize for ConstInt<VALUE> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_u64(VALUE.try_into().expect("Failed converting a usize to u64."))
-    }
-}
-
-impl<'de, const VALUE: usize> Deserialize<'de> for ConstInt<VALUE> {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let value = usize::deserialize(deserializer)?;
-        if value == VALUE {
-            Ok(Self)
-        } else {
-            Err(D::Error::custom(format!("Expected constant integer {VALUE}, got {value}.")))
-        }
+    match known_error_code {
+        KnownStarknetErrorCode::DuplicatedTransaction => DUPLICATE_TX,
+        // See explanation on this mapping in AddInvokeError.
+        KnownStarknetErrorCode::EntryPointNotFoundInContract => NON_ACCOUNT,
+        KnownStarknetErrorCode::InsufficientAccountBalance => INSUFFICIENT_ACCOUNT_BALANCE,
+        KnownStarknetErrorCode::InsufficientMaxFee => INSUFFICIENT_MAX_FEE,
+        KnownStarknetErrorCode::InvalidTransactionNonce => INVALID_TRANSACTION_NONCE,
+        KnownStarknetErrorCode::InvalidTransactionVersion => UNSUPPORTED_TX_VERSION,
+        KnownStarknetErrorCode::UndeclaredClass => CLASS_HASH_NOT_FOUND,
+        KnownStarknetErrorCode::ValidateFailure => VALIDATION_FAILURE,
+        _ => unexpected_error(error.message),
     }
 }

--- a/crates/papyrus_gateway/src/v0_4_0/write_api_error_test.rs
+++ b/crates/papyrus_gateway/src/v0_4_0/write_api_error_test.rs
@@ -1,277 +1,60 @@
-use serde::Serialize;
+use enum_iterator::all;
+use jsonrpsee::types::ErrorObjectOwned;
 use starknet_client::starknet_error::{KnownStarknetErrorCode, StarknetError, StarknetErrorCode};
 
+use super::super::error::JsonRpcError;
 use super::{
-    AddDeclareError, AddDeployAccountError, AddInvokeError, ClassAlreadyDeclared,
-    ClassHashNotFound, CompilationFailed, CompiledClassHashMismatch, ContractClassSizeIsTooLarge,
-    DuplicateTx, ErrorCode, ErrorCodeWithData, InsufficientAccountBalance, InsufficientMaxFee,
-    InvalidTransactionNonce, NonAccount, UnexpectedError, UnsupportedContractClassVersion,
-    UnsupportedTxVersion, ValidationFailure,
+    starknet_error_to_declare_error, starknet_error_to_deploy_account_error,
+    starknet_error_to_invoke_error,
 };
 use crate::test_utils::{get_starknet_spec_api_schema_for_method_errors, SpecFile};
 use crate::version_config::VERSION_0_4;
 
-fn test_error_fits_rpc<AddError: Serialize>(error: AddError, spec_method: &str) {
+const MESSAGE: &str = "message";
+const UNKNOWN_CODE: &str = "code";
+
+fn test_error_from_conversion_fits_rpc<F: Fn(StarknetError) -> JsonRpcError>(
+    f: F,
+    spec_method: &str,
+) {
     let schema = get_starknet_spec_api_schema_for_method_errors(
         &[(SpecFile::StarknetWriteApi, &[spec_method])],
         &VERSION_0_4,
     );
-    assert!(schema.is_valid(&serde_json::to_value(error).unwrap()));
-}
-
-const MESSAGE: &str = "message";
-
-fn invoke_errors_and_starknet_error_codes() -> Vec<(AddInvokeError, StarknetErrorCode)> {
-    vec![
-        (
-            AddInvokeError::InsufficientAccountBalance(InsufficientAccountBalance::Error(
-                ErrorCode::default(),
-            )),
-            StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::InsufficientAccountBalance),
-        ),
-        (
-            AddInvokeError::InsufficientMaxFee(InsufficientMaxFee::Error(ErrorCode::default())),
-            StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::InsufficientMaxFee),
-        ),
-        (
-            AddInvokeError::InvalidTransactionNonce(InvalidTransactionNonce::Error(
-                ErrorCode::default(),
-            )),
-            StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::InvalidTransactionNonce),
-        ),
-        (
-            AddInvokeError::ValidationFailure(ValidationFailure::Error(ErrorCode::default())),
-            StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::ValidateFailure),
-        ),
-        (
-            AddInvokeError::NonAccount(NonAccount::Error(ErrorCode::default())),
-            StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::EntryPointNotFoundInContract),
-        ),
-        (
-            AddInvokeError::DuplicateTx(DuplicateTx::Error(ErrorCode::default())),
-            StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::DuplicatedTransaction),
-        ),
-        (
-            AddInvokeError::UnsupportedTxVersion(UnsupportedTxVersion::Error(ErrorCode::default())),
-            StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::InvalidTransactionVersion),
-        ),
-        (
-            AddInvokeError::UnexpectedError(UnexpectedError::Error(ErrorCodeWithData {
-                data: MESSAGE.to_string(),
-                ..Default::default()
-            })),
-            StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::BlockNotFound),
-        ),
-        (
-            AddInvokeError::UnexpectedError(UnexpectedError::Error(ErrorCodeWithData {
-                data: MESSAGE.to_string(),
-                ..Default::default()
-            })),
-            StarknetErrorCode::UnknownErrorCode("CODE".to_string()),
-        ),
-    ]
-}
-
-fn declare_errors_and_starknet_error_codes() -> Vec<(AddDeclareError, StarknetErrorCode)> {
-    vec![
-        (
-            AddDeclareError::ClassAlreadyDeclared(
-                ClassAlreadyDeclared::Error(ErrorCode::default()),
-            ),
-            StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::ClassAlreadyDeclared),
-        ),
-        (
-            AddDeclareError::CompilationFailed(CompilationFailed::Error(ErrorCode::default())),
-            StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::CompilationFailed),
-        ),
-        (
-            AddDeclareError::CompiledClassHashMismatch(CompiledClassHashMismatch::Error(
-                ErrorCode::default(),
-            )),
-            StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::InvalidCompiledClassHash),
-        ),
-        (
-            AddDeclareError::InsufficientAccountBalance(InsufficientAccountBalance::Error(
-                ErrorCode::default(),
-            )),
-            StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::InsufficientAccountBalance),
-        ),
-        (
-            AddDeclareError::InsufficientMaxFee(InsufficientMaxFee::Error(ErrorCode::default())),
-            StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::InsufficientMaxFee),
-        ),
-        (
-            AddDeclareError::InvalidTransactionNonce(InvalidTransactionNonce::Error(
-                ErrorCode::default(),
-            )),
-            StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::InvalidTransactionNonce),
-        ),
-        (
-            AddDeclareError::ValidationFailure(ValidationFailure::Error(ErrorCode::default())),
-            StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::ValidateFailure),
-        ),
-        (
-            AddDeclareError::NonAccount(NonAccount::Error(ErrorCode::default())),
-            StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::EntryPointNotFoundInContract),
-        ),
-        (
-            AddDeclareError::DuplicateTx(DuplicateTx::Error(ErrorCode::default())),
-            StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::DuplicatedTransaction),
-        ),
-        (
-            AddDeclareError::ContractClassSizeIsTooLarge(ContractClassSizeIsTooLarge::Error(
-                ErrorCode::default(),
-            )),
-            StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::ContractBytecodeSizeTooLarge),
-        ),
-        (
-            AddDeclareError::ContractClassSizeIsTooLarge(ContractClassSizeIsTooLarge::Error(
-                ErrorCode::default(),
-            )),
-            StarknetErrorCode::KnownErrorCode(
-                KnownStarknetErrorCode::ContractClassObjectSizeTooLarge,
-            ),
-        ),
-        (
-            AddDeclareError::UnsupportedTxVersion(
-                UnsupportedTxVersion::Error(ErrorCode::default()),
-            ),
-            StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::InvalidTransactionVersion),
-        ),
-        (
-            AddDeclareError::UnsupportedContractClassVersion(
-                UnsupportedContractClassVersion::Error(ErrorCode::default()),
-            ),
-            StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::InvalidContractClassVersion),
-        ),
-        (
-            AddDeclareError::UnexpectedError(UnexpectedError::Error(ErrorCodeWithData {
-                data: MESSAGE.to_string(),
-                ..Default::default()
-            })),
-            StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::BlockNotFound),
-        ),
-        (
-            AddDeclareError::UnexpectedError(UnexpectedError::Error(ErrorCodeWithData {
-                data: MESSAGE.to_string(),
-                ..Default::default()
-            })),
-            StarknetErrorCode::UnknownErrorCode("CODE".to_string()),
-        ),
-    ]
-}
-
-fn deploy_account_errors_and_starknet_error_codes()
--> Vec<(AddDeployAccountError, StarknetErrorCode)> {
-    vec![
-        (
-            AddDeployAccountError::InsufficientAccountBalance(InsufficientAccountBalance::Error(
-                ErrorCode::default(),
-            )),
-            StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::InsufficientAccountBalance),
-        ),
-        (
-            AddDeployAccountError::InsufficientMaxFee(InsufficientMaxFee::Error(
-                ErrorCode::default(),
-            )),
-            StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::InsufficientMaxFee),
-        ),
-        (
-            AddDeployAccountError::InvalidTransactionNonce(InvalidTransactionNonce::Error(
-                ErrorCode::default(),
-            )),
-            StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::InvalidTransactionNonce),
-        ),
-        (
-            AddDeployAccountError::ValidationFailure(
-                ValidationFailure::Error(ErrorCode::default()),
-            ),
-            StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::ValidateFailure),
-        ),
-        (
-            AddDeployAccountError::NonAccount(NonAccount::Error(ErrorCode::default())),
-            StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::EntryPointNotFoundInContract),
-        ),
-        (
-            AddDeployAccountError::ClassHashNotFound(
-                ClassHashNotFound::Error(ErrorCode::default()),
-            ),
-            StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::UndeclaredClass),
-        ),
-        (
-            AddDeployAccountError::DuplicateTx(DuplicateTx::Error(ErrorCode::default())),
-            StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::DuplicatedTransaction),
-        ),
-        (
-            AddDeployAccountError::UnsupportedTxVersion(UnsupportedTxVersion::Error(
-                ErrorCode::default(),
-            )),
-            StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::InvalidTransactionVersion),
-        ),
-        (
-            AddDeployAccountError::UnexpectedError(UnexpectedError::Error(ErrorCodeWithData {
-                data: MESSAGE.to_string(),
-                ..Default::default()
-            })),
-            StarknetErrorCode::KnownErrorCode(KnownStarknetErrorCode::BlockNotFound),
-        ),
-        (
-            AddDeployAccountError::UnexpectedError(UnexpectedError::Error(ErrorCodeWithData {
-                data: MESSAGE.to_string(),
-                ..Default::default()
-            })),
-            StarknetErrorCode::UnknownErrorCode("CODE".to_string()),
-        ),
-    ]
-}
-
-#[test]
-fn add_invoke_error_fits_rpc() {
-    for (error, _) in invoke_errors_and_starknet_error_codes() {
-        test_error_fits_rpc(error, "starknet_addInvokeTransaction");
+    for starknet_error_code in all::<KnownStarknetErrorCode>()
+        .map(StarknetErrorCode::KnownErrorCode)
+        .chain([StarknetErrorCode::UnknownErrorCode(UNKNOWN_CODE.to_owned())])
+    {
+        let starknet_error =
+            StarknetError { code: starknet_error_code, message: MESSAGE.to_owned() };
+        // Converting into ErrorObjectOwned since it has serialization.
+        let rpc_error: ErrorObjectOwned = f(starknet_error).into();
+        let mut json_value = serde_json::to_value(rpc_error).unwrap();
+        json_value.as_object_mut().unwrap().retain(|_, v| !v.is_null());
+        assert!(schema.is_valid(&json_value));
     }
 }
 
 #[test]
-fn add_invoke_error_from_starknet_error() {
-    for (error, starknet_error_code) in invoke_errors_and_starknet_error_codes() {
-        assert_eq!(
-            error,
-            StarknetError { code: starknet_error_code, message: MESSAGE.to_string() }.into()
-        );
-    }
+fn starknet_error_to_invoke_error_result_fits_specs() {
+    test_error_from_conversion_fits_rpc(
+        starknet_error_to_invoke_error,
+        "starknet_addInvokeTransaction",
+    );
 }
 
 #[test]
-fn add_declare_error_fits_rpc() {
-    for (error, _) in declare_errors_and_starknet_error_codes() {
-        test_error_fits_rpc(error, "starknet_addDeclareTransaction");
-    }
+fn starknet_error_to_declare_error_result_fits_specs() {
+    test_error_from_conversion_fits_rpc(
+        starknet_error_to_declare_error,
+        "starknet_addDeclareTransaction",
+    );
 }
 
 #[test]
-fn add_declare_error_from_starknet_error() {
-    for (error, starknet_error_code) in declare_errors_and_starknet_error_codes() {
-        assert_eq!(
-            error,
-            StarknetError { code: starknet_error_code, message: MESSAGE.to_string() }.into()
-        );
-    }
-}
-
-#[test]
-fn add_deploy_account_error_fits_rpc() {
-    for (error, _) in deploy_account_errors_and_starknet_error_codes() {
-        test_error_fits_rpc(error, "starknet_addDeployAccountTransaction");
-    }
-}
-
-#[test]
-fn add_deploy_account_error_from_starknet_error() {
-    for (error, starknet_error_code) in deploy_account_errors_and_starknet_error_codes() {
-        assert_eq!(
-            error,
-            StarknetError { code: starknet_error_code, message: MESSAGE.to_string() }.into()
-        );
-    }
+fn starknet_error_to_deploy_account_error_result_fits_specs() {
+    test_error_from_conversion_fits_rpc(
+        starknet_error_to_deploy_account_error,
+        "starknet_addDeployAccountTransaction",
+    );
 }

--- a/crates/starknet_client/Cargo.toml
+++ b/crates/starknet_client/Cargo.toml
@@ -8,6 +8,7 @@ description = "A client implementation that can communicate with Starknet."
 
 [features]
 testing = [
+    "enum-iterator",
     "mockall",
     "rand",
     "rand_chacha",
@@ -17,6 +18,7 @@ testing = [
 [dependencies]
 async-trait.workspace = true
 cairo-lang-starknet.workspace = true
+enum-iterator = { workspace = true, optional = true }
 http.workspace = true
 indexmap = { workspace = true, features = ["serde"] }
 lazy_static.workspace = true
@@ -39,6 +41,7 @@ url.workspace = true
 [dev-dependencies]
 assert.workspace = true
 assert_matches.workspace = true
+enum-iterator.workspace = true
 mockall.workspace = true
 mockito.workspace = true
 rand.workspace = true

--- a/crates/starknet_client/src/starknet_error.rs
+++ b/crates/starknet_client/src/starknet_error.rs
@@ -4,6 +4,8 @@ mod starknet_error_test;
 
 use std::fmt::{self, Display, Formatter};
 
+#[cfg(any(feature = "testing", test))]
+use enum_iterator::Sequence;
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize};
 
@@ -21,6 +23,7 @@ pub enum StarknetErrorCode {
 // The issue requesting that #[serde(other)] will deserialize the variant with the unknown tag's
 // content is: https://github.com/serde-rs/serde/issues/1701
 #[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[cfg_attr(any(test, feature = "testing"), derive(Sequence))]
 pub enum KnownStarknetErrorCode {
     #[serde(rename = "StarknetErrorCode.UNDECLARED_CLASS")]
     UndeclaredClass,


### PR DESCRIPTION
- refactor(JSON-RPC): move code around
- refactor(JSON-RPC): split JsonRpcError for each error
- feat(JSON-RPC): add more errors for 0.4.0 JsonRpcError
- feat(JSON-RPC): use JsonRpcError for write_api errors

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1004)
<!-- Reviewable:end -->
