### PR TITLE
feat(network): drop inbound session when failing to parse query

### DIFF
--- a/crates/papyrus_network/src/block_headers/mod.rs
+++ b/crates/papyrus_network/src/block_headers/mod.rs
@@ -45,7 +45,7 @@ pub enum Event {
         session_id: SessionId,
         session_error: SessionError,
     },
-    ProtobufConversionError(ProtobufConversionError),
+    QueryConversionError(ProtobufConversionError),
     SessionCompletedSuccessfully {
         session_id: SessionId,
     },

--- a/crates/papyrus_network/src/network_manager.rs
+++ b/crates/papyrus_network/src/network_manager.rs
@@ -94,8 +94,9 @@ impl NetworkManager {
                 debug!("Session {session_id:?} failed on {session_error:?}");
                 // TODO: Handle reputation and retry.
             }
-            Event::ProtobufConversionError(_) => {
-                unimplemented!("ProtobufConversionError");
+            Event::QueryConversionError(error) => {
+                debug!("Failed to convert incoming query on {error:?}");
+                // TODO: Consider adding peer_id to event and handling reputation.
             }
             Event::SessionCompletedSuccessfully { session_id } => {
                 debug!("Session completed successfully. session_id: {session_id:?}");

--- a/crates/papyrus_network/src/streamed_data/behaviour.rs
+++ b/crates/papyrus_network/src/streamed_data/behaviour.rs
@@ -120,7 +120,7 @@ pub struct Behaviour<Query: QueryBound, Data: DataBound> {
     session_id_to_peer_id_and_connection_id: HashMap<SessionId, (PeerId, ConnectionId)>,
     next_outbound_session_id: OutboundSessionId,
     next_inbound_session_id: Arc<AtomicUsize>,
-    dropped_outbound_sessions: HashSet<OutboundSessionId>,
+    dropped_sessions: HashSet<SessionId>,
 }
 
 impl<Query: QueryBound, Data: DataBound> PapyrusBehaviour for Behaviour<Query, Data> {
@@ -133,7 +133,7 @@ impl<Query: QueryBound, Data: DataBound> PapyrusBehaviour for Behaviour<Query, D
             session_id_to_peer_id_and_connection_id: Default::default(),
             next_outbound_session_id: Default::default(),
             next_inbound_session_id: Arc::new(Default::default()),
-            dropped_outbound_sessions: Default::default(),
+            dropped_sessions: Default::default(),
         }
     }
 }
@@ -198,17 +198,14 @@ impl<Query: QueryBound, Data: DataBound> Behaviour<Query, Data> {
 
     /// Instruct behaviour to drop outbound session. The session won't emit any events once dropped.
     /// The other peer will receive an IOError on their corresponding inbound session.
-    pub fn drop_outbound_session(
-        &mut self,
-        outbound_session_id: OutboundSessionId,
-    ) -> Result<(), SessionIdNotFoundError> {
+    pub fn drop_session(&mut self, session_id: SessionId) -> Result<(), SessionIdNotFoundError> {
         let (peer_id, connection_id) =
-            self.get_peer_id_and_connection_id_from_session_id(outbound_session_id.into())?;
-        if self.dropped_outbound_sessions.insert(outbound_session_id) {
+            self.get_peer_id_and_connection_id_from_session_id(session_id)?;
+        if self.dropped_sessions.insert(session_id) {
             self.pending_events.push_back(ToSwarm::NotifyHandler {
                 peer_id,
                 handler: NotifyHandler::One(connection_id),
-                event: RequestFromBehaviourEvent::DropOutboundSession { outbound_session_id },
+                event: RequestFromBehaviourEvent::DropSession { session_id },
             });
         }
         Ok(())
@@ -297,16 +294,13 @@ impl<Query: QueryBound, Data: DataBound> NetworkBehaviour for Behaviour<Query, D
                     Event::SessionFailed { session_id, .. }
                     | Event::SessionFinishedSuccessfully { session_id, .. } => {
                         self.session_id_to_peer_id_and_connection_id.remove(&session_id);
-                        if let SessionId::OutboundSessionId(outbound_session_id) = session_id {
-                            let is_dropped =
-                                self.dropped_outbound_sessions.remove(&outbound_session_id);
-                            if is_dropped {
-                                is_event_muted = true;
-                            }
+                        let is_dropped = self.dropped_sessions.remove(&session_id);
+                        if is_dropped {
+                            is_event_muted = true;
                         }
                     }
                     Event::ReceivedData { outbound_session_id, .. } => {
-                        if self.dropped_outbound_sessions.contains(&outbound_session_id) {
+                        if self.dropped_sessions.contains(&outbound_session_id.into()) {
                             is_event_muted = true;
                         }
                     }
@@ -315,8 +309,8 @@ impl<Query: QueryBound, Data: DataBound> NetworkBehaviour for Behaviour<Query, D
                     self.pending_events.push_back(ToSwarm::GenerateEvent(converted_event));
                 }
             }
-            RequestToBehaviourEvent::NotifyOutboundSessionDropped { outbound_session_id } => {
-                self.dropped_outbound_sessions.remove(&outbound_session_id);
+            RequestToBehaviourEvent::NotifySessionDropped { session_id } => {
+                self.dropped_sessions.remove(&session_id);
             }
         }
     }


### PR DESCRIPTION
- revert(network): remove close_outbound_session
- feature(network): drop inbound session when failing to parse query

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1652)
<!-- Reviewable:end -->
