### PR TITLE
build: break path dependencies of papyrus_storage papyrus_config crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,7 +642,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "starknet-crypto",
- "starknet_api",
+ "starknet_api 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum 0.24.1",
  "strum_macros 0.24.3",
  "thiserror",
@@ -4299,12 +4299,12 @@ dependencies = [
  "async-trait",
  "ethers",
  "ethers-core",
- "papyrus_config",
+ "papyrus_config 0.0.4 (git+https://github.com/starkware-libs/papyrus?rev=224b66a)",
  "pretty_assertions",
  "rustc-hex",
  "serde",
  "serde_json",
- "starknet_api",
+ "starknet_api 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar",
  "tempfile",
  "test-with",
@@ -4324,7 +4324,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "starknet-crypto",
- "starknet_api",
+ "starknet_api 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "test_utils",
 ]
 
@@ -4346,6 +4346,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "papyrus_config"
+version = "0.0.4"
+source = "git+https://github.com/starkware-libs/papyrus?rev=224b66a#224b66af273552cd54834be3a888632266ed49d3"
+dependencies = [
+ "clap",
+ "itertools 0.10.5",
+ "serde",
+ "serde_json",
+ "strum_macros 0.25.2",
+ "thiserror",
+ "validator",
+]
+
+[[package]]
 name = "papyrus_execution"
 version = "0.0.4"
 dependencies = [
@@ -4358,13 +4372,13 @@ dependencies = [
  "indexmap 1.9.3",
  "itertools 0.10.5",
  "lazy_static",
- "papyrus_config",
- "papyrus_storage",
+ "papyrus_config 0.0.4 (git+https://github.com/starkware-libs/papyrus?rev=224b66a)",
+ "papyrus_storage 0.0.4 (git+https://github.com/starkware-libs/papyrus?rev=224b66a)",
  "rand",
  "rand_chacha",
  "serde",
  "serde_json",
- "starknet_api",
+ "starknet_api 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "test_utils",
  "thiserror",
 ]
@@ -4397,8 +4411,8 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "metrics-process",
- "papyrus_config",
- "papyrus_storage",
+ "papyrus_config 0.0.4 (git+https://github.com/starkware-libs/papyrus?rev=224b66a)",
+ "papyrus_storage 0.0.4 (git+https://github.com/starkware-libs/papyrus?rev=224b66a)",
  "pretty_assertions",
  "serde",
  "serde_json",
@@ -4424,16 +4438,16 @@ dependencies = [
  "libmdbx",
  "papyrus_base_layer",
  "papyrus_common",
- "papyrus_config",
+ "papyrus_config 0.0.4 (git+https://github.com/starkware-libs/papyrus?rev=224b66a)",
  "papyrus_monitoring_gateway",
  "papyrus_rpc",
- "papyrus_storage",
+ "papyrus_storage 0.0.4 (git+https://github.com/starkware-libs/papyrus?rev=224b66a)",
  "papyrus_sync",
  "pretty_assertions",
  "reqwest",
  "serde",
  "serde_json",
- "starknet_api",
+ "starknet_api 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "starknet_client",
  "tempfile",
  "test_utils",
@@ -4482,10 +4496,10 @@ dependencies = [
  "metrics-exporter-prometheus",
  "mockall",
  "papyrus_common",
- "papyrus_config",
+ "papyrus_config 0.0.4 (git+https://github.com/starkware-libs/papyrus?rev=224b66a)",
  "papyrus_execution",
  "papyrus_proc_macros",
- "papyrus_storage",
+ "papyrus_storage 0.0.4 (git+https://github.com/starkware-libs/papyrus?rev=224b66a)",
  "pretty_assertions",
  "prometheus-parse",
  "rand",
@@ -4494,7 +4508,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "starknet_api",
+ "starknet_api 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "starknet_client",
  "strum 0.25.0",
  "strum_macros 0.25.2",
@@ -4525,7 +4539,7 @@ dependencies = [
  "libmdbx",
  "num-bigint",
  "num-traits 0.2.16",
- "papyrus_config",
+ "papyrus_config 0.0.4",
  "parity-scale-codec",
  "paste",
  "pretty_assertions",
@@ -4535,11 +4549,37 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "starknet_api",
+ "starknet_api 0.4.1 (git+https://github.com/starkware-libs/starknet-api?branch=barak/v3/declare)",
  "tempfile",
  "test_utils",
  "thiserror",
  "tokio",
+ "tracing",
+ "validator",
+]
+
+[[package]]
+name = "papyrus_storage"
+version = "0.0.4"
+source = "git+https://github.com/starkware-libs/papyrus?rev=224b66a#224b66af273552cd54834be3a888632266ed49d3"
+dependencies = [
+ "byteorder",
+ "cairo-lang-casm",
+ "cairo-lang-starknet",
+ "cairo-lang-utils",
+ "flate2",
+ "indexmap 1.9.3",
+ "integer-encoding",
+ "libmdbx",
+ "num-bigint",
+ "papyrus_config 0.0.4 (git+https://github.com/starkware-libs/papyrus?rev=224b66a)",
+ "parity-scale-codec",
+ "primitive-types",
+ "serde",
+ "serde_json",
+ "starknet_api 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile",
+ "thiserror",
  "tracing",
  "validator",
 ]
@@ -4564,13 +4604,13 @@ dependencies = [
  "mockall",
  "papyrus_base_layer",
  "papyrus_common",
- "papyrus_config",
- "papyrus_storage",
+ "papyrus_config 0.0.4 (git+https://github.com/starkware-libs/papyrus?rev=224b66a)",
+ "papyrus_storage 0.0.4 (git+https://github.com/starkware-libs/papyrus?rev=224b66a)",
  "pretty_assertions",
  "reqwest",
  "serde",
  "simple_logger",
- "starknet_api",
+ "starknet_api 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "starknet_client",
  "thiserror",
  "tokio",
@@ -6029,6 +6069,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "starknet_api"
+version = "0.4.1"
+source = "git+https://github.com/starkware-libs/starknet-api?branch=barak/v3/declare#7e33aae17ec4ec25d889f024d2ad1b554b1c8f28"
+dependencies = [
+ "cairo-lang-starknet",
+ "derive_more",
+ "hex",
+ "indexmap 1.9.3",
+ "once_cell",
+ "primitive-types",
+ "serde",
+ "serde_json",
+ "starknet-crypto",
+ "thiserror",
+]
+
+[[package]]
 name = "starknet_client"
 version = "0.0.4"
 dependencies = [
@@ -6043,14 +6100,14 @@ dependencies = [
  "mockall",
  "mockito",
  "os_info",
- "papyrus_config",
+ "papyrus_config 0.0.4 (git+https://github.com/starkware-libs/papyrus?rev=224b66a)",
  "pretty_assertions",
  "rand",
  "rand_chacha",
  "reqwest",
  "serde",
  "serde_json",
- "starknet_api",
+ "starknet_api 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "test_utils",
  "thiserror",
  "tokio",
@@ -6267,7 +6324,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "starknet_api",
+ "starknet_api 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
 ]
 

--- a/crates/papyrus_base_layer/Cargo.toml
+++ b/crates/papyrus_base_layer/Cargo.toml
@@ -8,7 +8,7 @@ license-file.workspace = true
 [dependencies]
 async-trait.workspace = true
 ethers.workspace = true
-papyrus_config = { path = "../papyrus_config", version = "0.0.4" }
+papyrus_config = { git = "https://github.com/starkware-libs/papyrus", rev = "224b66a" }
 rustc-hex.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/papyrus_execution/Cargo.toml
+++ b/crates/papyrus_execution/Cargo.toml
@@ -19,8 +19,8 @@ cairo-lang-starknet.workspace = true
 cairo-vm.workspace = true
 itertools.workspace = true
 lazy_static.workspace = true
-papyrus_config = { path = "../papyrus_config", version = "0.0.4" }
-papyrus_storage = { path = "../papyrus_storage", version = "0.0.4" }
+papyrus_config = { git = "https://github.com/starkware-libs/papyrus", rev = "224b66a" }
+papyrus_storage = { git = "https://github.com/starkware-libs/papyrus", rev = "224b66a" }
 rand = { workspace = true, optional = true }
 rand_chacha = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
@@ -34,7 +34,7 @@ assert_matches.workspace = true
 cairo-lang-casm.workspace = true
 cairo-lang-utils.workspace = true
 indexmap = { workspace = true, features = ["serde"] }
-papyrus_storage = { path = "../papyrus_storage", features = ["testing"] }
+papyrus_storage = { git = "https://github.com/starkware-libs/papyrus", rev = "224b66a", features = ["testing"] }
 rand.workspace = true
 rand_chacha.workspace = true
 test_utils = { path = "../test_utils" }

--- a/crates/papyrus_monitoring_gateway/Cargo.toml
+++ b/crates/papyrus_monitoring_gateway/Cargo.toml
@@ -11,8 +11,8 @@ futures-util.workspace = true
 hyper = { workspace = true, features = ["full"] }
 metrics-exporter-prometheus = { version = "0.12.1" }
 metrics-process = { version = "1.0.11" }
-papyrus_storage = { path = "../papyrus_storage", version = "0.0.4" }
-papyrus_config = { path = "../papyrus_config", version = "0.0.4" }
+papyrus_config = { git = "https://github.com/starkware-libs/papyrus", rev = "224b66a" }
+papyrus_storage = { git = "https://github.com/starkware-libs/papyrus", rev = "224b66a" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["arbitrary_precision"]}
 thiserror.workspace = true
@@ -22,6 +22,6 @@ tracing.workspace = true
 [dev-dependencies]
 http-body = { version = "0.4.5" }
 metrics.workspace = true
-papyrus_storage = { path = "../papyrus_storage", features = ["testing"] }
+papyrus_storage = { git = "https://github.com/starkware-libs/papyrus", rev = "224b66a", features = ["testing"] }
 pretty_assertions.workspace = true
 tower = { workspace = true, features = ["util"] }

--- a/crates/papyrus_node/Cargo.toml
+++ b/crates/papyrus_node/Cargo.toml
@@ -19,11 +19,11 @@ jsonrpsee = { workspace = true, features = ["full"] }
 libmdbx = { workspace = true, features = ["lifetimed-bytes"] }
 lazy_static.workspace = true
 papyrus_base_layer = { path = "../papyrus_base_layer" }
-papyrus_config = { path = "../papyrus_config", version = "0.0.4" }
+papyrus_config = { git = "https://github.com/starkware-libs/papyrus", rev = "224b66a" }
 papyrus_common = { path = "../papyrus_common" }
 papyrus_monitoring_gateway = { path = "../papyrus_monitoring_gateway" }
 papyrus_rpc = { path = "../papyrus_rpc" }
-papyrus_storage = { path = "../papyrus_storage", version = "0.0.4" }
+papyrus_storage = { git = "https://github.com/starkware-libs/papyrus", rev = "224b66a" }
 papyrus_sync = { path = "../papyrus_sync" }
 reqwest = { workspace = true, features = ["json", "blocking"] }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/papyrus_rpc/Cargo.toml
+++ b/crates/papyrus_rpc/Cargo.toml
@@ -17,10 +17,10 @@ jsonrpsee = { workspace = true, features = ["full"] }
 lazy_static.workspace = true
 metrics.workspace = true
 papyrus_common = { path = "../papyrus_common"}
-papyrus_config = { path = "../papyrus_config", version = "0.0.4" }
+papyrus_config = { git = "https://github.com/starkware-libs/papyrus", rev = "224b66a" }
 papyrus_execution = { path = "../papyrus_execution" }
 papyrus_proc_macros = { path = "../papyrus_proc_macros"}
-papyrus_storage = { path = "../papyrus_storage", version = "0.0.4" }
+papyrus_storage = { git = "https://github.com/starkware-libs/papyrus", rev = "224b66a" }
 starknet_client = { path = "../starknet_client" }
 regex = {workspace = true}
 serde = { workspace = true, features = ["derive"] }
@@ -49,7 +49,7 @@ lazy_static.workspace = true
 metrics-exporter-prometheus = { version = "0.12.1" }
 mockall.workspace = true
 papyrus_execution = { path = "../papyrus_execution", features = ["testing"] }
-papyrus_storage = { path = "../papyrus_storage", features = ["testing"] }
+papyrus_storage = { git = "https://github.com/starkware-libs/papyrus", rev = "224b66a", features = ["testing"] }
 pretty_assertions.workspace = true
 prometheus-parse.workspace = true
 rand_chacha.workspace = true

--- a/crates/papyrus_sync/Cargo.toml
+++ b/crates/papyrus_sync/Cargo.toml
@@ -18,10 +18,10 @@ indexmap = { workspace = true, features = ["serde"] }
 itertools.workspace = true
 libmdbx = { workspace = true, features = ["lifetimed-bytes"] }
 metrics.workspace = true
-papyrus_storage = { path = "../papyrus_storage", version = "0.0.4" }
+papyrus_storage = { git = "https://github.com/starkware-libs/papyrus", rev = "224b66a" }
 papyrus_base_layer = { path = "../papyrus_base_layer" }
 papyrus_common = { path = "../papyrus_common" }
-papyrus_config = { path = "../papyrus_config", version = "0.0.4" }
+papyrus_config = { git = "https://github.com/starkware-libs/papyrus", rev = "224b66a" }
 reqwest = { workspace = true, features = ["json", "blocking"] }
 serde = { workspace = true, features = ["derive"] }
 starknet_api.workspace = true
@@ -35,7 +35,7 @@ url.workspace = true
 simple_logger.workspace = true
 assert_matches.workspace = true
 mockall.workspace = true
-papyrus_storage = { path = "../papyrus_storage", features = ["testing"] }
+papyrus_storage = { git = "https://github.com/starkware-libs/papyrus", rev = "224b66a", features = ["testing"] }
 pretty_assertions.workspace = true
 starknet_client = { path = "../starknet_client", features = ["testing"] }
 starknet_api = { workspace = true, features = ["testing"] }

--- a/crates/starknet_client/Cargo.toml
+++ b/crates/starknet_client/Cargo.toml
@@ -24,7 +24,7 @@ indexmap = { workspace = true, features = ["serde"] }
 lazy_static.workspace = true
 mockall = { workspace = true, optional = true }
 os_info.workspace = true
-papyrus_config = { path = "../papyrus_config", version = "0.0.4" }
+papyrus_config = { git = "https://github.com/starkware-libs/papyrus", rev = "224b66a" }
 rand = { workspace = true, optional = true }
 rand_chacha = { workspace = true, optional = true }
 reqwest = { workspace = true, features = ["json", "blocking"] }


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [+] Other (please describe): Second phase upgrade to 0.0.5 (First was upgrading starknet_api)

## What is the current behavior?

Crates depend on papyrus_storage and papyrus_config crates via relative paths.

Issue Number: N/A

## What is the new behavior?

Crates depend on papyrus_storage and papyrus_config crates via relative git commit.

-

## Does this introduce a breaking change?

- [+] Yes
- [ ] No

New structs were introduced in starknet_api repo and now are supported by papyrus_storage and papyrus_config crates.

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1126)
<!-- Reviewable:end -->
