### PR TITLE
feat(JSON-RPC): store pending data and classes in rpc

### DIFF
--- a/crates/papyrus_rpc/src/api.rs
+++ b/crates/papyrus_rpc/src/api.rs
@@ -1,12 +1,14 @@
 use std::sync::Arc;
 
 use jsonrpsee::{Methods, RpcModule};
+use papyrus_common::pending_classes::PendingClasses;
 use papyrus_common::BlockHashAndNumber;
 use papyrus_execution::ExecutionConfigByBlock;
 use papyrus_storage::StorageReader;
 use serde::{Deserialize, Serialize};
 use starknet_api::block::{BlockHash, BlockNumber};
 use starknet_api::core::ChainId;
+use starknet_client::reader::PendingData;
 use starknet_client::writer::StarknetWriter;
 use tokio::sync::RwLock;
 
@@ -50,6 +52,8 @@ pub fn get_methods_from_supported_apis(
     max_events_keys: usize,
     starting_block: BlockHashAndNumber,
     shared_highest_block: Arc<RwLock<Option<BlockHashAndNumber>>>,
+    pending_data: Arc<RwLock<PendingData>>,
+    pending_classes: Arc<RwLock<PendingClasses>>,
     starknet_writer: Arc<dyn StarknetWriter>,
 ) -> Methods {
     let mut methods: Methods = Methods::new();
@@ -61,6 +65,8 @@ pub fn get_methods_from_supported_apis(
         max_events_keys,
         starting_block,
         shared_highest_block,
+        pending_data,
+        pending_classes,
         starknet_writer,
     };
     version_config::VERSION_CONFIG
@@ -100,6 +106,8 @@ pub trait JsonRpcServerImpl: Sized {
         max_events_keys: usize,
         starting_block: BlockHashAndNumber,
         shared_highest_block: Arc<RwLock<Option<BlockHashAndNumber>>>,
+        pending_data: Arc<RwLock<PendingData>>,
+        pending_classes: Arc<RwLock<PendingClasses>>,
         starknet_writer: Arc<dyn StarknetWriter>,
     ) -> Self;
 
@@ -115,6 +123,8 @@ struct JsonRpcServerImplGenerator {
     max_events_keys: usize,
     starting_block: BlockHashAndNumber,
     shared_highest_block: Arc<RwLock<Option<BlockHashAndNumber>>>,
+    pending_data: Arc<RwLock<PendingData>>,
+    pending_classes: Arc<RwLock<PendingClasses>>,
     // TODO(shahak): Change this struct to be with a generic type of StarknetWriter.
     starknet_writer: Arc<dyn StarknetWriter>,
 }
@@ -127,6 +137,8 @@ type JsonRpcServerImplParams = (
     usize,
     BlockHashAndNumber,
     Arc<RwLock<Option<BlockHashAndNumber>>>,
+    Arc<RwLock<PendingData>>,
+    Arc<RwLock<PendingClasses>>,
     Arc<dyn StarknetWriter>,
 );
 
@@ -140,6 +152,8 @@ impl JsonRpcServerImplGenerator {
             self.max_events_keys,
             self.starting_block,
             self.shared_highest_block,
+            self.pending_data,
+            self.pending_classes,
             self.starknet_writer,
         )
     }
