### PR TITLE
chore(storage): bump storage version after state_diff_length and receipts_commitment PR

### DIFF
--- a/crates/papyrus_storage/src/lib.rs
+++ b/crates/papyrus_storage/src/lib.rs
@@ -141,7 +141,7 @@ pub const STORAGE_VERSION_STATE: Version = Version { major: 0, minor: 13 };
 /// Major change requires a re-sync, minor change means a versioned value changed an re-sync is not
 /// required.
 /// This version is only checked for storages that store transactions (StorageScope::FullArchive).
-pub const STORAGE_VERSION_BLOCKS: Version = Version { major: 1, minor: 0 };
+pub const STORAGE_VERSION_BLOCKS: Version = Version { major: 1, minor: 1 };
 
 /// Opens a storage and returns a [`StorageReader`] and a [`StorageWriter`].
 pub fn open_storage(


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1827)
<!-- Reviewable:end -->
