### PR TITLE
feat(network): send/read query without length prefix

### DIFF
--- a/crates/papyrus_network/src/messages/mod.rs
+++ b/crates/papyrus_network/src/messages/mod.rs
@@ -7,6 +7,7 @@ pub mod protobuf {
 
 use std::io;
 
+use futures::io::{ReadHalf, WriteHalf};
 use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use prost::Message;
 use prost_types::Timestamp;
@@ -16,21 +17,33 @@ pub const MAX_MESSAGE_SIZE: usize = 1 << 20;
 
 pub async fn write_message<T: Message, Stream: AsyncWrite + Unpin>(
     message: T,
-    mut io: Stream,
+    io: &mut Stream,
 ) -> Result<(), io::Error> {
     let message_vec = message.encode_to_vec();
     // This code is based on write_length_prefixed from libp2p v0.52 which was erased in v0.53.
-    write_usize(&mut io, message_vec.len()).await?;
+    write_usize(io, message_vec.len()).await?;
     io.write_all(&message_vec).await?;
-    io.flush().await?;
+    Ok(())
+}
+
+pub async fn write_message_without_length_prefix<T: Message, Stream: AsyncWrite + Unpin>(
+    message: T,
+    // We require `io` to be WriteHalf<Stream> and not Stream in order to ensure it's not a
+    // reference.
+    // We want to ensure it's not a reference because this function will make it unusable
+    mut io: WriteHalf<Stream>,
+) -> Result<(), io::Error> {
+    let message_vec = message.encode_to_vec();
+    io.write_all(&message_vec).await?;
+    io.close().await?;
     Ok(())
 }
 
 pub async fn read_message<T: Message + Default, Stream: AsyncRead + Unpin>(
-    mut io: Stream,
+    io: &mut Stream,
 ) -> Result<Option<T>, io::Error> {
     // This code is based on read_length_prefixed from libp2p v0.52 which was erased in v0.53.
-    let Some(message_len) = read_usize(&mut io).await? else { return Ok(None) };
+    let Some(message_len) = read_usize(io).await? else { return Ok(None) };
     if message_len > MAX_MESSAGE_SIZE {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -45,10 +58,21 @@ pub async fn read_message<T: Message + Default, Stream: AsyncRead + Unpin>(
     Ok(Some(T::decode(buf.as_slice())?))
 }
 
+pub async fn read_message_without_length_prefix<T: Message + Default, Stream: AsyncRead + Unpin>(
+    // We require `io` to be ReadHalf<Stream> and not Stream in order to ensure it's not a
+    // reference.
+    // We want to ensure it's not a reference because this function will make it unusable
+    mut io: ReadHalf<Stream>,
+) -> Result<T, io::Error> {
+    let mut buf = vec![];
+    io.read_to_end(&mut buf).await?;
+    Ok(T::decode(buf.as_slice())?)
+}
+
 // This code is based on read_varint from libp2p v0.52 which was erased in v0.53. The difference
 // from there is that here we return None if we have EOF before starting to read.
 pub async fn read_usize<Stream: AsyncRead + Unpin>(
-    mut io: Stream,
+    io: &mut Stream,
 ) -> Result<Option<usize>, io::Error> {
     let mut buffer = unsigned_varint::encode::usize_buffer();
     let mut buffer_len = 0;
@@ -81,7 +105,7 @@ pub async fn read_usize<Stream: AsyncRead + Unpin>(
 
 // This code is based on write_varint from libp2p v0.52 which was erased in v0.53.
 pub async fn write_usize<Stream: AsyncWrite + Unpin>(
-    mut io: Stream,
+    io: &mut Stream,
     num: usize,
 ) -> Result<(), io::Error> {
     let mut buffer = usize_buffer();

--- a/crates/papyrus_network/src/streamed_data/handler/inbound_session.rs
+++ b/crates/papyrus_network/src/streamed_data/handler/inbound_session.rs
@@ -6,7 +6,7 @@ use std::task::{Context, Poll, Waker};
 
 use futures::future::BoxFuture;
 use futures::io::WriteHalf;
-use futures::{AsyncReadExt, AsyncWriteExt, FutureExt};
+use futures::{AsyncWriteExt, FutureExt};
 use libp2p::swarm::Stream;
 use replace_with::replace_with_or_abort;
 
@@ -31,11 +31,10 @@ enum WriteMessageTask {
 }
 
 impl<Data: DataBound> InboundSession<Data> {
-    pub fn new(stream: Stream) -> Self {
-        let (_read_half, write_half) = stream.split();
+    pub fn new(write_stream: WriteHalf<Stream>) -> Self {
         Self {
             pending_messages: Default::default(),
-            current_task: WriteMessageTask::Waiting(write_half),
+            current_task: WriteMessageTask::Waiting(write_stream),
             wakers_waiting_for_new_message: Default::default(),
         }
     }
@@ -54,23 +53,23 @@ impl<Data: DataBound> InboundSession<Data> {
 
     pub fn start_closing(&mut self) {
         replace_with_or_abort(&mut self.current_task, |current_task| {
-            let WriteMessageTask::Waiting(mut stream) = current_task else {
+            let WriteMessageTask::Waiting(mut write_stream) = current_task else {
                 panic!("Called start_closing while not waiting.");
             };
-            WriteMessageTask::Closing(async move { stream.close().await }.boxed())
+            WriteMessageTask::Closing(async move { write_stream.close().await }.boxed())
         })
     }
 
     fn handle_waiting(&mut self, cx: &mut Context<'_>) {
         if let Some(data) = self.pending_messages.pop_front() {
             replace_with_or_abort(&mut self.current_task, |current_task| {
-                let WriteMessageTask::Waiting(mut stream) = current_task else {
+                let WriteMessageTask::Waiting(mut write_stream) = current_task else {
                     panic!("Called handle_waiting while not waiting.");
                 };
                 WriteMessageTask::Running(
                     async move {
-                        write_message(data, &mut stream).await?;
-                        Ok(stream)
+                        write_message(data, &mut write_stream).await?;
+                        Ok(write_stream)
                     }
                     .boxed(),
                 )
@@ -86,8 +85,8 @@ impl<Data: DataBound> InboundSession<Data> {
         };
         match fut.poll_unpin(cx) {
             Poll::Pending => None,
-            Poll::Ready(Ok(stream)) => {
-                self.current_task = WriteMessageTask::Waiting(stream);
+            Poll::Ready(Ok(write_stream)) => {
+                self.current_task = WriteMessageTask::Waiting(write_stream);
                 None
             }
             Poll::Ready(Err(io_error)) => Some(FinishReason::Error(io_error)),

--- a/crates/papyrus_network/src/streamed_data/handler_test.rs
+++ b/crates/papyrus_network/src/streamed_data/handler_test.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use assert_matches::assert_matches;
 use futures::task::{Context, Poll};
-use futures::{select, AsyncWriteExt, FutureExt, Stream as StreamTrait, StreamExt};
+use futures::{select, AsyncReadExt, AsyncWriteExt, FutureExt, Stream as StreamTrait, StreamExt};
 use libp2p::swarm::handler::{
     ConnectionEvent,
     DialUpgradeError,
@@ -67,7 +67,7 @@ fn simulate_negotiated_inbound_session_from_swarm<Query: QueryBound, Data: DataB
     inbound_session_id: InboundSessionId,
 ) {
     handler.on_connection_event(ConnectionEvent::FullyNegotiatedInbound(FullyNegotiatedInbound {
-        protocol: (query, inbound_stream),
+        protocol: (query, inbound_stream.split().1),
         info: inbound_session_id,
     }));
 }
@@ -78,7 +78,7 @@ fn simulate_negotiated_outbound_session_from_swarm<Query: QueryBound, Data: Data
     outbound_session_id: OutboundSessionId,
 ) {
     handler.on_connection_event(ConnectionEvent::FullyNegotiatedOutbound(
-        FullyNegotiatedOutbound { protocol: outbound_stream, info: outbound_session_id },
+        FullyNegotiatedOutbound { protocol: outbound_stream.split().0, info: outbound_session_id },
     ));
 }
 

--- a/crates/papyrus_network/src/streamed_data/protocol_test.rs
+++ b/crates/papyrus_network/src/streamed_data/protocol_test.rs
@@ -1,6 +1,3 @@
-use std::io::ErrorKind;
-
-use assert_matches::assert_matches;
 use futures::AsyncWriteExt;
 use libp2p::core::upgrade::{InboundUpgrade, OutboundUpgrade};
 use libp2p::core::UpgradeInfo;
@@ -70,23 +67,6 @@ async fn outbound_sends_invalid_request() {
             // The first element is the length of the message, if we don't write that many bytes
             // after then the message will be invalid.
             write_usize(&mut outbound_stream, 10).await.unwrap();
-            outbound_stream.close().await.unwrap();
-        },
-    );
-}
-
-#[tokio::test]
-async fn outbound_sends_no_request() {
-    let (inbound_stream, mut outbound_stream, _) = get_connected_streams().await;
-    let inbound_protocol = InboundProtocol::<protobuf::BasicMessage>::new(PROTOCOL_NAME);
-
-    tokio::join!(
-        async move {
-            let error =
-                inbound_protocol.upgrade_inbound(inbound_stream, PROTOCOL_NAME).await.unwrap_err();
-            assert_matches!(error.kind(), ErrorKind::UnexpectedEof);
-        },
-        async move {
             outbound_stream.close().await.unwrap();
         },
     );


### PR DESCRIPTION
- revert(network): revert InboundSession checks if outbound closed
- revert(network): outbound session closes its write half upon closing (#1571)
- revert(network): small fixes to revert commit
- feature(network): send/read query without length prefix

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1642)
<!-- Reviewable:end -->
