### PR TITLE
ci: fail GW-integration-test-call job upon test failue

### DIFF
--- a/.github/workflows/nightly-tests-call.yml
+++ b/.github/workflows/nightly-tests-call.yml
@@ -26,7 +26,8 @@ jobs:
       - run: sudo apt update; sudo apt -y install libclang-dev
         # Install libclang-dev that is not a part of the ubuntu vm in github actions.
         if: runner.os == 'Linux'
-      - id: run_test
+      - name: Run gateway_integration_test.
+        id: run_test
         # Workflow steps exit upon failure of a subcommand (running `set -e` implicitly before the
         # run). As we want to keep running this step after a test failure we can either start with
         # `set +e` to suppress all errors, or, as done below, append `|| retVal=$?` to the command
@@ -54,3 +55,6 @@ jobs:
             logs>.
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      - name: Fail job in case of test failure.
+        if: ${{ steps.run_test.outputs.retVal != 0 }}
+        run: exit 1


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [x] Other (please describe):

## What is the current behavior?

A filed test in nightly-test-call doesn't fail the job (and the workflow is marked as successful in the Github Actions UI).

## What is the new behavior?

Fail the job if the test failed.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1334)
<!-- Reviewable:end -->
