### PR TITLE
feat(storage): remove the different already exists errors

### DIFF
--- a/crates/papyrus_storage/src/body/mod.rs
+++ b/crates/papyrus_storage/src/body/mod.rs
@@ -60,7 +60,7 @@ use tracing::debug;
 
 use crate::body::events::{EventIndex, ThinTransactionOutput};
 use crate::db::serialization::StorageSerde;
-use crate::db::{DbError, DbTransaction, TableHandle, TransactionKind, RW};
+use crate::db::{DbTransaction, TableHandle, TransactionKind, RW};
 use crate::{MarkerKind, MarkersTable, StorageError, StorageResult, StorageScope, StorageTxn};
 
 type TransactionsTable<'env> = TableHandle<'env, TransactionIndex, Transaction>;
@@ -443,13 +443,7 @@ fn update_tx_hash_mapping<'env>(
     tx_hash: &TransactionHash,
     transaction_index: TransactionIndex,
 ) -> Result<(), StorageError> {
-    let res = transaction_hash_to_idx_table.insert(txn, tx_hash, &transaction_index);
-    res.map_err(|err| match err {
-        DbError::KeyAlreadyExists(..) => {
-            StorageError::TransactionHashAlreadyExists { tx_hash: *tx_hash, transaction_index }
-        }
-        err => err.into(),
-    })?;
+    transaction_hash_to_idx_table.insert(txn, tx_hash, &transaction_index)?;
     transaction_idx_to_hash_table.insert(txn, &transaction_index, tx_hash)?;
     Ok(())
 }

--- a/crates/papyrus_storage/src/compiled_class_test.rs
+++ b/crates/papyrus_storage/src/compiled_class_test.rs
@@ -5,6 +5,7 @@ use starknet_api::core::ClassHash;
 use test_utils::read_json_file;
 
 use crate::compiled_class::{CasmStorageReader, CasmStorageWriter};
+use crate::db::{DbError, KeyAlreadyExistsError};
 use crate::test_utils::get_test_storage;
 use crate::StorageError;
 
@@ -46,5 +47,9 @@ fn casm_rewrite() {
         panic!("Unexpected Ok.");
     };
 
-    assert_matches!(err, StorageError::CompiledClassReWrite{class_hash} if class_hash == ClassHash::default());
+    assert_matches!(err, StorageError::InnerError(DbError::KeyAlreadyExists(KeyAlreadyExistsError {
+        table_name: _,
+        key,
+        value: _
+    })) if key == format!("{:?}", ClassHash::default()));
 }

--- a/crates/papyrus_storage/src/header.rs
+++ b/crates/papyrus_storage/src/header.rs
@@ -43,7 +43,7 @@ use serde::{Deserialize, Serialize};
 use starknet_api::block::{BlockHash, BlockHeader, BlockNumber};
 use tracing::debug;
 
-use crate::db::{DbError, DbTransaction, TableHandle, TransactionKind, RW};
+use crate::db::{DbTransaction, TableHandle, TransactionKind, RW};
 use crate::{MarkerKind, MarkersTable, StorageError, StorageResult, StorageTxn};
 
 type BlockHashToNumberTable<'env> = TableHandle<'env, BlockHash, BlockNumber>;
@@ -175,16 +175,7 @@ impl<'env> HeaderStorageWriter for StorageTxn<'env, RW> {
         match res {
             Some((_block_number, last_starknet_version))
                 if last_starknet_version == *starknet_version => {}
-            _ => match starknet_version_table.insert(&self.txn, block_number, starknet_version) {
-                Ok(()) => {}
-                Err(DbError::KeyAlreadyExists(..)) => {
-                    return Err(StorageError::StarknetVersionAlreadyExists {
-                        block_number: *block_number,
-                        starknet_version: starknet_version.clone(),
-                    });
-                }
-                Err(err) => return Err(err.into()),
-            },
+            _ => starknet_version_table.insert(&self.txn, block_number, starknet_version)?,
         }
         Ok(self)
     }
@@ -231,14 +222,7 @@ fn update_hash_mapping<'env>(
     block_header: &BlockHeader,
     block_number: BlockNumber,
 ) -> Result<(), StorageError> {
-    let res = block_hash_to_number_table.insert(txn, &block_header.block_hash, &block_number);
-    res.map_err(|err| match err {
-        DbError::KeyAlreadyExists(..) => StorageError::BlockHashAlreadyExists {
-            block_hash: block_header.block_hash,
-            block_number,
-        },
-        err => err.into(),
-    })?;
+    block_hash_to_number_table.insert(txn, &block_header.block_hash, &block_number)?;
     Ok(())
 }
 

--- a/crates/papyrus_storage/src/lib.rs
+++ b/crates/papyrus_storage/src/lib.rs
@@ -394,19 +394,6 @@ pub enum StorageError {
     InnerError(#[from] DbError),
     #[error("Marker mismatch (expected {expected}, found {found}).")]
     MarkerMismatch { expected: BlockNumber, found: BlockNumber },
-    #[error("Block hash {block_hash} already exists, when adding block number {block_number}.")]
-    BlockHashAlreadyExists { block_hash: BlockHash, block_number: BlockNumber },
-    #[error(
-        "Transaction hash {tx_hash:?} already exists, when adding transaction \
-         {transaction_index:?}."
-    )]
-    TransactionHashAlreadyExists { tx_hash: TransactionHash, transaction_index: TransactionIndex },
-    #[error("State diff redployed to an existing contract address {address:?}.")]
-    ContractAlreadyExists { address: ContractAddress },
-    #[error(
-        "State diff redeclared a different class to an existing contract hash {class_hash:?}."
-    )]
-    ClassAlreadyExists { class_hash: ClassHash },
     #[error(
         "State diff redefined a nonce {nonce:?} for contract {contract_address:?} at block \
          {block_number}."
