### PR TITLE
build(network): close benchmark executable when there's no connection for 10 seconds

### DIFF
--- a/crates/papyrus_network/src/bin/streamed_data_benchmark.rs
+++ b/crates/papyrus_network/src/bin/streamed_data_benchmark.rs
@@ -190,10 +190,12 @@ async fn main() {
     dial_if_requested(&mut swarm, &args);
 
     let mut outbound_session_measurements = HashMap::new();
+    let mut connected_in_the_past = false;
     while let Some(event) = swarm.next().await {
         match event {
             SwarmEvent::ConnectionEstablished { peer_id, .. } => {
                 println!("Connected to a peer!");
+                connected_in_the_past = true;
                 create_outbound_sessions(
                     &mut swarm,
                     peer_id,
@@ -250,6 +252,9 @@ async fn main() {
             _ => {
                 panic!("Unexpected event {:?}", event);
             }
+        }
+        if connected_in_the_past && swarm.network_info().num_peers() == 0 {
+            break;
         }
     }
 }


### PR DESCRIPTION
- build(network): add time from start of session to measurement
- build(network): clean up benchmark code
- build(network): close benchmark executable when there's no connection for 10 seconds

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1620)
<!-- Reviewable:end -->
