### PR TITLE
feat(JSON-RPC): add support for pending to call (#1427)

### DIFF
--- a/crates/papyrus_common/src/lib.rs
+++ b/crates/papyrus_common/src/lib.rs
@@ -5,6 +5,7 @@ pub mod block_hash;
 pub mod metrics;
 pub mod patricia_hash_tree;
 pub mod pending_classes;
+pub mod state;
 pub mod transaction_hash;
 
 #[derive(Copy, Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]

--- a/crates/papyrus_common/src/state.rs
+++ b/crates/papyrus_common/src/state.rs
@@ -1,0 +1,31 @@
+use serde::{Deserialize, Serialize};
+use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress};
+use starknet_api::hash::StarkFelt;
+use starknet_api::state::StorageKey;
+
+/// A storage entry in a contract.
+#[derive(Debug, Default, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord)]
+pub struct StorageEntry {
+    pub key: StorageKey,
+    pub value: StarkFelt,
+}
+
+/// A deployed contract in StarkNet.
+#[derive(Debug, Default, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord)]
+pub struct DeployedContract {
+    pub address: ContractAddress,
+    pub class_hash: ClassHash,
+}
+
+/// A mapping from class hash to the compiled class hash.
+#[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
+pub struct DeclaredClassHashEntry {
+    pub class_hash: ClassHash,
+    pub compiled_class_hash: CompiledClassHash,
+}
+
+#[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
+pub struct ReplacedClass {
+    pub address: ContractAddress,
+    pub class_hash: ClassHash,
+}

