### PR TITLE
feat(common): pending classes stores compiled classes by class hash

### DIFF
--- a/crates/papyrus_common/src/pending_classes.rs
+++ b/crates/papyrus_common/src/pending_classes.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use cairo_lang_starknet::casm_contract_class::CasmContractClass;
-use starknet_api::core::{ClassHash, CompiledClassHash};
+use starknet_api::core::ClassHash;
 use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContractClass;
 use starknet_api::state::ContractClass as SierraContractClass;
 
@@ -10,16 +10,9 @@ pub trait PendingClassesTrait {
 
     fn add_class(&mut self, class_hash: ClassHash, class: PendingClass);
 
-    fn get_compiled_class(
-        &self,
-        compiled_class_hash: CompiledClassHash,
-    ) -> Option<CasmContractClass>;
+    fn get_compiled_class(&self, class_hash: ClassHash) -> Option<CasmContractClass>;
 
-    fn add_compiled_class(
-        &mut self,
-        class_hash: CompiledClassHash,
-        compiled_class: CasmContractClass,
-    );
+    fn add_compiled_class(&mut self, class_hash: ClassHash, compiled_class: CasmContractClass);
 
     fn clear(&mut self);
 }
@@ -27,7 +20,7 @@ pub trait PendingClassesTrait {
 #[derive(Debug, Default, Eq, PartialEq, Clone)]
 pub struct PendingClasses {
     pub classes: HashMap<ClassHash, PendingClass>,
-    pub compiled_classes: HashMap<CompiledClassHash, CasmContractClass>,
+    pub compiled_classes: HashMap<ClassHash, CasmContractClass>,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -45,19 +38,12 @@ impl PendingClassesTrait for PendingClasses {
         self.classes.insert(class_hash, class);
     }
 
-    fn get_compiled_class(
-        &self,
-        compiled_class_hash: CompiledClassHash,
-    ) -> Option<CasmContractClass> {
-        self.compiled_classes.get(&compiled_class_hash).cloned()
+    fn get_compiled_class(&self, class_hash: ClassHash) -> Option<CasmContractClass> {
+        self.compiled_classes.get(&class_hash).cloned()
     }
 
-    fn add_compiled_class(
-        &mut self,
-        compiled_class_hash: CompiledClassHash,
-        compiled_class: CasmContractClass,
-    ) {
-        self.compiled_classes.insert(compiled_class_hash, compiled_class);
+    fn add_compiled_class(&mut self, class_hash: ClassHash, compiled_class: CasmContractClass) {
+        self.compiled_classes.insert(class_hash, compiled_class);
     }
 
     fn clear(&mut self) {


### PR DESCRIPTION
- refactor(storage): shared mmap write (#1307)
- feat(storage)!: store deprecated classes in a file (#1309)
- fix(storage): revert starknet version (#1328)
- chore(execution,JSON-RPC): order field of events and messages, 0.4 s… (#1305)
- test(starknet_client): add get_test_instance to ContractClass (#1327)
- fix(common): fix PendingClasses interface (#1325)
- feat(starknet_client): add conversion from ContractClass to PendingClass (#1326)
- test(storage): add CASM serde test (#1330)
- feat(JSON-RPC): get_block_transaction_count supports pending (#1317)
- feat(JSON-RPC): get_transaction_by_block_id_and_index supports pending (#1318)
- feat(JSON-RPC): get_transaction_by_hash supports pending (#1319)
- feat(JSON-RPC): get_storage_at supports pending
- feat(JSON-RPC): get_state_update supports pending
- feat: add PendingBlockHeader struct
- feat: support pending block in get_block_w_transaction_hashes()
- feat(JSON-RPC): get_transaction_receipt supports pending
- disable commitlint
- feat(common): pending classes stores compiled classes by class hash

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1336)
<!-- Reviewable:end -->