@@ -156,6 +170,8 @@ impl JsonRpcServerImplGenerator {
             max_events_keys,
             starting_block,
             shared_highest_block,
+            pending_data,
+            pending_classes,
             starknet_writer,
         ) = self.get_params();
         Into::<Methods>::into(
@@ -167,6 +183,8 @@ impl JsonRpcServerImplGenerator {
                 max_events_keys,
                 starting_block,
                 shared_highest_block,
+                pending_data,
+                pending_classes,
                 starknet_writer,
             )
             .into_rpc_module(),

--- a/crates/papyrus_rpc/src/lib.rs
+++ b/crates/papyrus_rpc/src/lib.rs
@@ -25,6 +25,7 @@ use jsonrpsee::server::{ServerBuilder, ServerHandle};
 use jsonrpsee::types::error::ErrorCode::InternalError;
 use jsonrpsee::types::error::INTERNAL_ERROR_MSG;
 use jsonrpsee::types::ErrorObjectOwned;
+use papyrus_common::pending_classes::PendingClasses;
 use papyrus_common::BlockHashAndNumber;
 use papyrus_config::dumping::{append_sub_config_name, ser_param, SerializeConfig};
 use papyrus_config::validators::{validate_ascii, validate_path_exists};
@@ -38,6 +39,7 @@ use rpc_metrics::MetricLogger;
 use serde::{Deserialize, Serialize};
 use starknet_api::block::{BlockNumber, BlockStatus};
 use starknet_api::core::ChainId;
+use starknet_client::reader::PendingData;
 use starknet_client::writer::StarknetGatewayClient;
 use starknet_client::RetryConfig;
 use tokio::sync::RwLock;
@@ -176,6 +178,8 @@ struct ContinuationTokenAsStruct(EventIndex);
 pub async fn run_server(
     config: &RpcConfig,
     shared_highest_block: Arc<RwLock<Option<BlockHashAndNumber>>>,
+    pending_data: Arc<RwLock<PendingData>>,
+    pending_classes: Arc<RwLock<PendingClasses>>,
     storage_reader: StorageReader,
     node_version: &'static str,
 ) -> anyhow::Result<(SocketAddr, ServerHandle)> {
@@ -189,6 +193,8 @@ pub async fn run_server(
         config.max_events_keys,
         starting_block,
         shared_highest_block,
+        pending_data,
+        pending_classes,
         Arc::new(StarknetGatewayClient::new(
             &config.starknet_url,
             node_version,

--- a/crates/papyrus_rpc/src/rpc_test.rs
+++ b/crates/papyrus_rpc/src/rpc_test.rs
@@ -19,7 +19,12 @@ use test_utils::get_rng;
 use tower::BoxError;
 
 use crate::middleware::proxy_rpc_request;
-use crate::test_utils::{get_test_highest_block, get_test_rpc_config};
+use crate::test_utils::{
+    get_test_highest_block,
+    get_test_pending_classes,
+    get_test_pending_data,
+    get_test_rpc_config,
+};
 use crate::v0_4_0::error::NO_BLOCKS;
 use crate::version_config::VERSION_CONFIG;
 use crate::{get_block_status, run_server, SERVER_MAX_BODY_SIZE};
@@ -29,10 +34,18 @@ async fn run_server_no_blocks() {
     let ((storage_reader, _), _temp_dir) = get_test_storage();
     let gateway_config = get_test_rpc_config();
     let shared_highest_block = get_test_highest_block();
-    let (addr, _handle) =
-        run_server(&gateway_config, shared_highest_block, storage_reader, "NODE VERSION")
-            .await
-            .unwrap();
+    let pending_data = get_test_pending_data();
+    let pending_classes = get_test_pending_classes();
+    let (addr, _handle) = run_server(
+        &gateway_config,
+        shared_highest_block,
+        pending_data,
+        pending_classes,
+        storage_reader,
+        "NODE VERSION",
+    )
+    .await
+    .unwrap();
     let client = HttpClientBuilder::default().build(format!("http://{addr:?}")).unwrap();
     let res: Result<RpcResult<BlockNumber>, Error> =
         client.request("starknet_blockNumber", [""]).await;

--- a/crates/papyrus_rpc/src/v0_3_0/api/api_impl.rs
+++ b/crates/papyrus_rpc/src/v0_3_0/api/api_impl.rs
@@ -5,6 +5,7 @@ use jsonrpsee::core::RpcResult;
 use jsonrpsee::types::ErrorObjectOwned;
 use jsonrpsee::RpcModule;
 use lazy_static::lazy_static;
+use papyrus_common::pending_classes::PendingClasses;
 use papyrus_common::BlockHashAndNumber;
 use papyrus_execution::ExecutionConfigByBlock;
 use papyrus_storage::body::events::{EventIndex, EventsReader};
@@ -21,6 +22,7 @@ use starknet_api::transaction::{
     TransactionHash,
     TransactionOffsetInBlock,
 };
+use starknet_client::reader::PendingData;
 use starknet_client::writer::StarknetWriter;
 use tokio::sync::RwLock;
 use tracing::instrument;
@@ -501,6 +503,9 @@ impl JsonRpcServerImpl for JsonRpcServerV0_3Impl {
         max_events_keys: usize,
         starting_block: BlockHashAndNumber,
         shared_highest_block: Arc<RwLock<Option<BlockHashAndNumber>>>,
+        // TODO(shahak): Put these parameters inside Self once pending block is supported in v0.3.0
+        _: Arc<RwLock<PendingData>>,
+        _: Arc<RwLock<PendingClasses>>,
         // TODO(shahak): Put this parameter inside Self once write_api is supported in v0.3.0
         _: Arc<dyn StarknetWriter>,
     ) -> Self {

--- a/crates/papyrus_rpc/src/v0_3_0/api/test.rs
+++ b/crates/papyrus_rpc/src/v0_3_0/api/test.rs
@@ -66,6 +66,8 @@ use crate::test_utils::{
     get_starknet_spec_api_schema_for_components,
     get_starknet_spec_api_schema_for_method_results,
     get_test_highest_block,
+    get_test_pending_classes,
+    get_test_pending_data,
     get_test_rpc_config,
     get_test_rpc_server_and_storage_writer,
     get_test_rpc_server_and_storage_writer_from_params,
@@ -187,6 +189,8 @@ async fn syncing() {
     let (module, _) = get_test_rpc_server_and_storage_writer_from_params::<JsonRpcServerV0_3Impl>(
         None,
         Some(shared_highest_block.clone()),
+        None,
+        None,
         None,
     );
 
@@ -1815,10 +1819,16 @@ async fn serialize_returns_valid_json() {
         .unwrap();
 
     let gateway_config = get_test_rpc_config();
-    let (server_address, _handle) =
-        run_server(&gateway_config, get_test_highest_block(), storage_reader, NODE_VERSION)
-            .await
-            .unwrap();
+    let (server_address, _handle) = run_server(
+        &gateway_config,
+        get_test_highest_block(),
+        get_test_pending_data(),
+        get_test_pending_classes(),
+        storage_reader,
+        NODE_VERSION,
+    )
+    .await
+    .unwrap();
 
     let schema = get_starknet_spec_api_schema_for_components(
         &[(

--- a/crates/papyrus_rpc/src/v0_4_0/api/api_impl.rs
+++ b/crates/papyrus_rpc/src/v0_4_0/api/api_impl.rs
@@ -5,6 +5,7 @@ use jsonrpsee::core::RpcResult;
 use jsonrpsee::types::ErrorObjectOwned;
 use jsonrpsee::RpcModule;
 use lazy_static::lazy_static;
+use papyrus_common::pending_classes::PendingClasses;
 use papyrus_execution::objects::TransactionTrace;
 use papyrus_execution::{
     estimate_fee as exec_estimate_fee,
@@ -35,6 +36,7 @@ use starknet_api::transaction::{
     TransactionHash,
     TransactionOffsetInBlock,
 };
+use starknet_client::reader::PendingData;
 use starknet_client::writer::{StarknetWriter, WriterClientError};
 use starknet_client::ClientError;
 use tokio::sync::RwLock;
@@ -121,6 +123,8 @@ pub struct JsonRpcServerV0_4Impl {
     pub max_events_keys: usize,
     pub starting_block: BlockHashAndNumber,
     pub shared_highest_block: Arc<RwLock<Option<BlockHashAndNumber>>>,
+    pub pending_data: Arc<RwLock<PendingData>>,
+    pub pending_classes: Arc<RwLock<PendingClasses>>,
     pub writer_client: Arc<dyn StarknetWriter>,
 }
 
@@ -852,6 +856,8 @@ impl JsonRpcServerImpl for JsonRpcServerV0_4Impl {
         max_events_keys: usize,
         starting_block: BlockHashAndNumber,
         shared_highest_block: Arc<RwLock<Option<BlockHashAndNumber>>>,
+        pending_data: Arc<RwLock<PendingData>>,
+        pending_classes: Arc<RwLock<PendingClasses>>,
         writer_client: Arc<dyn StarknetWriter>,
     ) -> Self {
         Self {
@@ -862,6 +868,8 @@ impl JsonRpcServerImpl for JsonRpcServerV0_4Impl {
             max_events_keys,
             starting_block,
             shared_highest_block,
+            pending_data,
+            pending_classes,
             writer_client,
         }
     }

--- a/crates/papyrus_rpc/src/v0_4_0/api/test.rs
+++ b/crates/papyrus_rpc/src/v0_4_0/api/test.rs
@@ -92,6 +92,8 @@ use crate::test_utils::{
     get_starknet_spec_api_schema_for_components,
     get_starknet_spec_api_schema_for_method_results,
     get_test_highest_block,
+    get_test_pending_classes,
+    get_test_pending_data,
     get_test_rpc_config,
     get_test_rpc_server_and_storage_writer,
     get_test_rpc_server_and_storage_writer_from_params,
@@ -219,6 +221,8 @@ async fn syncing() {
     let (module, _) = get_test_rpc_server_and_storage_writer_from_params::<JsonRpcServerV0_4Impl>(
         None,
         Some(shared_highest_block.clone()),
+        None,
+        None,
         None,
     );
 
@@ -1163,6 +1167,8 @@ async fn get_transaction_by_hash_state_only() {
     let (module, _) = get_test_rpc_server_and_storage_writer_from_params::<JsonRpcServerV0_4Impl>(
         None,
         None,
+        None,
+        None,
         Some(StorageScope::StateOnly),
     );
 
@@ -1722,10 +1728,16 @@ async fn serialize_returns_valid_json() {
         .unwrap();
 
     let gateway_config = get_test_rpc_config();
-    let (server_address, _handle) =
-        run_server(&gateway_config, get_test_highest_block(), storage_reader, NODE_VERSION)
-            .await
-            .unwrap();
+    let (server_address, _handle) = run_server(
+        &gateway_config,
+        get_test_highest_block(),
+        get_test_pending_data(),
+        get_test_pending_classes(),
+        storage_reader,
+        NODE_VERSION,
+    )
+    .await
+    .unwrap();
 
     let schema = get_starknet_spec_api_schema_for_components(
         &[(
@@ -1967,6 +1979,8 @@ where
             Some(client_mock),
             None,
             None,
+            None,
+            None,
         );
         let resp = module.call::<_, Self::Response>(Self::METHOD_NAME, [tx]).await.unwrap();
         assert_eq!(resp, expected_resp);
@@ -1990,6 +2004,8 @@ where
 
         let (module, _) = get_test_rpc_server_and_storage_writer_from_params::<JsonRpcServerV0_4Impl>(
             Some(client_mock),
+            None,
+            None,
             None,
             None,
         );
@@ -2024,6 +2040,8 @@ where
             Some(client_mock),
             None,
             None,
+            None,
+            None,
         );
         let result = module.call::<_, Self::Response>(Self::METHOD_NAME, [tx]).await;
         let jsonrpsee::core::Error::Call(error) = result.unwrap_err() else {
@@ -2051,6 +2069,8 @@ where
 
         let (module, _) = get_test_rpc_server_and_storage_writer_from_params::<JsonRpcServerV0_4Impl>(
             Some(client_mock),
+            None,
+            None,
             None,
             None,
         );


### PR DESCRIPTION
- feat(storage): add db table iterator (#1235)
- feat(storage): add dump storage table to file utility (#1239)
- feat(storage): add an executable that dumps the declared_class table … (#1241)
- fix(execution): skip serialization of None objects in transaction trace (#1247)
- fix(execution): execution of declare txs - fetch the class from the r… (#1236)
- chore(config): add infomative prints to the configuration validations… (#1188)
- feat(monitoring): add alerts grafana (#1237)
- feat(): more details and changes to de table stats (#1194)
- chore(): solve clippy warnings (#1253)
- fix(common): v3 transaction hash calculation (#1210)
- feat(common): add PendingClasses struct
- feat(rpc): store pending data and classes in rpc

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1267)
<!-- Reviewable:end -->
