### PR TITLE
fix(network): remove empty storage diffs when converting to protobuf

### DIFF
--- a/crates/papyrus_network/src/converters/protobuf_conversion/state_diff.rs
+++ b/crates/papyrus_network/src/converters/protobuf_conversion/state_diff.rs
@@ -155,6 +155,9 @@ impl From<ThinStateDiff> for StateDiffsResponseVec {
             });
         }
         for (contract_address, storage_diffs) in value.storage_diffs {
+            if storage_diffs.is_empty() {
+                continue;
+            }
             result.push(protobuf::StateDiffsResponse {
                 state_diff_message: Some(
                     protobuf::state_diffs_response::StateDiffMessage::ContractDiff(


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1818)
<!-- Reviewable:end -->