--- a/crates/papyrus_execution/src/execution_test.rs
+++ b/crates/papyrus_execution/src/execution_test.rs
@@ -68,6 +68,8 @@ fn execute_call_cairo0() {
 
     let retdata = execute_call(
         storage_reader.clone(),
+        None,
+        None,
         &chain_id,
         StateNumber::right_after_block(BlockNumber(0)),
         BlockNumber(0),
@@ -83,6 +85,8 @@ fn execute_call_cairo0() {
     // Test that the entry point can be called with arguments.
     let retdata = execute_call(
         storage_reader.clone(),
+        None,
+        None,
         &chain_id,
         StateNumber::right_after_block(BlockNumber(0)),
         BlockNumber(0),
@@ -98,6 +102,8 @@ fn execute_call_cairo0() {
     // Test that the entry point can return a result.
     let retdata = execute_call(
         storage_reader.clone(),
+        None,
+        None,
         &chain_id,
         StateNumber::right_after_block(BlockNumber(0)),
         BlockNumber(0),
@@ -113,6 +119,8 @@ fn execute_call_cairo0() {
     // Test that the entry point can read and write to the contract storage.
     let retdata = execute_call(
         storage_reader,
+        None,
+        None,
         &chain_id,
         StateNumber::right_after_block(BlockNumber(0)),
         BlockNumber(0),
@@ -139,6 +147,8 @@ fn execute_call_cairo1() {
     // Test that the entry point can read and write to the contract storage.
     let retdata = execute_call(
         storage_reader,
+        None,
+        None,
         &CHAIN_ID,
         StateNumber::right_after_block(BlockNumber(0)),
         BlockNumber(0),
@@ -224,6 +234,8 @@ fn estimate_fees(txs: Vec<ExecutableTransactionInput>) -> Vec<(GasPrice, Fee)> {
         txs,
         &CHAIN_ID,
         storage_reader,
+        None,
+        None,
         StateNumber::right_after_block(BlockNumber(0)),
         BlockNumber(1),
         &test_block_execution_config(),
@@ -248,14 +260,35 @@ fn simulate_invoke() {
     let tx = TxsScenarioBuilder::default()
         .invoke_deprecated(*ACCOUNT_ADDRESS, *DEPRECATED_CONTRACT_ADDRESS, None)
         .collect();
-    let exec_only_results =
-        execute_simulate_transactions(storage_reader.clone(), tx.clone(), None, false, false);
-    let validate_results =
-        execute_simulate_transactions(storage_reader.clone(), tx.clone(), None, false, true);
-    let charge_fee_results =
-        execute_simulate_transactions(storage_reader.clone(), tx.clone(), None, true, false);
+    let exec_only_results = execute_simulate_transactions(
+        storage_reader.clone(),
+        None,
+        None,
+        tx.clone(),
+        None,
+        false,
+        false,
+    );
+    let validate_results = execute_simulate_transactions(
+        storage_reader.clone(),
+        None,
+        None,
+        tx.clone(),
+        None,
+        false,
+        true,
+    );
+    let charge_fee_results = execute_simulate_transactions(
+        storage_reader.clone(),
+        None,
+        None,
+        tx.clone(),
+        None,
+        true,
+        false,
+    );
     let charge_fee_validate_results =
-        execute_simulate_transactions(storage_reader, tx, None, true, true);
+        execute_simulate_transactions(storage_reader, None, None, tx, None, true, true);
 
     for (exec_only, (validate, (charge_fee, charge_fee_validate))) in exec_only_results.iter().zip(
         validate_results
@@ -323,14 +356,35 @@ fn simulate_declare_deprecated() {
     prepare_storage(storage_writer);
 
     let tx = TxsScenarioBuilder::default().declare_deprecated_class(*ACCOUNT_ADDRESS).collect();
-    let exec_only_results =
-        execute_simulate_transactions(storage_reader.clone(), tx.clone(), None, false, false);
-    let validate_results =
-        execute_simulate_transactions(storage_reader.clone(), tx.clone(), None, false, true);
-    let charge_fee_results =
-        execute_simulate_transactions(storage_reader.clone(), tx.clone(), None, true, false);
+    let exec_only_results = execute_simulate_transactions(
+        storage_reader.clone(),
+        None,
+        None,
+        tx.clone(),
+        None,
+        false,
+        false,
+    );
+    let validate_results = execute_simulate_transactions(
+        storage_reader.clone(),
+        None,
+        None,
+        tx.clone(),
+        None,
+        false,
+        true,
+    );
+    let charge_fee_results = execute_simulate_transactions(
+        storage_reader.clone(),
+        None,
+        None,
+        tx.clone(),
+        None,
+        true,
+        false,
+    );
     let charge_fee_validate_results =
-        execute_simulate_transactions(storage_reader, tx, None, true, true);
+        execute_simulate_transactions(storage_reader, None, None, tx, None, true, true);
 
     for (exec_only, (validate, (charge_fee, charge_fee_validate))) in exec_only_results.iter().zip(
         validate_results
@@ -382,14 +436,35 @@ fn simulate_declare() {
     prepare_storage(storage_writer);
 
     let tx = TxsScenarioBuilder::default().declare_class(*ACCOUNT_ADDRESS).collect();
-    let exec_only_results =
-        execute_simulate_transactions(storage_reader.clone(), tx.clone(), None, false, false);
-    let validate_results =
-        execute_simulate_transactions(storage_reader.clone(), tx.clone(), None, false, true);
-    let charge_fee_results =
-        execute_simulate_transactions(storage_reader.clone(), tx.clone(), None, true, false);
+    let exec_only_results = execute_simulate_transactions(
+        storage_reader.clone(),
+        None,
+        None,
+        tx.clone(),
+        None,
+        false,
+        false,
+    );
+    let validate_results = execute_simulate_transactions(
+        storage_reader.clone(),
+        None,
+        None,
+        tx.clone(),
+        None,
+        false,
+        true,
+    );
+    let charge_fee_results = execute_simulate_transactions(
+        storage_reader.clone(),
+        None,
+        None,
+        tx.clone(),
+        None,
+        true,
+        false,
+    );
     let charge_fee_validate_results =
-        execute_simulate_transactions(storage_reader, tx, None, true, true);
+        execute_simulate_transactions(storage_reader, None, None, tx, None, true, true);
 
     for (exec_only, (validate, (charge_fee, charge_fee_validate))) in exec_only_results.iter().zip(
         validate_results
@@ -441,14 +516,35 @@ fn simulate_deploy_account() {
     prepare_storage(storage_writer);
 
     let tx = TxsScenarioBuilder::default().deploy_account().collect();
-    let exec_only_results =
-        execute_simulate_transactions(storage_reader.clone(), tx.clone(), None, false, false);
-    let validate_results =
-        execute_simulate_transactions(storage_reader.clone(), tx.clone(), None, false, true);
-    let charge_fee_results =
-        execute_simulate_transactions(storage_reader.clone(), tx.clone(), None, true, false);
+    let exec_only_results = execute_simulate_transactions(
+        storage_reader.clone(),
+        None,
+        None,
+        tx.clone(),
+        None,
+        false,
+        false,
+    );
+    let validate_results = execute_simulate_transactions(
+        storage_reader.clone(),
+        None,
+        None,
+        tx.clone(),
+        None,
+        false,
+        true,
+    );
+    let charge_fee_results = execute_simulate_transactions(
+        storage_reader.clone(),
+        None,
+        None,
+        tx.clone(),
+        None,
+        true,
+        false,
+    );
     let charge_fee_validate_results =
-        execute_simulate_transactions(storage_reader, tx, None, true, true);
+        execute_simulate_transactions(storage_reader, None, None, tx, None, true, true);
 
     for (exec_only, (validate, (charge_fee, charge_fee_validate))) in exec_only_results.iter().zip(
         validate_results
@@ -525,7 +621,8 @@ fn simulate_invoke_from_new_account() {
         // TODO(yair): Find out how to deploy another contract to test calling a new contract.
         .collect();
 
-    let mut result = execute_simulate_transactions(storage_reader, txs, None, false, false);
+    let mut result =
+        execute_simulate_transactions(storage_reader, None, None, txs, None, false, false);
     assert_eq!(result.len(), 2);
 
     let Some((TransactionTrace::Invoke(invoke_trace), _, _, _)) = result.pop() else {
@@ -566,7 +663,8 @@ fn simulate_invoke_from_new_account_validate_and_charge() {
         // TODO(yair): Find out how to deploy another contract to test calling a new contract.
         .collect();
 
-    let mut result = execute_simulate_transactions(storage_reader, txs, None, true, true);
+    let mut result =
+        execute_simulate_transactions(storage_reader, None, None, txs, None, true, true);
     assert_eq!(result.len(), 2);
 
     let Some((TransactionTrace::Invoke(invoke_trace), _, _, invoke_fee_estimation)) = result.pop()
@@ -697,7 +795,8 @@ fn induced_state_diff() {
         .declare_deprecated_class(*ACCOUNT_ADDRESS)
         .deploy_account()
         .collect();
-    let simulation_results = execute_simulate_transactions(storage_reader, tx, None, true, true);
+    let simulation_results =
+        execute_simulate_transactions(storage_reader, None, None, tx, None, true, true);
     // This is the value TxsScenarioBuilder uses for the first declared class hash.
     let mut next_declared_class_hash = 100_u128;
     let mut account_balance = u64::try_from(*ACCOUNT_INITIAL_BALANCE).unwrap() as u128;
@@ -791,6 +890,8 @@ fn execute_call_checks_if_node_is_synced() {
     let block_context = latest_block;
     execute_call(
         storage_reader.clone(),
+        None,
+        None,
         &chain_id,
         state_number,
         block_context,
@@ -806,6 +907,8 @@ fn execute_call_checks_if_node_is_synced() {
     let block_context = latest_block;
     execute_call(
         storage_reader.clone(),
+        None,
+        None,
         &chain_id,
         state_number,
         block_context,
@@ -821,6 +924,8 @@ fn execute_call_checks_if_node_is_synced() {
     let block_context = latest_block.next();
     let err = execute_call(
         storage_reader.clone(),
+        None,
+        None,
         &chain_id,
         state_number,
         block_context,

--- a/crates/papyrus_execution/src/execution_utils.rs
+++ b/crates/papyrus_execution/src/execution_utils.rs
@@ -14,12 +14,14 @@ use blockifier::state::state_api::{State, StateReader};
 use blockifier::transaction::objects::TransactionExecutionInfo;
 use cairo_vm::types::errors::program_errors::ProgramError;
 use indexmap::IndexMap;
+use papyrus_common::state::StorageEntry;
 use papyrus_storage::compiled_class::CasmStorageReader;
 use papyrus_storage::db::RO;
 use papyrus_storage::state::StateStorageReader;
-use papyrus_storage::{StorageError, StorageTxn};
-use starknet_api::core::ClassHash;
-use starknet_api::state::{StateNumber, ThinStateDiff};
+use papyrus_storage::{StorageError, StorageReader, StorageResult, StorageTxn};
+use starknet_api::core::{ClassHash, ContractAddress};
+use starknet_api::hash::StarkFelt;
+use starknet_api::state::{StateNumber, StorageKey, ThinStateDiff};
 use thiserror::Error;
 
 use crate::objects::TransactionTrace;
@@ -136,4 +138,32 @@ pub fn induced_state_diff(
         nonces: blockifier_state_diff.address_to_nonce,
         replaced_classes,
     })
+}
+
+/// Get the storage at the given contract and key in the given state. If there's a given pending
+/// storage diffs, apply them on top of the given state.
+// TODO(shahak) If the structure of storage diffs changes, remove this function and move its code
+// into papyrus_rpc.
+pub fn get_storage_at(
+    storage_reader: &StorageReader,
+    state_number: StateNumber,
+    pending_storage_diffs: Option<&IndexMap<ContractAddress, Vec<StorageEntry>>>,
+    contract_address: ContractAddress,
+    key: StorageKey,
+) -> StorageResult<StarkFelt> {
+    if let Some(pending_storage_diffs) = pending_storage_diffs {
+        if let Some(storage_entries) = pending_storage_diffs.get(&contract_address) {
+            if let Some(StorageEntry { key: _, value }) = storage_entries
+                .iter()
+                .find(|StorageEntry { key: other_key, value: _ }| key == *other_key)
+            {
+                return Ok(*value);
+            }
+        }
+    }
+    storage_reader.begin_ro_txn()?.get_state_reader()?.get_storage_at(
+        state_number,
+        &contract_address,
+        &key,
+    )
 }

--- a/crates/papyrus_execution/src/lib.rs
+++ b/crates/papyrus_execution/src/lib.rs
@@ -46,6 +46,7 @@ use cairo_lang_starknet::casm_contract_class::CasmContractClass;
 use cairo_vm::types::errors::program_errors::ProgramError;
 use execution_utils::{get_trace_constructor, induced_state_diff};
 use objects::TransactionTrace;
+use papyrus_common::pending_classes::PendingClasses;
 use papyrus_common::transaction_hash::get_transaction_hash;
 use papyrus_storage::compiled_class::CasmStorageReader;
 use papyrus_storage::db::RO;
@@ -77,6 +78,8 @@ use starknet_api::transaction::{
 use starknet_api::StarknetApiError;
 use state_reader::ExecutionStateReader;
 use tracing::trace;
+
+use crate::objects::PendingStateDiff;
 
 /// Result type for execution functions.
 pub type ExecutionResult<T> = Result<T, ExecutionError>;
@@ -178,6 +181,8 @@ pub enum ExecutionError {
 #[allow(clippy::too_many_arguments)]
 pub fn execute_call(
     storage_reader: StorageReader,
+    maybe_pending_state_diff: Option<PendingStateDiff>,
+    maybe_pending_classes: Option<PendingClasses>,
     chain_id: &ChainId,
     state_number: StateNumber,
     block_context_number: BlockNumber,
@@ -209,6 +214,8 @@ pub fn execute_call(
     let mut cached_state = CachedState::from(ExecutionStateReader {
         storage_reader: storage_reader.clone(),
         state_number,
+        maybe_pending_state_diff,
+        maybe_pending_classes,
     });
     let header = storage_reader
         .begin_ro_txn()?
@@ -398,10 +405,13 @@ fn calc_tx_hashes(
 }
 
 /// Returns the fee estimation for a series of transactions.
+#[allow(clippy::too_many_arguments)]
 pub fn estimate_fee(
     txs: Vec<ExecutableTransactionInput>,
     chain_id: &ChainId,
     storage_reader: StorageReader,
+    maybe_pending_state_diff: Option<PendingStateDiff>,
+    maybe_pending_classes: Option<PendingClasses>,
     state_number: StateNumber,
     block_context_block_number: BlockNumber,
     execution_config: &BlockExecutionConfig,
@@ -411,6 +421,8 @@ pub fn estimate_fee(
         None,
         chain_id,
         storage_reader,
+        maybe_pending_state_diff,
+        maybe_pending_classes,
         state_number,
         block_context_block_number,
         execution_config,
@@ -433,6 +445,8 @@ fn execute_transactions(
     tx_hashes: Option<Vec<TransactionHash>>,
     chain_id: &ChainId,
     storage_reader: StorageReader,
+    maybe_pending_state_diff: Option<PendingStateDiff>,
+    maybe_pending_classes: Option<PendingClasses>,
     state_number: StateNumber,
     block_context_block_number: BlockNumber,
     execution_config: &BlockExecutionConfig,
@@ -454,7 +468,12 @@ fn execute_transactions(
         .expect("Should have block header.");
 
     // The starknet state will be from right before the block in which the transactions should run.
-    let mut cached_state = CachedState::from(ExecutionStateReader { storage_reader, state_number });
+    let mut cached_state = CachedState::from(ExecutionStateReader {
+        storage_reader,
+        state_number,
+        maybe_pending_state_diff,
+        maybe_pending_classes,
+    });
     let block_context = create_block_context(
         chain_id.clone(),
         header.block_number,
@@ -594,6 +613,8 @@ pub fn simulate_transactions(
     tx_hashes: Option<Vec<TransactionHash>>,
     chain_id: &ChainId,
     storage_reader: StorageReader,
+    maybe_pending_state_diff: Option<PendingStateDiff>,
+    maybe_pending_classes: Option<PendingClasses>,
     state_number: StateNumber,
     block_context_block_number: BlockNumber,
     execution_config: &BlockExecutionConfig,
@@ -606,6 +627,8 @@ pub fn simulate_transactions(
         tx_hashes,
         chain_id,
         storage_reader,
+        maybe_pending_state_diff,
+        maybe_pending_classes,
         state_number,
         block_context_block_number,
         execution_config,

--- a/crates/papyrus_execution/src/objects.rs
+++ b/crates/papyrus_execution/src/objects.rs
@@ -8,9 +8,16 @@ use blockifier::execution::call_info::{
 };
 use blockifier::execution::entry_point::CallType as BlockifierCallType;
 use blockifier::transaction::objects::TransactionExecutionInfo;
+use indexmap::IndexMap;
 use itertools::Itertools;
+use papyrus_common::state::{
+    DeclaredClassHashEntry,
+    DeployedContract,
+    ReplacedClass,
+    StorageEntry,
+};
 use serde::{Deserialize, Serialize};
-use starknet_api::core::{ClassHash, ContractAddress, EntryPointSelector};
+use starknet_api::core::{ClassHash, ContractAddress, EntryPointSelector, Nonce};
 use starknet_api::deprecated_contract_class::EntryPointType;
 use starknet_api::hash::StarkFelt;
 use starknet_api::transaction::{Calldata, EventContent, MessageToL1};
@@ -315,4 +322,22 @@ pub struct FunctionCall {
     pub entry_point_selector: EntryPointSelector,
     /// The calldata of the function call.
     pub calldata: Calldata,
+}
+
+/// A state diff for the pending block.
+#[derive(Debug, Default, Deserialize, Serialize, Clone, Eq, PartialEq)]
+pub struct PendingStateDiff {
+    // TODO(shahak): Consider indexing by address and key.
+    /// All the contract storages that were changed in the pending block.
+    pub storage_diffs: IndexMap<ContractAddress, Vec<StorageEntry>>,
+    /// All the contracts that were deployed in the pending block.
+    pub deployed_contracts: Vec<DeployedContract>,
+    /// All the classes that were declared in the pending block.
+    pub declared_classes: Vec<DeclaredClassHashEntry>,
+    /// All the deprecated classes that were declared in the pending block.
+    pub old_declared_contracts: Vec<ClassHash>,
+    /// All the nonces that were changed in the pending block.
+    pub nonces: IndexMap<ContractAddress, Nonce>,
+    /// All the classes that were declared in the pending block.
+    pub replaced_classes: Vec<ReplacedClass>,
 }

--- a/crates/papyrus_execution/src/state_reader.rs
+++ b/crates/papyrus_execution/src/state_reader.rs
@@ -48,20 +48,21 @@ impl BlockifierStateReader for ExecutionStateReader {
 
     // Returns the default value if the contract address is not found.
     fn get_nonce_at(&mut self, contract_address: ContractAddress) -> StateResult<Nonce> {
-        Ok(self
-            .storage_reader
-            .begin_ro_txn()
-            .map_err(storage_err_to_state_err)?
-            .get_state_reader()
-            .map_err(storage_err_to_state_err)?
-            .get_nonce_at(self.state_number, &contract_address)
-            .map_err(storage_err_to_state_err)?
-            .unwrap_or_default())
+        Ok(execution_utils::get_nonce_at(
+            &self.storage_reader,
+            self.state_number,
+            self.maybe_pending_state_diff
+                .as_ref()
+                .map(|pending_state_diff| &pending_state_diff.nonces),
+            contract_address,
+        )
+        .map_err(storage_err_to_state_err)?
+        .unwrap_or_default())
     }
 
     // Returns the default value if the contract address is not found.
     fn get_class_hash_at(&mut self, contract_address: ContractAddress) -> StateResult<ClassHash> {
-        execution_utils::get_class_hash_at(
+        Ok(execution_utils::get_class_hash_at(
             &self.storage_reader,
             self.state_number,
             self.maybe_pending_state_diff
@@ -69,8 +70,8 @@ impl BlockifierStateReader for ExecutionStateReader {
                 .map(|pending_state_diff| &pending_state_diff.deployed_contracts),
             contract_address,
         )
-        .map_err(storage_err_to_state_err)
-        .map(|maybe_class_hash| maybe_class_hash.unwrap_or_default())
+        .map_err(storage_err_to_state_err)?
+        .unwrap_or_default())
     }
 
     fn get_compiled_contract_class(

--- a/crates/papyrus_execution/src/state_reader.rs
+++ b/crates/papyrus_execution/src/state_reader.rs
@@ -5,6 +5,7 @@ mod state_reader_test;
 use blockifier::execution::contract_class::ContractClass as BlockifierContractClass;
 use blockifier::state::errors::StateError;
 use blockifier::state::state_api::{StateReader as BlockifierStateReader, StateResult};
+use papyrus_common::pending_classes::PendingClasses;
 use papyrus_storage::state::StateStorageReader;
 use papyrus_storage::{StorageError, StorageReader};
 use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
@@ -12,11 +13,14 @@ use starknet_api::hash::StarkFelt;
 use starknet_api::state::{StateNumber, StorageKey};
 
 use crate::execution_utils::{get_contract_class, ExecutionUtilsError};
+use crate::objects::PendingStateDiff;
 
 /// A view into the state at a specific state number.
 pub struct ExecutionStateReader {
     pub storage_reader: StorageReader,
     pub state_number: StateNumber,
+    pub maybe_pending_state_diff: Option<PendingStateDiff>,
+    pub maybe_pending_classes: Option<PendingClasses>,
 }
 
 impl BlockifierStateReader for ExecutionStateReader {

--- a/crates/papyrus_execution/src/state_reader.rs
+++ b/crates/papyrus_execution/src/state_reader.rs
@@ -57,15 +57,16 @@ impl BlockifierStateReader for ExecutionStateReader {
 
     // Returns the default value if the contract address is not found.
     fn get_class_hash_at(&mut self, contract_address: ContractAddress) -> StateResult<ClassHash> {
-        Ok(self
-            .storage_reader
-            .begin_ro_txn()
-            .map_err(storage_err_to_state_err)?
-            .get_state_reader()
-            .map_err(storage_err_to_state_err)?
-            .get_class_hash_at(self.state_number, &contract_address)
-            .map_err(storage_err_to_state_err)?
-            .unwrap_or_default())
+        execution_utils::get_class_hash_at(
+            &self.storage_reader,
+            self.state_number,
+            self.maybe_pending_state_diff
+                .as_ref()
+                .map(|pending_state_diff| &pending_state_diff.deployed_contracts),
+            contract_address,
+        )
+        .map_err(storage_err_to_state_err)
+        .map(|maybe_class_hash| maybe_class_hash.unwrap_or_default())
     }
 
     fn get_compiled_contract_class(

--- a/crates/papyrus_execution/src/state_reader_test.rs
+++ b/crates/papyrus_execution/src/state_reader_test.rs
@@ -6,7 +6,7 @@ use blockifier::execution::contract_class::{
 use blockifier::state::errors::StateError;
 use blockifier::state::state_api::StateReader;
 use indexmap::{indexmap, IndexMap};
-use papyrus_common::state::StorageEntry;
+use papyrus_common::state::{DeployedContract, StorageEntry};
 use papyrus_storage::body::BodyStorageWriter;
 use papyrus_storage::compiled_class::CasmStorageWriter;
 use papyrus_storage::header::HeaderStorageWriter;
@@ -45,6 +45,7 @@ fn read_state() {
 
     let address2 = ContractAddress(patricia_key!("0x123"));
     let storage_value2 = stark_felt!(999_u128);
+    let class_hash2 = ClassHash(1234u128.into());
 
     storage_writer
         .begin_rw_txn()
@@ -166,10 +167,12 @@ fn read_state() {
             address0 => vec![StorageEntry{key: storage_key0, value: storage_value1}],
             address2 => vec![StorageEntry{key: storage_key0, value: storage_value2}],
         ),
+        deployed_contracts: vec![DeployedContract { address: address2, class_hash: class_hash2 }],
         ..Default::default()
     });
     assert_eq!(state_reader2.get_storage_at(address0, storage_key0).unwrap(), storage_value1);
     assert_eq!(state_reader2.get_storage_at(address2, storage_key0).unwrap(), storage_value2);
+    assert_eq!(state_reader2.get_class_hash_at(address2).unwrap(), class_hash2);
 }
 
 // Make sure we have the arbitrary precision feature of serde_json.

--- a/crates/papyrus_execution/src/state_reader_test.rs
+++ b/crates/papyrus_execution/src/state_reader_test.rs
@@ -108,6 +108,8 @@ fn read_state() {
     let mut state_reader0 = ExecutionStateReader {
         storage_reader: storage_reader.clone(),
         state_number: state_number0,
+        maybe_pending_state_diff: None,
+        maybe_pending_classes: None,
     };
     let storage_after_block_0 =
         state_reader0.get_storage_at(address0, StorageKey(patricia_key!("0x0"))).unwrap();
@@ -127,6 +129,8 @@ fn read_state() {
     let mut state_reader1 = ExecutionStateReader {
         storage_reader: storage_reader.clone(),
         state_number: state_number1,
+        maybe_pending_state_diff: None,
+        maybe_pending_classes: None,
     };
     let storage_after_block_1 =
         state_reader1.get_storage_at(address0, StorageKey(patricia_key!("0x0"))).unwrap();
@@ -141,7 +145,12 @@ fn read_state() {
     assert_eq!(compiled_contract_class_after_block_1, expected_class);
 
     let state_number2 = StateNumber::right_after_block(BlockNumber(2));
-    let mut state_reader2 = ExecutionStateReader { storage_reader, state_number: state_number2 };
+    let mut state_reader2 = ExecutionStateReader {
+        storage_reader,
+        state_number: state_number2,
+        maybe_pending_state_diff: None,
+        maybe_pending_classes: None,
+    };
     let nonce_after_block_2 = state_reader2.get_nonce_at(address0).unwrap();
     assert_eq!(nonce_after_block_2, Nonce(stark_felt!(1_u128)));
 }

--- a/crates/papyrus_execution/src/state_reader_test.rs
+++ b/crates/papyrus_execution/src/state_reader_test.rs
@@ -46,6 +46,7 @@ fn read_state() {
     let class_hash1 = ClassHash(1u128.into());
     let class1 = get_test_deprecated_contract_class();
     let address1 = ContractAddress(patricia_key!(DEPRECATED_CONTRACT_ADDRESS));
+    let nonce0 = Nonce(stark_felt!(1_u128));
 
     let address2 = ContractAddress(patricia_key!("0x123"));
     let storage_value2 = stark_felt!(999_u128);
@@ -55,6 +56,7 @@ fn read_state() {
     casm1.bytecode[0] = BigUintAsHex { value: 12345u32.into() };
     let blockifier_casm1 =
         BlockifierContractClass::V1(ContractClassV1::try_from(casm1.clone()).unwrap());
+    let nonce1 = Nonce(stark_felt!(2_u128));
 
     storage_writer
         .begin_rw_txn()
@@ -96,7 +98,7 @@ fn read_state() {
                     class_hash1 => class1,
                 ),
                 nonces: indexmap!(
-                    address0 => Nonce(stark_felt!(1_u128)),
+                    address0 => nonce0,
                     address1 => Nonce::default(),
                 ),
                 replaced_classes: indexmap!(),
@@ -153,7 +155,7 @@ fn read_state() {
     let storage_after_block_1 = state_reader1.get_storage_at(address0, storage_key0).unwrap();
     assert_eq!(storage_after_block_1, storage_value0);
     let nonce_after_block_1 = state_reader1.get_nonce_at(address0).unwrap();
-    assert_eq!(nonce_after_block_1, Nonce(stark_felt!(1_u128)));
+    assert_eq!(nonce_after_block_1, nonce0);
     let class_hash_after_block_1 = state_reader1.get_class_hash_at(address0).unwrap();
     assert_eq!(class_hash_after_block_1, class_hash0);
     let compiled_contract_class_after_block_1 =
@@ -168,7 +170,7 @@ fn read_state() {
         maybe_pending_classes: None,
     };
     let nonce_after_block_2 = state_reader2.get_nonce_at(address0).unwrap();
-    assert_eq!(nonce_after_block_2, Nonce(stark_felt!(1_u128)));
+    assert_eq!(nonce_after_block_2, nonce0);
 
     // Test pending state diff
     state_reader2.maybe_pending_state_diff = Some(PendingStateDiff {
@@ -181,6 +183,9 @@ fn read_state() {
             class_hash: class_hash2,
             compiled_class_hash: compiled_class_hash2,
         }],
+        nonces: indexmap!(
+            address2 => nonce1,
+        ),
         ..Default::default()
     });
     let mut pending_classes = PendingClasses::default();
@@ -195,6 +200,8 @@ fn read_state() {
     assert_eq!(state_reader2.get_compiled_class_hash(class_hash2).unwrap(), compiled_class_hash2);
     assert_eq!(state_reader2.get_compiled_contract_class(&class_hash0).unwrap(), blockifier_casm0);
     assert_eq!(state_reader2.get_compiled_contract_class(&class_hash2).unwrap(), blockifier_casm1);
+    assert_eq!(state_reader2.get_nonce_at(address0).unwrap(), nonce0);
+    assert_eq!(state_reader2.get_nonce_at(address2).unwrap(), nonce1);
 }
 
 // Make sure we have the arbitrary precision feature of serde_json.

--- a/crates/papyrus_execution/src/test_utils.rs
+++ b/crates/papyrus_execution/src/test_utils.rs
@@ -4,6 +4,7 @@ use blockifier::abi::abi_utils::get_storage_var_address;
 use cairo_lang_starknet::casm_contract_class::CasmContractClass;
 use indexmap::indexmap;
 use lazy_static::lazy_static;
+use papyrus_common::pending_classes::PendingClasses;
 use papyrus_storage::body::BodyStorageWriter;
 use papyrus_storage::compiled_class::CasmStorageWriter;
 use papyrus_storage::header::HeaderStorageWriter;
@@ -44,7 +45,7 @@ use starknet_api::{calldata, class_hash, contract_address, patricia_key, stark_f
 use test_utils::read_json_file;
 
 use crate::execution_utils::selector_from_name;
-use crate::objects::TransactionTrace;
+use crate::objects::{PendingStateDiff, TransactionTrace};
 use crate::testing_instances::test_block_execution_config;
 use crate::{simulate_transactions, ExecutableTransactionInput};
 
@@ -174,6 +175,8 @@ pub fn prepare_storage(mut storage_writer: StorageWriter) {
 
 pub fn execute_simulate_transactions(
     storage_reader: StorageReader,
+    maybe_pending_state_diff: Option<PendingStateDiff>,
+    maybe_pending_classes: Option<PendingClasses>,
     txs: Vec<ExecutableTransactionInput>,
     tx_hashes: Option<Vec<TransactionHash>>,
     charge_fee: bool,
@@ -186,6 +189,8 @@ pub fn execute_simulate_transactions(
         tx_hashes,
         &chain_id,
         storage_reader,
+        maybe_pending_state_diff,
+        maybe_pending_classes,
         StateNumber::right_after_block(BlockNumber(0)),
         BlockNumber(1),
         &test_block_execution_config(),

--- a/crates/papyrus_rpc/src/lib.rs
+++ b/crates/papyrus_rpc/src/lib.rs
@@ -8,6 +8,7 @@ mod middleware;
 mod rpc_metrics;
 #[cfg(test)]
 mod rpc_test;
+mod state;
 mod syncing_state;
 #[cfg(test)]
 mod test_utils;

--- a/crates/papyrus_rpc/src/state.rs
+++ b/crates/papyrus_rpc/src/state.rs
@@ -1,0 +1,15 @@
+use papyrus_execution::objects::PendingStateDiff;
+use starknet_client::reader::objects::state::StateDiff;
+
+pub(crate) fn client_state_diff_to_execution_state_diff(
+    client_state_diff: StateDiff,
+) -> PendingStateDiff {
+    PendingStateDiff {
+        storage_diffs: client_state_diff.storage_diffs,
+        deployed_contracts: client_state_diff.deployed_contracts,
+        declared_classes: client_state_diff.declared_classes,
+        old_declared_contracts: client_state_diff.old_declared_contracts,
+        nonces: client_state_diff.nonces,
+        replaced_classes: client_state_diff.replaced_classes,
+    }
+}

--- a/crates/papyrus_rpc/src/v0_4/api/api_impl.rs
+++ b/crates/papyrus_rpc/src/v0_4/api/api_impl.rs
@@ -838,6 +838,9 @@ impl JsonRpcV0_4Server for JsonRpcServerV0_4Impl {
         let call_result = tokio::task::spawn_blocking(move || {
             execute_call(
                 reader,
+                // TODO(shahak): Add pending data here.
+                None,
+                None,
                 &chain_id,
                 state_number,
                 block_number,
@@ -940,6 +943,9 @@ impl JsonRpcV0_4Server for JsonRpcServerV0_4Impl {
                 executable_txns,
                 &chain_id,
                 reader,
+                // TODO(shahak): Add pending data here.
+                None,
+                None,
                 state_number,
                 block_number,
                 &block_execution_config,
@@ -993,6 +999,9 @@ impl JsonRpcV0_4Server for JsonRpcServerV0_4Impl {
                 None,
                 &chain_id,
                 reader,
+                // TODO(shahak): Add pending data here.
+                None,
+                None,
                 state_number,
                 block_number,
                 &block_execution_config,
@@ -1082,6 +1091,9 @@ impl JsonRpcV0_4Server for JsonRpcServerV0_4Impl {
                 Some(tx_hashes),
                 &chain_id,
                 reader,
+                // TODO(shahak): Add pending data here.
+                None,
+                None,
                 state_number,
                 block_number,
                 &block_execution_config,
@@ -1164,6 +1176,9 @@ impl JsonRpcV0_4Server for JsonRpcServerV0_4Impl {
                 Some(tx_hashes_clone),
                 &chain_id,
                 reader,
+                // TODO(shahak): Add pending data here.
+                None,
+                None,
                 state_number,
                 block_number,
                 &block_execution_config,

--- a/crates/papyrus_rpc/src/v0_4/api/api_impl.rs
+++ b/crates/papyrus_rpc/src/v0_4/api/api_impl.rs
@@ -9,6 +9,7 @@ use papyrus_common::pending_classes::{PendingClasses, PendingClassesTrait};
 use papyrus_execution::{
     estimate_fee as exec_estimate_fee,
     execute_call,
+    execution_utils,
     simulate_transactions as exec_simulate_transactions,
     ExecutionConfigByBlock,
     ExecutionError,
@@ -41,7 +42,7 @@ use starknet_client::reader::objects::pending_data::{
     PendingBlock,
     PendingStateUpdate as ClientPendingStateUpdate,
 };
-use starknet_client::reader::{DeployedContract, PendingData, StorageEntry};
+use starknet_client::reader::{DeployedContract, PendingData};
 use starknet_client::writer::{StarknetWriter, WriterClientError};
 use starknet_client::ClientError;
 use tokio::sync::RwLock;
@@ -257,43 +258,40 @@ impl JsonRpcV0_4Server for JsonRpcServerV0_4Impl {
         &self,
         contract_address: ContractAddress,
         key: StorageKey,
-        block_id: BlockId,
+        mut block_id: BlockId,
     ) -> RpcResult<StarkFelt> {
-        let block_id = if let BlockId::Tag(Tag::Pending) = block_id {
-            let pending_storage_diffs = read_pending_data(&self.pending_data, &self.storage_reader)
-                .await?
-                .state_update
-                .state_diff
-                .storage_diffs;
-            if let Some(storage_entries) = pending_storage_diffs.get(&contract_address) {
-                // iterating in reverse to get the latest value.
-                for StorageEntry { key: other_key, value } in storage_entries.iter().rev() {
-                    if key == *other_key {
-                        return Ok(*value);
-                    }
-                }
-            }
-            BlockId::Tag(Tag::Latest)
-        } else {
-            block_id
-        };
+        let maybe_pending_data = get_pending_data_if_block_id_is_pending(
+            &mut block_id,
+            &self.pending_data,
+            &self.storage_reader,
+        )
+        .await?;
+        let maybe_pending_storage_diffs = maybe_pending_data
+            .map(|pending_data| pending_data.state_update.state_diff.storage_diffs);
 
         let txn = self.storage_reader.begin_ro_txn().map_err(internal_server_error)?;
 
         // Check that the block is valid and get the state number.
         let block_number = get_block_number(&txn, block_id)?;
-        let state = StateNumber::right_after_block(block_number);
-        let state_reader = txn.get_state_reader().map_err(internal_server_error)?;
+        let state_number = StateNumber::right_after_block(block_number);
+        let res = execution_utils::get_storage_at(
+            &self.storage_reader,
+            state_number,
+            maybe_pending_storage_diffs.as_ref(),
+            contract_address,
+            key,
+        )
+        .map_err(internal_server_error)?;
 
-        let res = state_reader
-            .get_storage_at(state, &contract_address, &key)
-            .map_err(internal_server_error)?;
+        // If the contract is not deployed, res will be 0. Checking if that's the case so that
+        // we'll return an error instead.
         // Contract address 0x1 is a special address, it stores the block
         // hashes. Contracts are not deployed to this address.
         if res == StarkFelt::default() && contract_address != *BLOCK_HASH_TABLE_ADDRESS {
             // check if the contract exists
-            state_reader
-                .get_class_hash_at(state, &contract_address)
+            txn.get_state_reader()
+                .map_err(internal_server_error)?
+                .get_class_hash_at(state_number, &contract_address)
                 .map_err(internal_server_error)?
                 .ok_or_else(|| ErrorObjectOwned::from(CONTRACT_NOT_FOUND))?;
         }
@@ -1236,6 +1234,18 @@ async fn read_pending_data(
             },
         })
     }
+}
+
+async fn get_pending_data_if_block_id_is_pending(
+    block_id: &mut BlockId,
+    pending_data: &Arc<RwLock<PendingData>>,
+    storage_reader: &StorageReader,
+) -> RpcResult<Option<PendingData>> {
+    let BlockId::Tag(Tag::Pending) = block_id else {
+        return Ok(None);
+    };
+    *block_id = BlockId::Tag(Tag::Latest);
+    Ok(Some(read_pending_data(pending_data, storage_reader).await?))
 }
 
 fn do_event_keys_match_filter(event_content: &EventContent, filter: &EventFilter) -> bool {

--- a/crates/papyrus_rpc/src/v0_5/api/api_impl.rs
+++ b/crates/papyrus_rpc/src/v0_5/api/api_impl.rs
@@ -881,6 +881,9 @@ impl JsonRpcServer for JsonRpcServerV0_5Impl {
         let call_result = tokio::task::spawn_blocking(move || {
             execute_call(
                 reader,
+                // TODO(shahak): Add pending data here.
+                None,
+                None,
                 &chain_id,
                 state_number,
                 block_number,
@@ -983,6 +986,9 @@ impl JsonRpcServer for JsonRpcServerV0_5Impl {
                 executable_txns,
                 &chain_id,
                 reader,
+                // TODO(shahak): Add pending data here.
+                None,
+                None,
                 state_number,
                 block_number,
                 &block_execution_config,
@@ -1036,6 +1042,9 @@ impl JsonRpcServer for JsonRpcServerV0_5Impl {
                 None,
                 &chain_id,
                 reader,
+                // TODO(shahak): Add pending data here.
+                None,
+                None,
                 state_number,
                 block_number,
                 &block_execution_config,
@@ -1125,6 +1134,9 @@ impl JsonRpcServer for JsonRpcServerV0_5Impl {
                 Some(tx_hashes),
                 &chain_id,
                 reader,
+                // TODO(shahak): Add pending data here.
+                None,
+                None,
                 state_number,
                 block_number,
                 &block_execution_config,
@@ -1207,6 +1219,9 @@ impl JsonRpcServer for JsonRpcServerV0_5Impl {
                 Some(tx_hashes_clone),
                 &chain_id,
                 reader,
+                // TODO(shahak): Add pending data here.
+                None,
+                None,
                 state_number,
                 block_number,
                 &block_execution_config,

--- a/crates/starknet_client/src/reader/objects/state.rs
+++ b/crates/starknet_client/src/reader/objects/state.rs
@@ -1,11 +1,17 @@
 use std::collections::HashMap;
 
 use indexmap::IndexMap;
+pub use papyrus_common::state::{
+    DeclaredClassHashEntry,
+    DeployedContract,
+    ReplacedClass,
+    StorageEntry,
+};
 use serde::{Deserialize, Serialize};
 use starknet_api::block::BlockHash;
-use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, GlobalRoot, Nonce};
+use starknet_api::core::{ClassHash, ContractAddress, GlobalRoot, Nonce};
 use starknet_api::hash::StarkFelt;
-use starknet_api::state::{EntryPoint, EntryPointType, StorageKey};
+use starknet_api::state::{EntryPoint, EntryPointType};
 
 /// A state update derived from a single block as returned by the starknet gateway.
 #[derive(Debug, Default, Deserialize, Serialize, Clone, Eq, PartialEq)]
@@ -48,20 +54,6 @@ impl StateDiff {
     }
 }
 
-/// A deployed contract in StarkNet.
-#[derive(Debug, Default, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord)]
-pub struct DeployedContract {
-    pub address: ContractAddress,
-    pub class_hash: ClassHash,
-}
-
-/// A storage entry in a contract.
-#[derive(Debug, Default, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord)]
-pub struct StorageEntry {
-    pub key: StorageKey,
-    pub value: StarkFelt,
-}
-
 #[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
 pub struct ContractClass {
     pub sierra_program: Vec<StarkFelt>,
@@ -78,17 +70,4 @@ impl From<ContractClass> for starknet_api::state::ContractClass {
             abi: class.abi,
         }
     }
-}
-
-/// A mapping from class hash to the compiled class hash.
-#[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
-pub struct DeclaredClassHashEntry {
-    pub class_hash: ClassHash,
-    pub compiled_class_hash: CompiledClassHash,
-}
-
-#[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
-pub struct ReplacedClass {
-    pub address: ContractAddress,
-    pub class_hash: ClassHash,
 }


### PR DESCRIPTION
- refactor(starknet_client): move small structs of StateDiff to common (#1381)
- feat(execution): add pending members to ExecutionStateReader (#1386)
- feat(execution): pending support for ExecutionStateReader::get_storage_at (#1407)
- feat(execution): pending support for ExecutionStateReader::get_class_hash_at (#1410)
- feat(execution): pending support for ExecutionStateReader::get_compiled_class_hash_at (#1414)
- feat(execution): pending support for ExecutionStateReader::get_compiled_contract_class (#1418)
- feat(execution): pending support for ExecutionStateReader::get_nonce (#1420)
- fix(execution): get_compiled_contract_class looks for pending deprecated classes (#1426)
- fix(execution): verify_contract_exists looks at pending as well (#1425)
- feat(JSON-RPC): add support for pending to call (#1427)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1428)
<!-- Reviewable:end -->
