### PR TITLE
chore: run tests in the CI using nextest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - run: |
-          cargo nextest run; cargo test --doc
+          cargo test; cargo test --doc
         env:
           SEED: 0
           
@@ -98,7 +98,7 @@ jobs:
       - if: ${{ matrix.cmd == '-p papyrus_base_layer' }}
         run: npm install -g ganache@7.4.3
       - run: |
-          cargo test ${{ matrix.cmd }}
+          cargo nextest run ${{ matrix.cmd }}
         env:
           SEED: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,11 +54,8 @@ jobs:
           target/release/papyrus_node --base_layer.node_url ${{ secrets.CI_BASE_LAYER_NODE_URL }}
           & sleep 30 ; kill $!
 
-  test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [macos-latest, ubuntu-latest]
+  test-macos:
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -70,6 +67,38 @@ jobs:
         uses: taiki-e/install-action@nextest
       - run: |
           cargo nextest run; cargo test --doc
+        env:
+          SEED: 0
+          
+  test-ubuntu:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cmd:
+          - -p papyrus_base_layer
+          - -p papyrus_common
+          - -p papyrus_config
+          - -p papyrus_execution
+          - -p papyrus_load_test
+          - -p papyrus_monitoring_gateway
+          - -p papyrus_node
+          - -p papyrus_storage
+          - -p papyrus_sync
+          - -p starknet_client
+          - -p test_utils
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+      - run: npm install -g ganache@7.4.3
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+      - if: ${{ matrix.cmd == '-p papyrus_base_layer' }}
+        run: npm install -g ganache@7.4.3
+      - run: |
+          cargo test ${{ matrix.cmd }}
         env:
           SEED: 0
 
@@ -186,7 +215,7 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@nextest
       - name: Coverage
-        run: cargo +nightly llvm-cov nextest --codecov --output-path codecov.json
+        run: cargo +nightly llvm-cov --codecov --output-path codecov.json
         env:
           SEED: 0
       - name: Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,10 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@v2
       - run: npm install -g ganache@7.4.3
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
       - run: |
-          cargo test
+          cargo nextest run; cargo test --doc
         env:
           SEED: 0
 
@@ -95,8 +97,10 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@v2
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
       - run: >
-          cargo test --test '*' -- --include-ignored;
+          cargo nextest run --test '*' -- --include-ignored;
           cargo run -p papyrus_node --bin central_source_integration_test
 
   rustfmt:
@@ -179,8 +183,10 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
       - uses: Swatinem/rust-cache@v2
       - run: npm install -g ganache@7.4.3
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
       - name: Coverage
-        run: cargo +nightly llvm-cov --codecov --output-path codecov.json
+        run: cargo +nightly llvm-cov nextest --codecov --output-path codecov.json
         env:
           SEED: 0
       - name: Codecov


### PR DESCRIPTION
I used nextest in three places in the CI:
1. instead of cargo test , and added a separate call for cargo test --doc ti test the documentation which is not supported by nextest
2. integration test 
3. Code coverage

Comparing some numbers:
TLDR; The code coverage run and integration tests takes longer with nextest , I think it should be applied only on the tests.

Test name                running time without nextest       running time with nextest
test(macos-latest)                     2.14 m                                    2.11 m
test(ubuntu-latest)                      5.32 m                                    4.13 m
integration_test(macos)             1.25 m                                    1.21 m
integration_test(ubuntu)             9.31 m                                    8.33 m
integration_test(macos)             1.38 m                                    1.26 m
integration_test(ubuntu)             1.35 m                                    1.26 m
Coverage                                   6.25 m                                    7.46 m
Coverage - 2nd try                     7.12 m                                    9.21 m

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1107)
<!-- Reviewable:end -->
