### PR TITLE
feat(network): impl From<Inbound/OutboundSessionId> for SessionId

### DIFF
--- a/crates/papyrus_network/src/streamed_data_protocol/behaviour.rs
+++ b/crates/papyrus_network/src/streamed_data_protocol/behaviour.rs
@@ -137,7 +137,7 @@ impl<Query: QueryBound, Data: DataBound> Behaviour<Query, Data> {
         self.next_outbound_session_id.value += 1;
 
         self.session_id_to_peer_id_and_connection_id
-            .insert(SessionId::OutboundSessionId(outbound_session_id), (peer_id, connection_id));
+            .insert(outbound_session_id.into(), (peer_id, connection_id));
 
         self.pending_events.push_back(ToSwarm::NotifyHandler {
             peer_id,
@@ -154,9 +154,8 @@ impl<Query: QueryBound, Data: DataBound> Behaviour<Query, Data> {
         data: Data,
         inbound_session_id: InboundSessionId,
     ) -> Result<(), SessionIdNotFoundError> {
-        let (peer_id, connection_id) = self.get_peer_id_and_connection_id_from_session_id(
-            SessionId::InboundSessionId(inbound_session_id),
-        )?;
+        let (peer_id, connection_id) =
+            self.get_peer_id_and_connection_id_from_session_id(inbound_session_id.into())?;
         self.pending_events.push_back(ToSwarm::NotifyHandler {
             peer_id,
             handler: NotifyHandler::One(connection_id),
@@ -244,10 +243,8 @@ impl<Query: QueryBound, Data: DataBound> NetworkBehaviour for Behaviour<Query, D
         let converted_event = event.into();
         match converted_event {
             Event::NewInboundSession { inbound_session_id, .. } => {
-                self.session_id_to_peer_id_and_connection_id.insert(
-                    SessionId::InboundSessionId(inbound_session_id),
-                    (peer_id, connection_id),
-                );
+                self.session_id_to_peer_id_and_connection_id
+                    .insert(inbound_session_id.into(), (peer_id, connection_id));
             }
             Event::SessionFailed { session_id, .. }
             | Event::SessionClosedByRequest { session_id, .. } => {

--- a/crates/papyrus_network/src/streamed_data_protocol/behaviour_test.rs
+++ b/crates/papyrus_network/src/streamed_data_protocol/behaviour_test.rs
@@ -272,7 +272,7 @@ async fn process_inbound_session() {
     }
     validate_no_events(&mut behaviour);
 
-    let session_id = SessionId::InboundSessionId(inbound_session_id);
+    let session_id = inbound_session_id.into();
     behaviour.close_session(session_id).unwrap();
     validate_request_close_session_event(&mut behaviour, &peer_id, session_id).await;
     validate_no_events(&mut behaviour);
@@ -314,7 +314,7 @@ async fn create_and_process_outbound_session() {
     }
     validate_no_events(&mut behaviour);
 
-    let session_id = SessionId::OutboundSessionId(outbound_session_id);
+    let session_id = outbound_session_id.into();
     behaviour.close_session(session_id).unwrap();
     validate_request_close_session_event(&mut behaviour, &peer_id, session_id).await;
     validate_no_events(&mut behaviour);
@@ -340,17 +340,9 @@ async fn outbound_session_closed_by_peer() {
     // Consume the event to create an outbound session.
     behaviour.next().await.unwrap();
 
-    simulate_session_closed_by_peer(
-        &mut behaviour,
-        peer_id,
-        SessionId::OutboundSessionId(outbound_session_id),
-    );
+    simulate_session_closed_by_peer(&mut behaviour, peer_id, outbound_session_id.into());
 
-    validate_session_closed_by_peer_event(
-        &mut behaviour,
-        SessionId::OutboundSessionId(outbound_session_id),
-    )
-    .await;
+    validate_session_closed_by_peer_event(&mut behaviour, outbound_session_id.into()).await;
     validate_no_events(&mut behaviour);
 }
 

--- a/crates/papyrus_network/src/streamed_data_protocol/handler.rs
+++ b/crates/papyrus_network/src/streamed_data_protocol/handler.rs
@@ -113,7 +113,7 @@ impl<Query: QueryBound, Data: DataBound> Handler<Query, Data> {
         if let FinishReason::Error(io_error) = finish_reason {
             pending_events.push_back(ConnectionHandlerEvent::NotifyBehaviour(
                 ToBehaviourEvent::SessionFailed {
-                    session_id: SessionId::InboundSessionId(inbound_session_id),
+                    session_id: inbound_session_id.into(),
                     error: SessionError::IOError(io_error),
                 },
             ));
@@ -256,7 +256,7 @@ impl<Query: QueryBound, Data: DataBound> ConnectionHandler for Handler<Query, Da
                 self.inbound_sessions_marked_to_end.insert(inbound_session_id);
                 self.pending_events.push_back(ConnectionHandlerEvent::NotifyBehaviour(
                     ToBehaviourEvent::SessionClosedByRequest {
-                        session_id: SessionId::InboundSessionId(inbound_session_id),
+                        session_id: inbound_session_id.into(),
                     },
                 ));
             }
@@ -266,7 +266,7 @@ impl<Query: QueryBound, Data: DataBound> ConnectionHandler for Handler<Query, Da
                 self.id_to_outbound_session.remove(&outbound_session_id);
                 self.pending_events.push_back(ConnectionHandlerEvent::NotifyBehaviour(
                     ToBehaviourEvent::SessionClosedByRequest {
-                        session_id: SessionId::OutboundSessionId(outbound_session_id),
+                        session_id: outbound_session_id.into(),
                     },
                 ));
             }
@@ -341,7 +341,7 @@ impl<Query: QueryBound, Data: DataBound> ConnectionHandler for Handler<Query, Da
                 };
                 self.pending_events.push_back(ConnectionHandlerEvent::NotifyBehaviour(
                     ToBehaviourEvent::SessionFailed {
-                        session_id: SessionId::OutboundSessionId(outbound_session_id),
+                        session_id: outbound_session_id.into(),
                         error: session_error,
                     },
                 ));

--- a/crates/papyrus_network/src/streamed_data_protocol/handler_test.rs
+++ b/crates/papyrus_network/src/streamed_data_protocol/handler_test.rs
@@ -266,15 +266,8 @@ async fn closed_inbound_session_ignores_behaviour_request_to_send_data() {
     // consume the new inbound session event without reading it.
     handler.next().await;
 
-    simulate_request_to_close_session(
-        &mut handler,
-        SessionId::InboundSessionId(inbound_session_id),
-    );
-    validate_session_closed_by_request_event(
-        &mut handler,
-        SessionId::InboundSessionId(inbound_session_id),
-    )
-    .await;
+    simulate_request_to_close_session(&mut handler, inbound_session_id.into());
+    validate_session_closed_by_request_event(&mut handler, inbound_session_id.into()).await;
 
     let hardcoded_data_vec = hardcoded_data();
     for data in &hardcoded_data_vec {
@@ -349,11 +342,7 @@ async fn process_outbound_session() {
     validate_no_events(&mut handler);
 
     inbound_stream.close().await.unwrap();
-    validate_session_closed_by_peer_event(
-        &mut handler,
-        SessionId::OutboundSessionId(outbound_session_id),
-    )
-    .await;
+    validate_session_closed_by_peer_event(&mut handler, outbound_session_id.into()).await;
 }
 
 // Extracting to a function because two closures have different types.
@@ -369,12 +358,8 @@ async fn test_outbound_session_negotiation_failure(
         PeerId::random(),
     );
     simulate_outbound_negotiation_failed(&mut handler, outbound_session_id, upgrade_error);
-    validate_session_failed_event(
-        &mut handler,
-        SessionId::OutboundSessionId(outbound_session_id),
-        session_error_matcher,
-    )
-    .await;
+    validate_session_failed_event(&mut handler, outbound_session_id.into(), session_error_matcher)
+        .await;
     validate_no_events(&mut handler);
 }
 
@@ -450,15 +435,8 @@ async fn closed_outbound_session_doesnt_emit_events_when_data_is_sent() {
         outbound_session_id,
     );
 
-    simulate_request_to_close_session(
-        &mut handler,
-        SessionId::OutboundSessionId(outbound_session_id),
-    );
-    validate_session_closed_by_request_event(
-        &mut handler,
-        SessionId::OutboundSessionId(outbound_session_id),
-    )
-    .await;
+    simulate_request_to_close_session(&mut handler, outbound_session_id.into());
+    validate_session_closed_by_request_event(&mut handler, outbound_session_id.into()).await;
 
     for data in hardcoded_data() {
         // The handler might have already closed outbound_stream, so we don't unwrap the result

--- a/crates/papyrus_network/src/streamed_data_protocol/mod.rs
+++ b/crates/papyrus_network/src/streamed_data_protocol/mod.rs
@@ -23,11 +23,21 @@ pub struct InboundSessionId {
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-// TODO(shahak) remove allow(dead_code).
-#[allow(dead_code)]
 pub(crate) enum SessionId {
     OutboundSessionId(OutboundSessionId),
     InboundSessionId(InboundSessionId),
+}
+
+impl From<OutboundSessionId> for SessionId {
+    fn from(outbound_session_id: OutboundSessionId) -> Self {
+        Self::OutboundSessionId(outbound_session_id)
+    }
+}
+
+impl From<InboundSessionId> for SessionId {
+    fn from(inbound_session_id: InboundSessionId) -> Self {
+        Self::InboundSessionId(inbound_session_id)
+    }
 }
 
 // This is a workaround for the unstable feature trait aliases
@@ -39,8 +49,6 @@ pub(crate) trait DataBound: Message + 'static + Unpin + Default {}
 impl<T> DataBound for T where T: Message + 'static + Unpin + Default {}
 
 #[derive(Debug)]
-// TODO(shahak) remove allow dead code.
-#[allow(dead_code)]
 pub(crate) enum GenericEvent<Query: QueryBound, Data: DataBound, SessionError> {
     NewInboundSession { query: Query, inbound_session_id: InboundSessionId, peer_id: PeerId },
     ReceivedData { outbound_session_id: OutboundSessionId, data: Data },


### PR DESCRIPTION
- feat(network): add block messages through protobuf (#1116)
- feat(network): add read_message and write_message (#1121)
- feat(network): add RequestProtocol and ResponseProtocol (#1122)
- feat(network): add get_blocks::Handler with simple test (#1123)
- feat(network): add db executor trait (#1145)
- feat(network): add Behaviour that only sends requests to handler (#1138)
- fix(network): nake behaviour generic (#1152)
- refactor(network): rename get_blocks to streamed_data_protocol (#1154)
- feat(network): add methods to finish sessions without impl (#1158)
- feat(network): create trait aliases for Query and Data (#1166)
- fix(network): unite clippy.toml with .clippy.toml
- feat(network): protocols return the IO (#1157)
- feat(network): extract get_connected_stream_futures to test utils (#1167)
- test(network): add create_swarm function (#1176)
- feat(network): add handler with unimplemented
- test(network): extract hardcoded_responses to test_utils and rename to hardcoded_data (#1186)
- feat(network): add InboundSession struct (#1187)
- test(network): change get_connected_streams to return Stream (#1177)
- feat(network): implement inbound session in handler (#1189)
- chore(network): uncomment behaviour (#1206)
- feat(network): add generic event common to behaviour and handler (#1207)
- feat(network): add outbound sessions to handler (#1208)
- fix(network): read_message returns None if EOF instead of empty message (#1212)
- feat(network): add support to finishing outbound session (#1215)
- feat(network): add OutboundSessionClosedByPeer event (#1216)
- fix(network): close the stream when finishing an inbound session (#1214)
- refactor(network): rename FinishSession to CloseSession (#1218)
- feat(network): restore commented behaviour test (#1220)
- feat(network): add SessionClosedByRequest event (#1221)
- feat(network): convert handler event to behaviour event (#1227)
- feat(network): impl behaviour's close_session (#1229)
- feat(network): remove dial logic from streamed data (#1234)
- fix(network): notify the correct handler
- feat(network): implement on_swarm_event for events we want to ignore
- feat(network): behaviour removes closed or failed sessions
- fix(network): upgrade libp2p to v0.53 (#1520)
- feat(network): session closed by peer event can be for inbound session too (#1509)
- test(network): add StreamHashMap and a way to create a StreamHashMap of swarms (#1539)
- test(network): add flow test for streamed_data (#1508)
- feat(network): make protocol name configurable (#1551)
- chore(network): update network version in cargo lock (#1555)
- feat(network): update protobuf to latest version and fix code to match it (#1535)
- fix(network): add dial error support to handler (#1550)
- feat(network): impl From<Inbound/OutboundSessionId> for SessionId

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1558)
<!-- Reviewable:end -->
