### PR TITLE
fix: use append_thin_state_diff in network and execution

### DIFF
--- a/crates/papyrus_execution/src/state_reader_test.rs
+++ b/crates/papyrus_execution/src/state_reader_test.rs
@@ -9,7 +9,7 @@ use blockifier::execution::contract_class::{
 use blockifier::state::errors::StateError;
 use blockifier::state::state_api::StateReader;
 use cairo_lang_utils::bigint::BigUintAsHex;
-use indexmap::{indexmap, IndexMap};
+use indexmap::indexmap;
 use papyrus_common::pending_classes::{ApiContractClass, PendingClasses, PendingClassesTrait};
 use papyrus_common::state::{
     DeclaredClassHashEntry,
@@ -18,6 +18,7 @@ use papyrus_common::state::{
     StorageEntry,
 };
 use papyrus_storage::body::BodyStorageWriter;
+use papyrus_storage::class::ClassStorageWriter;
 use papyrus_storage::compiled_class::CasmStorageWriter;
 use papyrus_storage::header::HeaderStorageWriter;
 use papyrus_storage::state::StateStorageWriter;
@@ -25,7 +26,7 @@ use papyrus_storage::test_utils::get_test_storage;
 use starknet_api::block::{BlockBody, BlockHash, BlockHeader, BlockNumber};
 use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce, PatriciaKey};
 use starknet_api::hash::{StarkFelt, StarkHash};
-use starknet_api::state::{ContractClass, StateDiff, StateNumber, StorageKey};
+use starknet_api::state::{ContractClass, StateNumber, StorageKey, ThinStateDiff};
 use starknet_api::{patricia_key, stark_felt};
 
 use crate::objects::PendingData;
@@ -76,7 +77,9 @@ fn read_state() {
         .unwrap()
         .append_body(BlockNumber(0), BlockBody::default())
         .unwrap()
-        .append_state_diff(BlockNumber(0), StateDiff::default(), IndexMap::new())
+        .append_thin_state_diff(BlockNumber(0), ThinStateDiff::default())
+        .unwrap()
+        .append_classes(BlockNumber(0), &[], &[])
         .unwrap()
         .append_header(
             BlockNumber(1),
@@ -89,9 +92,9 @@ fn read_state() {
         .unwrap()
         .append_body(BlockNumber(1), BlockBody::default())
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             BlockNumber(1),
-            StateDiff {
+            ThinStateDiff {
                 deployed_contracts: indexmap!(
                     address0 => class_hash0,
                     address1 => class_hash1,
@@ -102,21 +105,22 @@ fn read_state() {
                     ),
                 ),
                 declared_classes: indexmap!(
-                    class_hash0 =>
-                    (compiled_class_hash0, class0.clone()),
-                    class_hash5 =>
-                    (compiled_class_hash0, class0.clone())
+                    class_hash0 => compiled_class_hash0,
+                    class_hash5 => compiled_class_hash0,
                 ),
-                deprecated_declared_classes: indexmap!(
-                    class_hash1 => class1.clone(),
-                ),
+                deprecated_declared_classes: vec![class_hash1],
                 nonces: indexmap!(
                     address0 => nonce0,
                     address1 => Nonce::default(),
                 ),
                 replaced_classes: indexmap!(),
             },
-            indexmap!(),
+        )
+        .unwrap()
+        .append_classes(
+            BlockNumber(1),
+            &[(class_hash0, &class0), (class_hash5, &class0)],
+            &[(class_hash1, &class1)],
         )
         .unwrap()
         .append_casm(&class_hash0, &casm0)
@@ -132,7 +136,9 @@ fn read_state() {
         .unwrap()
         .append_body(BlockNumber(2), BlockBody::default())
         .unwrap()
-        .append_state_diff(BlockNumber(2), StateDiff::default(), IndexMap::new())
+        .append_thin_state_diff(BlockNumber(2), ThinStateDiff::default())
+        .unwrap()
+        .append_classes(BlockNumber(2), &[], &[])
         .unwrap()
         .commit()
         .unwrap();

--- a/crates/papyrus_execution/src/test_utils.rs
+++ b/crates/papyrus_execution/src/test_utils.rs
@@ -5,6 +5,7 @@ use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use indexmap::indexmap;
 use lazy_static::lazy_static;
 use papyrus_storage::body::BodyStorageWriter;
+use papyrus_storage::class::ClassStorageWriter;
 use papyrus_storage::compiled_class::CasmStorageWriter;
 use papyrus_storage::header::HeaderStorageWriter;
 use papyrus_storage::state::StateStorageWriter;
@@ -30,7 +31,7 @@ use starknet_api::core::{
 };
 use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContractClass;
 use starknet_api::hash::{StarkFelt, StarkHash};
-use starknet_api::state::{ContractClass, StateDiff, StateNumber};
+use starknet_api::state::{ContractClass, StateNumber, ThinStateDiff};
 use starknet_api::transaction::{
     Calldata,
     DeclareTransactionV0V1,
@@ -121,9 +122,9 @@ pub fn prepare_storage(mut storage_writer: StorageWriter) {
         .unwrap()
         .append_body(BlockNumber(0), BlockBody::default())
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             BlockNumber(0),
-            StateDiff {
+            ThinStateDiff {
                 deployed_contracts: indexmap!(
                     *TEST_ERC20_CONTRACT_ADDRESS => *TEST_ERC20_CONTRACT_CLASS_HASH,
                     *CONTRACT_ADDRESS => class_hash0,
@@ -140,15 +141,14 @@ pub fn prepare_storage(mut storage_writer: StorageWriter) {
                     ),
                 ),
                 declared_classes: indexmap!(
-                    class_hash0 =>
                     // The class is not used in the execution, so it can be default.
-                    (CompiledClassHash::default(), ContractClass::default())
+                    class_hash0 => CompiledClassHash::default()
                 ),
-                deprecated_declared_classes: indexmap!(
-                    *TEST_ERC20_CONTRACT_CLASS_HASH => get_test_erc20_fee_contract_class(),
-                    class_hash1 => get_test_deprecated_contract_class(),
-                    *ACCOUNT_CLASS_HASH => get_test_account_class(),
-                ),
+                deprecated_declared_classes: vec![
+                    *TEST_ERC20_CONTRACT_CLASS_HASH,
+                    class_hash1,
+                    *ACCOUNT_CLASS_HASH,
+                ],
                 nonces: indexmap!(
                     *TEST_ERC20_CONTRACT_ADDRESS => Nonce::default(),
                     *CONTRACT_ADDRESS => Nonce::default(),
@@ -157,7 +157,16 @@ pub fn prepare_storage(mut storage_writer: StorageWriter) {
                 ),
                 replaced_classes: indexmap!(),
             },
-            indexmap!(),
+        )
+        .unwrap()
+        .append_classes(
+            BlockNumber(0),
+            &[(class_hash0, &ContractClass::default())],
+            &[
+                (*TEST_ERC20_CONTRACT_CLASS_HASH, &get_test_erc20_fee_contract_class()),
+                (class_hash1, &get_test_deprecated_contract_class()),
+                (*ACCOUNT_CLASS_HASH, &get_test_account_class()),
+            ],
         )
         .unwrap()
         .append_casm(&class_hash0, &get_test_casm())
@@ -176,7 +185,9 @@ pub fn prepare_storage(mut storage_writer: StorageWriter) {
         .unwrap()
         .append_body(BlockNumber(1), BlockBody::default())
         .unwrap()
-        .append_state_diff(BlockNumber(1), StateDiff::default(), indexmap![])
+        .append_thin_state_diff(BlockNumber(1), ThinStateDiff::default())
+        .unwrap()
+        .append_classes(BlockNumber(1), &[], &[])
         .unwrap()
         .commit()
         .unwrap();

--- a/crates/papyrus_network/src/db_executor/test.rs
+++ b/crates/papyrus_network/src/db_executor/test.rs
@@ -5,14 +5,13 @@ use futures::channel::mpsc::Receiver;
 use futures::future::poll_fn;
 use futures::stream::SelectAll;
 use futures::{FutureExt, StreamExt};
-use indexmap::IndexMap;
 use papyrus_storage::header::{HeaderStorageReader, HeaderStorageWriter};
 use papyrus_storage::state::StateStorageWriter;
 use papyrus_storage::test_utils::get_test_storage;
 use papyrus_storage::StorageWriter;
 use rand::random;
 use starknet_api::block::{BlockHash, BlockHeader, BlockNumber, BlockSignature};
-use starknet_api::state::{StateDiff, ThinStateDiff};
+use starknet_api::state::ThinStateDiff;
 
 use super::Data::BlockHeaderAndSignature;
 use crate::db_executor::{DBExecutor, DBExecutorError, Data, MockFetchBlockDataFromDb, QueryId};
@@ -267,7 +266,7 @@ fn insert_to_storage_test_blocks_up_to(num_of_blocks: u64, storage_writer: &mut 
             // right signatures.
             .append_block_signature(BlockNumber(i), &BlockSignature::default())
             .unwrap()
-            .append_state_diff(BlockNumber(i), StateDiff::default(),IndexMap::new())
+            .append_thin_state_diff(BlockNumber(i), ThinStateDiff::default())
             .unwrap()
             .commit()
             .unwrap();


### PR DESCRIPTION
- fix(storage): revert_state_diff works if there are missing classes
- fix(sync): use append_thin_state_diff in sync
- fix: use append_thin_state_diff in network and execution

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1880)
<!-- Reviewable:end -->
