### PR TITLE
test(JSON-RPC): test params spec of write api methods

### DIFF
--- a/crates/papyrus_rpc/src/test_utils.rs
+++ b/crates/papyrus_rpc/src/test_utils.rs
@@ -438,11 +438,11 @@ pub fn get_method_names_from_spec(version_id: &VersionId) -> Vec<String> {
 
 // We implement this trait because `Serialize` and `Clone` are not object safe. For more info see
 // https://doc.rust-lang.org/reference/items/traits.html#object-safety
-pub trait SerializeJsonValue {
+pub trait SerializeJsonValue: Send {
     fn to_json_value(&self) -> Result<Value, serde_json::Error>;
 }
 
-impl<T: Serialize + Clone> SerializeJsonValue for T {
+impl<T: Serialize + Clone + Send> SerializeJsonValue for T {
     fn to_json_value(&self) -> Result<Value, serde_json::Error> {
         serde_json::to_value(self.clone())
     }


### PR DESCRIPTION
- fix(JSON-RPC): validate the type of transaction in write api methods
- fix(JSON-RPC): validate that the version field of transaction matches
- test(JSON-RPC): test params spec of write api methods

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1543)
<!-- Reviewable:end -->
