### PR TITLE
feat(network): add ProtobufConversionError to SessionError

### DIFF
--- a/crates/papyrus_network/src/block_headers/behaviour.rs
+++ b/crates/papyrus_network/src/block_headers/behaviour.rs
@@ -36,7 +36,7 @@ pub struct Behaviour {
         protobuf::BlockHeadersRequest,
         protobuf::BlockHeadersResponse,
     >,
-    header_pending_pairing: HashMap<OutboundSessionId, protobuf::BlockHeader>,
+    header_pending_pairing: HashMap<OutboundSessionId, BlockHeader>,
     sessions_pending_termination: HashSet<SessionId>,
 }
 
@@ -200,14 +200,20 @@ trait BehaviourTrait {
                             });
                         }
                     };
-                    let Some(signatures) = sigs.try_into().ok() else {
-                        self.drop_session(outbound_session_id.into());
-                        return Some(Event::SessionFailed {
-                            session_id: outbound_session_id.into(),
-                            session_error: SessionError::IncompatibleDataError,
-                        });
+                    match sigs.try_into() {
+                        Ok(signatures) => {
+                            data_received.push(BlockHeaderData { block_header, signatures })
+                        }
+                        Err(protobuf_conversion_error) => {
+                            self.drop_session(outbound_session_id.into());
+                            return Some(Event::SessionFailed {
+                                session_id: outbound_session_id.into(),
+                                session_error: SessionError::ProtobufConversionError(
+                                    protobuf_conversion_error,
+                                ),
+                            });
+                        }
                     };
-                    data_received.push(BlockHeaderData { block_header, signatures });
                 }
                 protobuf::block_headers_response_part::HeaderMessage::Fin(protobuf::Fin {
                     error: Some(error),
@@ -270,20 +276,17 @@ impl BehaviourTrait for Behaviour {
         outbound_session_id: OutboundSessionId,
     ) -> Result<(), SessionError> {
         self.header_pending_pairing
-            .insert(outbound_session_id, header.clone())
+            .insert(outbound_session_id, header.try_into()?)
             .map(|_| ())
             .xor(Some(()))
-            .ok_or_else(|| SessionError::PairingError)
+            .ok_or(SessionError::PairingError)
     }
 
     fn fetch_header_pending_pairing_with_signature(
         &mut self,
         outbound_session_id: OutboundSessionId,
     ) -> Result<BlockHeader, SessionError> {
-        self.header_pending_pairing
-            .remove(&outbound_session_id)
-            .map(|header| header.try_into().map_err(|_| SessionError::PairingError))
-            .unwrap_or(Err(SessionError::PairingError))
+        self.header_pending_pairing.remove(&outbound_session_id).ok_or(SessionError::PairingError)
     }
 
     fn handle_session_finished(&mut self, session_id: SessionId) -> Option<Event> {

--- a/crates/papyrus_network/src/block_headers/behaviour_test.rs
+++ b/crates/papyrus_network/src/block_headers/behaviour_test.rs
@@ -296,7 +296,7 @@ fn map_streamed_data_behaviour_event_to_own_event_recieve_data_incompatible_data
     };
     let _res_event = behaviour.map_streamed_data_behaviour_event_to_own_event(streamed_data_event);
 
-    // Send bad signature message - should return incompatible data error event
+    // Send bad signature message - should return ProtobufConversionError
     let streamed_data_event: StreamedDataEvent = streamed_data::behaviour::Event::ReceivedData {
         outbound_session_id,
         data: protobuf::BlockHeadersResponse {
@@ -320,7 +320,7 @@ fn map_streamed_data_behaviour_event_to_own_event_recieve_data_incompatible_data
             session_error,
         }) => {
             assert_eq!(session_id, outbound_session_id.into());
-            assert_matches!(session_error, SessionError::IncompatibleDataError)
+            assert_matches!(session_error, SessionError::ProtobufConversionError(ProtobufConversionError::MissingField))
         }
     );
 }

--- a/crates/papyrus_network/src/block_headers/mod.rs
+++ b/crates/papyrus_network/src/block_headers/mod.rs
@@ -15,6 +15,8 @@ pub enum SessionError {
     StreamedData(#[from] streamed_data::behaviour::SessionError),
     #[error("Incompatible data error")]
     IncompatibleDataError,
+    #[error(transparent)]
+    ProtobufConversionError(#[from] ProtobufConversionError),
     #[error("Pairing of header and signature error")]
     PairingError,
     #[error("Session closed unexpectedly")]


### PR DESCRIPTION
- feature(network): drop inbound session when failing to parse query
- feat(network): add ProtobufConversionError to SessionError

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1654)
<!-- Reviewable:end -->
