### PR TITLE
unneccessary "\" in the api-request example of the README.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -208,7 +208,7 @@ See the API specification at the https://github.com/starkware-libs/starknet-spec
 [source,bash]
 ----
 curl --location '<node_path>/rpc/<starknet-rpc-version-id>' --header 'Content-Type: application/json'\
- --data '\{"jsonrpc":"2.0","id":0,"method":"<method>"}'
+ --data '{"jsonrpc":"2.0","id":0,"method":"<method>"}'
 ----
 
 For example, to send a request calling the `starknet_blockHashAndNumber` method, using the 0.4.0 version of the API where `<node_path>` is `localhost:8080`, use the following command:
@@ -216,7 +216,7 @@ For example, to send a request calling the `starknet_blockHashAndNumber` method,
 [source,bash]
 ----
 curl --location 'localhost:8080/rpc/v0_4_0' --header 'Content-Type: application/json'\ 
- --data '\{"jsonrpc":"2.0","id":0,"method":"starknet_blockHashAndNumber"}'
+ --data '{"jsonrpc":"2.0","id":0,"method":"starknet_blockHashAndNumber"}'
 ----
 
 == JSON RPC API endpoints


### PR DESCRIPTION
Removed the "\\" from the api-request examples.
eg here, the one after the `--data`, before the curly braces.
`curl --location 'localhost:8080/rpc/v0_4_0' --header 'Content-Type: application/json'\
 --data '\{"jsonrpc":"2.0","id":0,"method":"starknet_blockHashAndNumber"}'`

If not doing this, papyrus will not recognize the request, but do `WARN connection: HTTP serve connection failed hyper::Error(User(Service), Malformed)` in the logs.

## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

papyrus shows a warning in the logs about a malformed http request.
`WARN connection: HTTP serve connection failed hyper::Error(User(Service), Malformed) remote_addr=127.0.0.1:56090 conn_id=0`

and no data is being returned to the requester


## What is the new behavior?

no warning, and proper return of expected json data


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1478)
<!-- Reviewable:end -->
