### PR TITLE
feat(storage): add a detailed default error message when inserting existing key to DB

### DIFF
--- a/crates/papyrus_storage/src/compiled_class.rs
+++ b/crates/papyrus_storage/src/compiled_class.rs
@@ -97,7 +97,7 @@ impl<'env> CasmStorageWriter for StorageTxn<'env, RW> {
 
         let location = self.file_handlers.append_casm(casm);
         casm_table.insert(&self.txn, class_hash, &location).map_err(|err| {
-            if matches!(err, DbError::Inner(libmdbx::Error::KeyExist)) {
+            if matches!(err, DbError::KeyAlreadyExists(..)) {
                 StorageError::CompiledClassReWrite { class_hash: *class_hash }
             } else {
                 StorageError::from(err)

--- a/crates/papyrus_storage/src/header.rs
+++ b/crates/papyrus_storage/src/header.rs
@@ -177,7 +177,7 @@ impl<'env> HeaderStorageWriter for StorageTxn<'env, RW> {
                 if last_starknet_version == *starknet_version => {}
             _ => match starknet_version_table.insert(&self.txn, block_number, starknet_version) {
                 Ok(()) => {}
-                Err(DbError::Inner(libmdbx::Error::KeyExist)) => {
+                Err(DbError::KeyAlreadyExists(..)) => {
                     return Err(StorageError::StarknetVersionAlreadyExists {
                         block_number: *block_number,
                         starknet_version: starknet_version.clone(),
@@ -233,7 +233,7 @@ fn update_hash_mapping<'env>(
 ) -> Result<(), StorageError> {
     let res = block_hash_to_number_table.insert(txn, &block_header.block_hash, &block_number);
     res.map_err(|err| match err {
-        DbError::Inner(libmdbx::Error::KeyExist) => StorageError::BlockHashAlreadyExists {
+        DbError::KeyAlreadyExists(..) => StorageError::BlockHashAlreadyExists {
             block_hash: block_header.block_hash,
             block_number,
         },

--- a/crates/papyrus_storage/src/lib.rs
+++ b/crates/papyrus_storage/src/lib.rs
@@ -70,6 +70,7 @@ mod test_instances;
 pub mod test_utils;
 
 use std::collections::BTreeMap;
+use std::fmt::Debug;
 use std::sync::Arc;
 
 use body::events::EventIndex;
@@ -314,7 +315,7 @@ impl<'env> StorageTxn<'env, RW> {
 }
 
 impl<'env, Mode: TransactionKind> StorageTxn<'env, Mode> {
-    pub(crate) fn open_table<K: StorageSerde, V: StorageSerde>(
+    pub(crate) fn open_table<K: StorageSerde + Debug, V: StorageSerde + Debug>(
         &self,
         table_id: &TableIdentifier<K, V>,
     ) -> StorageResult<TableHandle<'_, K, V>> {

--- a/crates/papyrus_storage/src/state/mod.rs
+++ b/crates/papyrus_storage/src/state/mod.rs
@@ -696,7 +696,7 @@ fn write_deployed_contracts<'env>(
     for (address, class_hash) in deployed_contracts {
         deployed_contracts_table.insert(txn, &(*address, block_number), class_hash).map_err(
             |err| {
-                if matches!(err, DbError::Inner(libmdbx::Error::KeyExist)) {
+                if matches!(err, DbError::KeyAlreadyExists(..)) {
                     StorageError::ContractAlreadyExists { address: *address }
                 } else {
                     StorageError::from(err)
@@ -705,7 +705,7 @@ fn write_deployed_contracts<'env>(
         )?;
 
         nonces_table.insert(txn, &(*address, block_number), &Nonce::default()).map_err(|err| {
-            if matches!(err, DbError::Inner(libmdbx::Error::KeyExist)) {
+            if matches!(err, DbError::KeyAlreadyExists(..)) {
                 StorageError::NonceReWrite {
                     contract_address: *address,
                     nonce: Nonce::default(),


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When trying to insert a key that already exists to the internal DB in papyrus_storage, an error with no info is given by default.

Issue Number: N/A

## What is the new behavior?

Table name, key, and value are logged in the new error.

-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1353)
<!-- Reviewable:end -->
