### PR TITLE
fix: replace expect when using format strings in error message

### DIFF
--- a/crates/papyrus_load_test/src/create_files.rs
+++ b/crates/papyrus_load_test/src/create_files.rs
@@ -191,8 +191,8 @@ where
     }
     // Remove the last '\n'.
     to_write.pop();
-    let mut file =
-        File::create(path_in_resources(file_name)).expect("Create file \"{file_name}\" failed.");
+    let mut file = File::create(path_in_resources(file_name))
+        .unwrap_or_else(|err| panic!("Create file \"{file_name}\" failed.: {err}"));
     file.write_all(to_write.as_bytes()).unwrap();
 }
 

--- a/crates/papyrus_rpc/tests/gateway_integration_test.rs
+++ b/crates/papyrus_rpc/tests/gateway_integration_test.rs
@@ -120,7 +120,7 @@ async fn test_gw_integration_testnet() {
             rpc_params!(SNClientInvokeTransaction::from(invoke_tx)),
         )
         .await
-        .unwrap();
+        .unwrap_or_else(|err| panic!("Failed to add tx '{hash}' with nonce '{nonce:?}'.: {err}"));
 
     println!("Invoke Tx result: {:?}", invoke_res);
 }

--- a/crates/papyrus_storage/src/state/mod.rs
+++ b/crates/papyrus_storage/src/state/mod.rs
@@ -524,7 +524,7 @@ impl<'env> StateStorageWriter for StorageTxn<'env, RW> {
 
         let thin_state_diff = self
             .get_state_diff(block_number)?
-            .expect("Missing state diff for block {block_number}.");
+            .unwrap_or_else(|| panic!("Missing state diff for block {block_number}."));
         markers_table.upsert(&self.txn, &MarkerKind::State, &block_number)?;
         let compiled_classes_marker =
             markers_table.get(&self.txn, &MarkerKind::CompiledClass)?.unwrap_or_default();
@@ -766,7 +766,7 @@ fn delete_declared_classes<'env>(
     for class_hash in thin_state_diff.declared_classes.keys() {
         let contract_class_location = declared_classes_table
             .get(txn, class_hash)?
-            .expect("Missing declared class {class_hash:#?}.");
+            .unwrap_or_else(|| panic!("Missing declared class {class_hash:#?}."));
         deleted_data.insert(
             *class_hash,
             file_access.get_contract_class_unchecked(contract_class_location)?,


### PR DESCRIPTION
Replaced with unwrap_or_else so that string allocation will only accure in the errorneous case.

## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Error messages are printed with a variable name instead of its value.

## What is the new behavior?

- The value is printed.

- The error message string will only be computed and allocated in case the error case was actually reached.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1329)
<!-- Reviewable:end -->
