### PR TITLE
fix(network): add dial error support to handler

### DIFF
--- a/crates/papyrus_network/src/streamed_data_protocol/behaviour.rs
+++ b/crates/papyrus_network/src/streamed_data_protocol/behaviour.rs
@@ -69,6 +69,13 @@ impl<Query: QueryBound, Data: DataBound> From<GenericEvent<Query, Data, HandlerS
                 session_id,
                 error: HandlerSessionError::IOError(error),
             } => Self::SessionFailed { session_id, error: SessionError::IOError(error) },
+            GenericEvent::SessionFailed {
+                session_id,
+                error: HandlerSessionError::RemoteDoesntSupportProtocol { protocol_name },
+            } => Self::SessionFailed {
+                session_id,
+                error: SessionError::RemoteDoesntSupportProtocol { protocol_name },
+            },
             GenericEvent::SessionClosedByRequest { session_id } => {
                 Self::SessionClosedByRequest { session_id }
             }


### PR DESCRIPTION
- feat(network): add block messages through protobuf (#1116)
- feat(network): add read_message and write_message (#1121)
- feat(network): add RequestProtocol and ResponseProtocol (#1122)
- feat(network): add get_blocks::Handler with simple test (#1123)
- feat(network): add db executor trait (#1145)
- feat(network): add Behaviour that only sends requests to handler (#1138)
- fix(network): nake behaviour generic (#1152)
- refactor(network): rename get_blocks to streamed_data_protocol (#1154)
- feat(network): add methods to finish sessions without impl (#1158)
- feat(network): create trait aliases for Query and Data (#1166)
- fix(network): unite clippy.toml with .clippy.toml
- feat(network): protocols return the IO (#1157)
- feat(network): extract get_connected_stream_futures to test utils (#1167)
- test(network): add create_swarm function (#1176)
- feat(network): add handler with unimplemented
- test(network): extract hardcoded_responses to test_utils and rename to hardcoded_data (#1186)
- feat(network): add InboundSession struct (#1187)
- test(network): change get_connected_streams to return Stream (#1177)
- feat(network): implement inbound session in handler (#1189)
- chore(network): uncomment behaviour (#1206)
- feat(network): add generic event common to behaviour and handler (#1207)
- feat(network): add outbound sessions to handler (#1208)
- fix(network): read_message returns None if EOF instead of empty message (#1212)
- feat(network): add support to finishing outbound session (#1215)
- feat(network): add OutboundSessionClosedByPeer event (#1216)
- fix(network): close the stream when finishing an inbound session (#1214)
- refactor(network): rename FinishSession to CloseSession (#1218)
- feat(network): restore commented behaviour test (#1220)
- feat(network): add SessionClosedByRequest event (#1221)
- feat(network): convert handler event to behaviour event (#1227)
- feat(network): impl behaviour's close_session (#1229)
- feat(network): remove dial logic from streamed data (#1234)
- fix(network): notify the correct handler
- feat(network): implement on_swarm_event for events we want to ignore
- feat(network): behaviour removes closed or failed sessions
- fix(network): upgrade libp2p to v0.53 (#1520)
- feat(network): session closed by peer event can be for inbound session too (#1509)
- test(network): add StreamHashMap and a way to create a StreamHashMap of swarms (#1539)
- test(network): add flow test for streamed_data (#1508)
- feat(network): make protocol name configurable
- fix(network): add dial error support to handler

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1550)
<!-- Reviewable:end -->
