### PR TITLE
ci: replace non-maintained actions-rs/toolchain with dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,7 @@ jobs:
         os: [macos-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
 
       - run: mkdir data
@@ -61,9 +59,7 @@ jobs:
         os: [macos-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: npm install -g ganache@7.4.3
       - run: |
@@ -78,9 +74,7 @@ jobs:
         os: [macos-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo build -r -p papyrus_load_test
 
@@ -91,9 +85,7 @@ jobs:
         os: [macos-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: >
           cargo test -r --test '*' -- --include-ignored --skip test_gw_integration_testnet;
@@ -103,12 +95,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           components: rustfmt
-          toolchain: nightly-2023-07-05
+          toolchain: nightly-2023-10-19
       - uses: Swatinem/rust-cache@v2
-      - run: cargo +nightly-2023-07-05 fmt --all -- --check
+      - run: cargo +nightly-2023-10-19 fmt --all -- --check
 
   udeps:
     runs-on: ubuntu-latest
@@ -117,23 +109,22 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         name: "Rust Toolchain Setup"
         with:
-          toolchain: nightly-2023-07-05
+          toolchain: nightly-2023-10-19
       - uses: Swatinem/rust-cache@v2
       - name: "Download and run cargo-udeps"
         run: |
           wget -O - -c https://github.com/est31/cargo-udeps/releases/download/v0.1.35/cargo-udeps-v0.1.35-x86_64-unknown-linux-gnu.tar.gz | tar -xz
           cargo-udeps-*/cargo-udeps udeps
         env:
-          RUSTUP_TOOLCHAIN: nightly-2023-07-05
+          RUSTUP_TOOLCHAIN: nightly-2023-10-19
 
   clippy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-          toolchain: stable
       - uses: Swatinem/rust-cache@v2
       - run: >
           cargo clippy --all-targets --all-features -- -D warnings -D future-incompatible
@@ -145,9 +136,7 @@ jobs:
       RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo doc -r --document-private-items --no-deps
 
@@ -157,9 +146,7 @@ jobs:
       RUSTDOCFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo check -r --all-features
 
@@ -167,10 +154,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - name: Set-Up
         run: |
           sudo apt-get update
@@ -195,7 +179,5 @@ jobs:
     if: github.base_ref == 'main' # this step is only run if the pr is to the main branch
     steps:
       - uses: actions/checkout@v3
-        with:
-          toolchain: stable
       - run: sudo apt-get install jq
       - run: ./check_starknet_api_version_dependency.sh # this script checks that if the starknet_api dependency is by git rev then this rev (commit) is on main

--- a/.github/workflows/nightly-tests-call.yml
+++ b/.github/workflows/nightly-tests-call.yml
@@ -21,9 +21,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: sudo apt update; sudo apt -y install libclang-dev
         # Install libclang-dev that is not a part of the ubuntu vm in github actions.

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -24,11 +24,11 @@ wrap_comments = true
 #     "rust-analyzer.rustfmt.overrideCommand": [
 #         "rustup",
 #         "run",
-#         "nightly-2023-07-05",
+#         "nightly-2023-10-19",
 #         "--",
 #         "rustfmt",
 #         "--edition",
 #         "2018",
 #         "--"
 #     ]
-# and run "rustup toolchain install nightly-2023-07-05".
+# and run "rustup toolchain install nightly-2023-10-19".


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [x] Other (please describe): CI action update.

## What is the current behavior?

Using `actions-rs/toolchain` in workflows.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Using `dtolnay/rust-toolchain` instead.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->



<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1289)
<!-- Reviewable:end -->