@@ -424,8 +411,6 @@ pub enum StorageError {
     MMapFileError(#[from] MMapFileError),
     #[error(transparent)]
     StorageVersionInconcistency(#[from] StorageVersionError),
-    #[error("Compiled class of {class_hash:?} already exists.")]
-    CompiledClassReWrite { class_hash: ClassHash },
     #[error("The table {table_name} is unused under the {storage_scope:?} storage scope.")]
     ScopeError { table_name: String, storage_scope: StorageScope },
     #[error(transparent)]
@@ -437,8 +422,6 @@ pub enum StorageError {
          {compiled_class_marker}."
     )]
     InvalidBlockNumber { block: BlockNumber, compiled_class_marker: BlockNumber },
-    #[error("Starknet version {starknet_version:?} already exists since block {block_number}.")]
-    StarknetVersionAlreadyExists { block_number: BlockNumber, starknet_version: StarknetVersion },
 }
 
 /// A type alias that maps to std::result::Result<T, StorageError>.

--- a/crates/papyrus_storage/src/state/state_test.rs
+++ b/crates/papyrus_storage/src/state/state_test.rs
@@ -4,18 +4,14 @@ use indexmap::{indexmap, IndexMap};
 use pretty_assertions::assert_eq;
 use starknet_api::block::BlockNumber;
 use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce, PatriciaKey};
-use starknet_api::deprecated_contract_class::{
-    ContractClass as DeprecatedContractClass,
-    ContractClassAbiEntry,
-    FunctionAbiEntry,
-};
+use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContractClass;
 use starknet_api::hash::{StarkFelt, StarkHash};
 use starknet_api::state::{ContractClass, StateDiff, StateNumber, StorageKey, ThinStateDiff};
 use starknet_api::{patricia_key, stark_felt};
 use test_utils::get_test_state_diff;
 
 use crate::compiled_class::{CasmStorageReader, CasmStorageWriter};
-use crate::state::{StateStorageReader, StateStorageWriter, StorageError};
+use crate::state::{StateStorageReader, StateStorageWriter};
 use crate::test_utils::get_test_storage;
 use crate::StorageWriter;
 
@@ -55,24 +51,6 @@ fn append_state_diff_declared_classes() {
     let state2 = StateNumber::right_before_block(BlockNumber(2));
 
     // Deprecated Classes Test
-    // Check for ClassAlreadyExists error when trying to declare another class to an existing
-    // class hash.
-    let txn = writer.begin_rw_txn().unwrap();
-    let mut diff2 = StateDiff {
-        deprecated_declared_classes: diff1.deprecated_declared_classes,
-        ..StateDiff::default()
-    };
-    let (_, class) = diff2.deprecated_declared_classes.iter_mut().next().unwrap();
-    class.abi = Some(vec![ContractClassAbiEntry::Function(FunctionAbiEntry {
-        name: String::from("junk"),
-        inputs: vec![],
-        outputs: vec![],
-        state_mutability: None,
-    })]);
-    let Err(err) = txn.append_state_diff(BlockNumber(2), diff2, IndexMap::new()) else {
-        panic!("Unexpected Ok.");
-    };
-    assert_matches!(err, StorageError::ClassAlreadyExists { class_hash: _ });
 
     let txn = writer.begin_rw_txn().unwrap();
     let statetxn = txn.get_state_reader().unwrap();

--- a/crates/papyrus_sync/src/lib.rs
+++ b/crates/papyrus_sync/src/lib.rs
@@ -27,6 +27,7 @@ use papyrus_proc_macros::latency_histogram;
 use papyrus_storage::base_layer::BaseLayerStorageWriter;
 use papyrus_storage::body::BodyStorageWriter;
 use papyrus_storage::compiled_class::{CasmStorageReader, CasmStorageWriter};
+use papyrus_storage::db::DbError;
 use papyrus_storage::header::{HeaderStorageReader, HeaderStorageWriter, StarknetVersion};
 use papyrus_storage::state::{StateStorageReader, StateStorageWriter};
 use papyrus_storage::{StorageError, StorageReader, StorageWriter};
@@ -440,9 +441,7 @@ impl<
             // TODO(yair): Modify the stream so it skips already stored classes.
             // Compiled classes rewrite is valid because the stream downloads from the beginning of
             // the block instead of the last downloaded class.
-            Err(StorageError::CompiledClassReWrite { class_hash: existing_class_hash })
-                if existing_class_hash == class_hash =>
-            {
+            Err(StorageError::InnerError(DbError::KeyAlreadyExists(..))) => {
                 debug!("Compiled class of {class_hash} already stored.");
                 Ok(())
             }


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Many unique KeyAlreadyExists errors exist for different objects.

## What is the new behavior?

A single error for all.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

Replacing existing error types:
`StorageError::{BlockHashAlreadyExists, TransactionHashAlreadyExists,  ContractAlreadyExists, CompiledClassReWrite,  StarknetVersionAlreadyExists, ClassAlreadyExists}`
with: `StorageError::InnerError::KeyAlreadyExists`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1357)
<!-- Reviewable:end -->
