### PR TITLE
refactor(network): rename FinishSession to CloseSession

### DIFF
--- a/crates/papyrus_network/src/streamed_data_protocol/behaviour.rs
+++ b/crates/papyrus_network/src/streamed_data_protocol/behaviour.rs
@@ -86,15 +86,15 @@ impl<Query: QueryBound, Data: DataBound> Behaviour<Query, Data> {
         unimplemented!();
     }
 
-    /// Report to the behaviour that we've finished sending all the required data for a given
-    /// inbound session.
-    pub fn finish_inbound_session(_inbound_session_id: InboundSessionId) {
+    /// Instruct behaviour to close inbound session. A corresponding SessionClosedByRequest event
+    /// will be reported when the session is closed.
+    pub fn close_inbound_session(_inbound_session_id: InboundSessionId) {
         unimplemented!();
     }
 
-    /// Report to the behaviour that we've received all the required data from a given outbound
-    /// session.
-    pub fn finish_outbound_session(_outbound_session_id: OutboundSessionId) {
+    /// Instruct behaviour to close outbound session. A corresponding SessionClosedByRequest event
+    /// will be reported when the session is closed.
+    pub fn closed_outbound_session(_outbound_session_id: OutboundSessionId) {
         unimplemented!();
     }
 

--- a/crates/papyrus_network/src/streamed_data_protocol/handler.rs
+++ b/crates/papyrus_network/src/streamed_data_protocol/handler.rs
@@ -33,7 +33,7 @@ use crate::messages::read_message;
 pub(crate) enum RequestFromBehaviourEvent<Query, Data> {
     CreateOutboundSession { query: Query, outbound_session_id: OutboundSessionId },
     SendData { data: Data, inbound_session_id: InboundSessionId },
-    FinishSession { session_id: SessionId },
+    CloseSession { session_id: SessionId },
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -251,7 +251,7 @@ impl<Query: QueryBound, Data: DataBound> ConnectionHandler for Handler<Query, Da
                         // TODO(shahak): Consider handling this in a different way than just
                         // logging.
                         debug!(
-                            "Got a request to send data on a finished inbound session with id \
+                            "Got a request to send data on a closed inbound session with id \
                              {inbound_session_id}. Ignoring request."
                         );
                     } else {
@@ -260,17 +260,17 @@ impl<Query: QueryBound, Data: DataBound> ConnectionHandler for Handler<Query, Da
                 } else {
                     // TODO(shahak): Consider handling this in a different way than just logging.
                     debug!(
-                        "Got a request to send data on a non-existing or finished inbound session \
+                        "Got a request to send data on a non-existing or closed inbound session \
                          with id {inbound_session_id}. Ignoring request."
                     );
                 }
             }
-            RequestFromBehaviourEvent::FinishSession {
+            RequestFromBehaviourEvent::CloseSession {
                 session_id: SessionId::InboundSessionId(inbound_session_id),
             } => {
                 self.inbound_sessions_marked_to_end.insert(inbound_session_id);
             }
-            RequestFromBehaviourEvent::FinishSession {
+            RequestFromBehaviourEvent::CloseSession {
                 session_id: SessionId::OutboundSessionId(outbound_session_id),
             } => {
                 self.id_to_outbound_session.remove(&outbound_session_id);

--- a/crates/papyrus_network/src/streamed_data_protocol/handler_test.rs
+++ b/crates/papyrus_network/src/streamed_data_protocol/handler_test.rs
@@ -50,11 +50,11 @@ fn simulate_request_to_send_query_from_swarm<Query: QueryBound, Data: DataBound>
     });
 }
 
-fn simulate_request_to_finish_session<Query: QueryBound, Data: DataBound>(
+fn simulate_request_to_close_session<Query: QueryBound, Data: DataBound>(
     handler: &mut Handler<Query, Data>,
     session_id: SessionId,
 ) {
-    handler.on_behaviour_event(RequestFromBehaviourEvent::FinishSession { session_id });
+    handler.on_behaviour_event(RequestFromBehaviourEvent::CloseSession { session_id });
 }
 
 fn simulate_negotiated_inbound_session_from_swarm<Query: QueryBound, Data: DataBound>(
@@ -200,7 +200,7 @@ async fn process_inbound_session() {
 }
 
 #[tokio::test]
-async fn finished_inbound_session_ignores_behaviour_request_to_send_data() {
+async fn closed_inbound_session_ignores_behaviour_request_to_send_data() {
     let mut handler = Handler::<GetBlocks, GetBlocksResponse>::new(
         SUBSTREAM_TIMEOUT,
         Arc::new(Default::default()),
@@ -222,7 +222,7 @@ async fn finished_inbound_session_ignores_behaviour_request_to_send_data() {
     // consume the new inbound session event without reading it.
     handler.next().await;
 
-    simulate_request_to_finish_session(
+    simulate_request_to_close_session(
         &mut handler,
         SessionId::InboundSessionId(inbound_session_id),
     );
@@ -303,7 +303,7 @@ async fn process_outbound_session() {
 }
 
 #[tokio::test]
-async fn finished_outbound_session_doesnt_emit_events_when_data_is_sent() {
+async fn closed_outbound_session_doesnt_emit_events_when_data_is_sent() {
     let mut handler = Handler::<GetBlocks, GetBlocksResponse>::new(
         SUBSTREAM_TIMEOUT,
         Arc::new(Default::default()),
@@ -318,7 +318,7 @@ async fn finished_outbound_session_doesnt_emit_events_when_data_is_sent() {
         outbound_session_id,
     );
 
-    simulate_request_to_finish_session(
+    simulate_request_to_close_session(
         &mut handler,
         SessionId::OutboundSessionId(outbound_session_id),
     );


### PR DESCRIPTION
- feat(network): add support to finishing outbound session
- fix(network): close the stream when finishing an inbound session
- feat(network): add OutboundSessionClosedByPeer event
- refactor(network): rename FinishSession to CloseSession

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1218)
<!-- Reviewable:end -->
