### PR TITLE
refactor(base_layer): use type for EthereumBaseLayerConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6729,6 +6729,7 @@ dependencies = [
  "form_urlencoded",
  "idna 0.4.0",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/config/default_config.json
+++ b/config/default_config.json
@@ -5,7 +5,7 @@
   },
   "base_layer.starknet_contract_address": {
     "description": "Starknet contract address in ethereum.",
-    "value": "0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4"
+    "value": "0xc662c410c0ecf747543f5ba90660f6abebd9c8c4"
   },
   "central.concurrent_requests": {
     "description": "Maximum number of concurrent requests to Starknet feeder-gateway for getting a type of data (for example, blocks).",

--- a/crates/papyrus_base_layer/Cargo.toml
+++ b/crates/papyrus_base_layer/Cargo.toml
@@ -15,7 +15,8 @@ serde_json.workspace = true
 starknet_api.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full", "sync"] }
-url.workspace = true
+url = { workspace = true, features = ["serde"] }
+
 
 [dev-dependencies]
 ethers-core = { version = "2.0.3"}

--- a/crates/papyrus_node/src/config/config_test.rs
+++ b/crates/papyrus_node/src/config/config_test.rs
@@ -19,7 +19,10 @@ use crate::config::{node_command, NodeConfig, DEFAULT_CONFIG_PATH};
 
 // Fill here all the required params in default_config.json with the default value.
 fn required_args() -> Vec<String> {
-    vec!["--base_layer.node_url".to_owned(), EthereumBaseLayerConfig::default().node_url]
+    vec![
+        "--base_layer.node_url".to_owned(),
+        EthereumBaseLayerConfig::default().node_url.to_string(),
+    ]
 }
 
 fn get_args(additional_args: Vec<&str>) -> Vec<String> {

--- a/crates/papyrus_node/src/config/snapshots/papyrus_node__config__config_test__dump_default_config.snap
+++ b/crates/papyrus_node/src/config/snapshots/papyrus_node__config__config_test__dump_default_config.snap
@@ -9,7 +9,7 @@ expression: dumped_default_config
   },
   "base_layer.starknet_contract_address": {
     "description": "Starknet contract address in ethereum.",
-    "value": "0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4"
+    "value": "0xc662c410c0ecf747543f5ba90660f6abebd9c8c4"
   },
   "central.concurrent_requests": {
     "description": "Maximum number of concurrent requests to Starknet feeder-gateway for getting a type of data (for example, blocks).",


### PR DESCRIPTION
## Pull Request type
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
`EthereumBaseLayerConfig`'s using string as a type for both the node url & contract addr.

## What is the new behavior?
Change `EthereumBaseLayerConfig`'s `node_url` & `starknet_contract_address` to `Url` & `ethers::Address` respectively.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1125)
<!-- Reviewable:end -->
