### PR TITLE
chore(storage): remove append_state_diff

### DIFF
--- a/crates/papyrus_execution/src/state_reader_test.rs
+++ b/crates/papyrus_execution/src/state_reader_test.rs
@@ -9,7 +9,7 @@ use blockifier::execution::contract_class::{
 use blockifier::state::errors::StateError;
 use blockifier::state::state_api::StateReader;
 use cairo_lang_utils::bigint::BigUintAsHex;
-use indexmap::{indexmap, IndexMap};
+use indexmap::indexmap;
 use papyrus_common::pending_classes::{ApiContractClass, PendingClasses, PendingClassesTrait};
 use papyrus_common::state::{
     DeclaredClassHashEntry,
@@ -18,6 +18,7 @@ use papyrus_common::state::{
     StorageEntry,
 };
 use papyrus_storage::body::BodyStorageWriter;
+use papyrus_storage::class::ClassStorageWriter;
 use papyrus_storage::compiled_class::CasmStorageWriter;
 use papyrus_storage::header::HeaderStorageWriter;
 use papyrus_storage::state::StateStorageWriter;
@@ -25,7 +26,7 @@ use papyrus_storage::test_utils::get_test_storage;
 use starknet_api::block::{BlockBody, BlockHash, BlockHeader, BlockNumber};
 use starknet_api::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce, PatriciaKey};
 use starknet_api::hash::{StarkFelt, StarkHash};
-use starknet_api::state::{ContractClass, StateDiff, StateNumber, StorageKey};
+use starknet_api::state::{ContractClass, StateNumber, StorageKey, ThinStateDiff};
 use starknet_api::{patricia_key, stark_felt};
 
 use crate::objects::PendingData;
@@ -76,7 +77,9 @@ fn read_state() {
         .unwrap()
         .append_body(BlockNumber(0), BlockBody::default())
         .unwrap()
-        .append_state_diff(BlockNumber(0), StateDiff::default(), IndexMap::new())
+        .append_thin_state_diff(BlockNumber(0), ThinStateDiff::default())
+        .unwrap()
+        .append_classes(BlockNumber(0), &[], &[])
         .unwrap()
         .append_header(
             BlockNumber(1),
@@ -89,9 +92,9 @@ fn read_state() {
         .unwrap()
         .append_body(BlockNumber(1), BlockBody::default())
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             BlockNumber(1),
-            StateDiff {
+            ThinStateDiff {
                 deployed_contracts: indexmap!(
                     address0 => class_hash0,
                     address1 => class_hash1,
@@ -102,21 +105,22 @@ fn read_state() {
                     ),
                 ),
                 declared_classes: indexmap!(
-                    class_hash0 =>
-                    (compiled_class_hash0, class0.clone()),
-                    class_hash5 =>
-                    (compiled_class_hash0, class0.clone())
+                    class_hash0 => compiled_class_hash0,
+                    class_hash5 => compiled_class_hash0,
                 ),
-                deprecated_declared_classes: indexmap!(
-                    class_hash1 => class1.clone(),
-                ),
+                deprecated_declared_classes: vec![class_hash1],
                 nonces: indexmap!(
                     address0 => nonce0,
                     address1 => Nonce::default(),
                 ),
                 replaced_classes: indexmap!(),
             },
-            indexmap!(),
+        )
+        .unwrap()
+        .append_classes(
+            BlockNumber(1),
+            &[(class_hash0, &class0), (class_hash5, &class0)],
+            &[(class_hash1, &class1)],
         )
         .unwrap()
         .append_casm(&class_hash0, &casm0)
@@ -132,7 +136,9 @@ fn read_state() {
         .unwrap()
         .append_body(BlockNumber(2), BlockBody::default())
         .unwrap()
-        .append_state_diff(BlockNumber(2), StateDiff::default(), IndexMap::new())
+        .append_thin_state_diff(BlockNumber(2), ThinStateDiff::default())
+        .unwrap()
+        .append_classes(BlockNumber(2), &[], &[])
         .unwrap()
         .commit()
         .unwrap();

--- a/crates/papyrus_execution/src/test_utils.rs
+++ b/crates/papyrus_execution/src/test_utils.rs
@@ -5,6 +5,7 @@ use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use indexmap::indexmap;
 use lazy_static::lazy_static;
 use papyrus_storage::body::BodyStorageWriter;
+use papyrus_storage::class::ClassStorageWriter;
 use papyrus_storage::compiled_class::CasmStorageWriter;
 use papyrus_storage::header::HeaderStorageWriter;
 use papyrus_storage::state::StateStorageWriter;
@@ -30,7 +31,7 @@ use starknet_api::core::{
 };
 use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContractClass;
 use starknet_api::hash::{StarkFelt, StarkHash};
-use starknet_api::state::{ContractClass, StateDiff, StateNumber};
+use starknet_api::state::{ContractClass, StateNumber, ThinStateDiff};
 use starknet_api::transaction::{
     Calldata,
     DeclareTransactionV0V1,
@@ -121,9 +122,9 @@ pub fn prepare_storage(mut storage_writer: StorageWriter) {
         .unwrap()
         .append_body(BlockNumber(0), BlockBody::default())
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             BlockNumber(0),
-            StateDiff {
+            ThinStateDiff {
                 deployed_contracts: indexmap!(
                     *TEST_ERC20_CONTRACT_ADDRESS => *TEST_ERC20_CONTRACT_CLASS_HASH,
                     *CONTRACT_ADDRESS => class_hash0,
@@ -140,15 +141,14 @@ pub fn prepare_storage(mut storage_writer: StorageWriter) {
                     ),
                 ),
                 declared_classes: indexmap!(
-                    class_hash0 =>
                     // The class is not used in the execution, so it can be default.
-                    (CompiledClassHash::default(), ContractClass::default())
+                    class_hash0 => CompiledClassHash::default()
                 ),
-                deprecated_declared_classes: indexmap!(
-                    *TEST_ERC20_CONTRACT_CLASS_HASH => get_test_erc20_fee_contract_class(),
-                    class_hash1 => get_test_deprecated_contract_class(),
-                    *ACCOUNT_CLASS_HASH => get_test_account_class(),
-                ),
+                deprecated_declared_classes: vec![
+                    *TEST_ERC20_CONTRACT_CLASS_HASH,
+                    class_hash1,
+                    *ACCOUNT_CLASS_HASH,
+                ],
                 nonces: indexmap!(
                     *TEST_ERC20_CONTRACT_ADDRESS => Nonce::default(),
                     *CONTRACT_ADDRESS => Nonce::default(),
@@ -157,7 +157,16 @@ pub fn prepare_storage(mut storage_writer: StorageWriter) {
                 ),
                 replaced_classes: indexmap!(),
             },
-            indexmap!(),
+        )
+        .unwrap()
+        .append_classes(
+            BlockNumber(0),
+            &[(class_hash0, &ContractClass::default())],
+            &[
+                (*TEST_ERC20_CONTRACT_CLASS_HASH, &get_test_erc20_fee_contract_class()),
+                (class_hash1, &get_test_deprecated_contract_class()),
+                (*ACCOUNT_CLASS_HASH, &get_test_account_class()),
+            ],
         )
         .unwrap()
         .append_casm(&class_hash0, &get_test_casm())
@@ -176,7 +185,9 @@ pub fn prepare_storage(mut storage_writer: StorageWriter) {
         .unwrap()
         .append_body(BlockNumber(1), BlockBody::default())
         .unwrap()
-        .append_state_diff(BlockNumber(1), StateDiff::default(), indexmap![])
+        .append_thin_state_diff(BlockNumber(1), ThinStateDiff::default())
+        .unwrap()
+        .append_classes(BlockNumber(1), &[], &[])
         .unwrap()
         .commit()
         .unwrap();

--- a/crates/papyrus_network/src/db_executor/test.rs
+++ b/crates/papyrus_network/src/db_executor/test.rs
@@ -5,14 +5,13 @@ use futures::channel::mpsc::Receiver;
 use futures::future::poll_fn;
 use futures::stream::SelectAll;
 use futures::{FutureExt, StreamExt};
-use indexmap::IndexMap;
 use papyrus_storage::header::{HeaderStorageReader, HeaderStorageWriter};
 use papyrus_storage::state::StateStorageWriter;
 use papyrus_storage::test_utils::get_test_storage;
 use papyrus_storage::StorageWriter;
 use rand::random;
 use starknet_api::block::{BlockHash, BlockHeader, BlockNumber, BlockSignature};
-use starknet_api::state::{StateDiff, ThinStateDiff};
+use starknet_api::state::ThinStateDiff;
 
 use super::Data::BlockHeaderAndSignature;
 use crate::db_executor::{DBExecutor, DBExecutorError, Data, MockFetchBlockDataFromDb, QueryId};
@@ -267,7 +266,7 @@ fn insert_to_storage_test_blocks_up_to(num_of_blocks: u64, storage_writer: &mut 
             // right signatures.
             .append_block_signature(BlockNumber(i), &BlockSignature::default())
             .unwrap()
-            .append_state_diff(BlockNumber(i), StateDiff::default(),IndexMap::new())
+            .append_thin_state_diff(BlockNumber(i), ThinStateDiff::default())
             .unwrap()
             .commit()
             .unwrap();

--- a/crates/papyrus_rpc/src/rpc_metrics/rpc_metrics_test.rs
+++ b/crates/papyrus_rpc/src/rpc_metrics/rpc_metrics_test.rs
@@ -5,13 +5,14 @@ use jsonrpsee::server::logger::{Logger, TransportProtocol};
 use jsonrpsee::Methods;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use papyrus_storage::body::BodyStorageWriter;
+use papyrus_storage::class::ClassStorageWriter;
 use papyrus_storage::header::HeaderStorageWriter;
 use papyrus_storage::state::StateStorageWriter;
 use papyrus_storage::test_utils::get_test_storage;
 use pretty_assertions::assert_eq;
 use prometheus_parse::Value::Counter;
 use starknet_api::block::{BlockBody, BlockHeader, BlockNumber};
-use starknet_api::state::StateDiff;
+use starknet_api::state::ThinStateDiff;
 use test_utils::{prometheus_is_contained, send_request};
 
 use crate::rpc_metrics::{
@@ -152,7 +153,9 @@ async fn server_metrics() {
         .unwrap()
         .append_body(BlockNumber(0), BlockBody::default())
         .unwrap()
-        .append_state_diff(BlockNumber(0), StateDiff::default(), [].into())
+        .append_thin_state_diff(BlockNumber(0), ThinStateDiff::default())
+        .unwrap()
+        .append_classes(BlockNumber(0), &[], &[])
         .unwrap()
         .commit()
         .unwrap();

--- a/crates/papyrus_rpc/src/v0_4/api/test.rs
+++ b/crates/papyrus_rpc/src/v0_4/api/test.rs
@@ -18,6 +18,7 @@ use papyrus_common::BlockHashAndNumber;
 use papyrus_storage::base_layer::BaseLayerStorageWriter;
 use papyrus_storage::body::events::EventIndex;
 use papyrus_storage::body::{BodyStorageWriter, TransactionIndex};
+use papyrus_storage::class::ClassStorageWriter;
 use papyrus_storage::header::HeaderStorageWriter;
 use papyrus_storage::state::StateStorageWriter;
 use papyrus_storage::test_utils::get_test_storage;
@@ -244,10 +245,9 @@ async fn block_hash_and_number() {
     storage_writer
         .begin_rw_txn()
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             block.header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
         )
         .unwrap()
         .commit()
@@ -306,11 +306,7 @@ async fn block_number() {
     storage_writer
         .begin_rw_txn()
         .unwrap()
-        .append_state_diff(
-            BlockNumber(0),
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
-        )
+        .append_thin_state_diff(BlockNumber(0), starknet_api::state::ThinStateDiff::default())
         .unwrap()
         .commit()
         .unwrap();
@@ -377,10 +373,9 @@ async fn get_block_transaction_count() {
         .unwrap()
         .append_body(block.header.block_number, block.body)
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             block.header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
         )
         .unwrap()
         .commit()
@@ -474,10 +469,9 @@ async fn get_block_w_full_transactions() {
         .unwrap()
         .append_body(block.header.block_number, block.body.clone())
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             block.header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
         )
         .unwrap()
         .commit()
@@ -639,10 +633,9 @@ async fn get_block_w_transaction_hashes() {
         .unwrap()
         .append_body(block.header.block_number, block.body.clone())
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             block.header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
         )
         .unwrap()
         .commit()
@@ -798,28 +791,38 @@ async fn get_class() {
         parent_hash: parent_header.block_hash,
         ..BlockHeader::default()
     };
-    let diff = get_test_state_diff();
+    let (diff, classes, deprecated_classes) =
+        starknet_api::state::ThinStateDiff::from_state_diff(get_test_state_diff());
     storage_writer
         .begin_rw_txn()
         .unwrap()
         .append_header(parent_header.block_number, &parent_header)
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             parent_header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
+        )
+        .unwrap()
+        .append_classes(
+            parent_header.block_number,
+            &classes.iter().map(|(class_hash, class)| (*class_hash, class)).collect::<Vec<_>>(),
+            &deprecated_classes
+                .iter()
+                .map(|(class_hash, deprecated_class)| (*class_hash, deprecated_class))
+                .collect::<Vec<_>>(),
         )
         .unwrap()
         .append_header(header.block_number, &header)
         .unwrap()
-        .append_state_diff(header.block_number, diff.clone(), IndexMap::new())
+        .append_thin_state_diff(header.block_number, diff.clone())
         .unwrap()
         .commit()
         .unwrap();
 
     // Deprecated Class
-    let (class_hash, contract_class) = diff.deprecated_declared_classes.get_index(0).unwrap();
-    let expected_contract_class = contract_class.clone().try_into().unwrap();
+    let class_hash = diff.deprecated_declared_classes[0];
+    let expected_contract_class =
+        deprecated_classes.get(&class_hash).unwrap().clone().try_into().unwrap();
 
     // Get class by block hash.
     call_api_then_assert_and_validate_schema_for_result(
@@ -875,8 +878,7 @@ async fn get_class() {
     .await;
 
     // New Class
-    let (class_hash, (_compiled_class_hash, contract_class)) =
-        diff.declared_classes.get_index(0).unwrap();
+    let (class_hash, contract_class) = classes.get_index(0).unwrap();
     let expected_contract_class = contract_class.clone().into();
 
     // Get class by block hash.
@@ -1076,7 +1078,8 @@ async fn get_class_at() {
         parent_hash: parent_header.block_hash,
         ..BlockHeader::default()
     };
-    let mut diff = get_test_state_diff();
+    let (mut diff, classes, deprecated_classes) =
+        starknet_api::state::ThinStateDiff::from_state_diff(get_test_state_diff());
     // Add a deployed contract with Cairo 1 class.
     let new_class_hash = diff.declared_classes.get_index(0).unwrap().0;
     diff.deployed_contracts.insert(ContractAddress(patricia_key!("0x2")), *new_class_hash);
@@ -1085,15 +1088,23 @@ async fn get_class_at() {
         .unwrap()
         .append_header(parent_header.block_number, &parent_header)
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             parent_header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
+        )
+        .unwrap()
+        .append_classes(
+            parent_header.block_number,
+            &classes.iter().map(|(class_hash, class)| (*class_hash, class)).collect::<Vec<_>>(),
+            &deprecated_classes
+                .iter()
+                .map(|(class_hash, deprecated_class)| (*class_hash, deprecated_class))
+                .collect::<Vec<_>>(),
         )
         .unwrap()
         .append_header(header.block_number, &header)
         .unwrap()
-        .append_state_diff(header.block_number, diff.clone(), IndexMap::new())
+        .append_thin_state_diff(header.block_number, diff.clone())
         .unwrap()
         .commit()
         .unwrap();
@@ -1114,8 +1125,9 @@ async fn get_class_at() {
     pending_classes.write().await.add_class(pending_class_hash, pending_class.clone());
 
     // Deprecated Class
-    let (class_hash, contract_class) = diff.deprecated_declared_classes.get_index(0).unwrap();
-    let expected_contract_class = contract_class.clone().try_into().unwrap();
+    let class_hash = diff.deprecated_declared_classes.last().unwrap();
+    let expected_contract_class =
+        deprecated_classes.get(class_hash).unwrap().clone().try_into().unwrap();
     assert_eq!(diff.deployed_contracts.get_index(0).unwrap().1, class_hash);
     let address = diff.deployed_contracts.get_index(0).unwrap().0;
 
@@ -1144,9 +1156,8 @@ async fn get_class_at() {
     assert_eq!(res, expected_contract_class);
 
     // New Class
-    let (class_hash, (_compiled_hash, contract_class)) =
-        diff.declared_classes.get_index(0).unwrap();
-    let expected_contract_class = contract_class.clone().into();
+    let class_hash = diff.declared_classes.get_index(0).unwrap().0;
+    let expected_contract_class = classes.get(class_hash).unwrap().clone().into();
     assert_eq!(diff.deployed_contracts.get_index(1).unwrap().1, class_hash);
     let address = diff.deployed_contracts.get_index(1).unwrap().0;
 
@@ -1253,14 +1264,15 @@ async fn get_class_hash_at() {
         JsonRpcServerImpl,
     >(None, None, Some(pending_data.clone()), None, None);
     let header = BlockHeader::default();
-    let diff = get_test_state_diff();
+    let diff = starknet_api::state::ThinStateDiff::from(get_test_state_diff());
     storage_writer
         .begin_rw_txn()
         .unwrap()
         .append_header(header.block_number, &header)
         .unwrap()
-        .append_state_diff(header.block_number, diff.clone(), IndexMap::new())
+        .append_thin_state_diff(header.block_number, diff.clone())
         .unwrap()
+        // No need to write the class definitions.
         .commit()
         .unwrap();
 
@@ -1408,13 +1420,13 @@ async fn get_nonce() {
         JsonRpcServerImpl,
     >(None, None, Some(pending_data.clone()), None, None);
     let header = BlockHeader::default();
-    let diff = get_test_state_diff();
+    let diff = starknet_api::state::ThinStateDiff::from(get_test_state_diff());
     storage_writer
         .begin_rw_txn()
         .unwrap()
         .append_header(header.block_number, &header)
         .unwrap()
-        .append_state_diff(header.block_number, diff.clone(), IndexMap::new())
+        .append_thin_state_diff(header.block_number, diff.clone())
         .unwrap()
         .commit()
         .unwrap();
@@ -1545,13 +1557,13 @@ async fn get_storage_at() {
         JsonRpcServerImpl,
     >(None, None, Some(pending_data.clone()), None, None);
     let header = BlockHeader::default();
-    let diff = get_test_state_diff();
+    let diff = starknet_api::state::ThinStateDiff::from(get_test_state_diff());
     storage_writer
         .begin_rw_txn()
         .unwrap()
         .append_header(header.block_number, &header)
         .unwrap()
-        .append_state_diff(header.block_number, diff.clone(), IndexMap::new())
+        .append_thin_state_diff(header.block_number, diff.clone())
         .unwrap()
         .commit()
         .unwrap();
@@ -1885,10 +1897,9 @@ async fn get_transaction_by_block_id_and_index() {
         .unwrap()
         .append_body(block.header.block_number, block.body.clone())
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             block.header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
         )
         .unwrap()
         .commit()
@@ -2015,27 +2026,27 @@ async fn get_state_update() {
         state_root: expected_pending_old_root,
         ..BlockHeader::default()
     };
-    let diff = get_test_state_diff();
+    let diff = starknet_api::state::ThinStateDiff::from(get_test_state_diff());
     storage_writer
         .begin_rw_txn()
         .unwrap()
         .append_header(parent_header.block_number, &parent_header)
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             parent_header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
         )
         .unwrap()
         .append_header(header.block_number, &header)
         .unwrap()
-        .append_state_diff(header.block_number, diff.clone(), IndexMap::new())
+        .append_thin_state_diff(header.block_number, diff.clone())
         .unwrap()
+        // No need to write the class definitions
         .commit()
         .unwrap();
 
     let expected_old_root = parent_header.state_root;
-    let expected_state_diff = ThinStateDiff::from(starknet_api::state::ThinStateDiff::from(diff));
+    let expected_state_diff = ThinStateDiff::from(diff);
     let expected_update = StateUpdate::AcceptedStateUpdate(AcceptedStateUpdate {
         block_hash: header.block_hash,
         new_root: header.state_root,
@@ -2166,7 +2177,7 @@ async fn get_state_update_with_empty_storage_diff() {
     let (module, mut storage_writer) = get_test_rpc_server_and_storage_writer_from_params::<
         JsonRpcServerImpl,
     >(None, None, Some(pending_data.clone()), None, None);
-    let state_diff = starknet_api::state::StateDiff {
+    let state_diff = starknet_api::state::ThinStateDiff {
         storage_diffs: indexmap!(ContractAddress::default() => indexmap![]),
         ..Default::default()
     };
@@ -2175,7 +2186,7 @@ async fn get_state_update_with_empty_storage_diff() {
         .unwrap()
         .append_header(BlockNumber(0), &BlockHeader::default())
         .unwrap()
-        .append_state_diff(BlockNumber(0), state_diff, IndexMap::new())
+        .append_thin_state_diff(BlockNumber(0), state_diff)
         .unwrap()
         .commit()
         .unwrap();
@@ -2345,10 +2356,9 @@ async fn test_get_events(
             .unwrap()
             .append_body(block_number, block.body)
             .unwrap()
-            .append_state_diff(
+            .append_thin_state_diff(
                 block.header.block_number,
-                starknet_api::state::StateDiff::default(),
-                IndexMap::new(),
+                starknet_api::state::ThinStateDiff::default(),
             )
             .unwrap();
     }
@@ -2874,10 +2884,9 @@ async fn get_events_invalid_ct() {
         .unwrap()
         .append_body(block.header.block_number, block.body)
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             block.header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
         )
         .unwrap()
         .commit()
@@ -2931,6 +2940,10 @@ async fn serialize_returns_valid_json() {
         .insert(ContractAddress(patricia_key!("0x2")), ClassHash(stark_felt!("0x2")));
     // TODO(yair): handle replaced classes.
     state_diff.replaced_classes.clear();
+
+    let (thin_state_diff, classes, deprecated_classes) =
+        starknet_api::state::ThinStateDiff::from_state_diff(state_diff.clone());
+
     storage_writer
         .begin_rw_txn()
         .unwrap()
@@ -2938,13 +2951,27 @@ async fn serialize_returns_valid_json() {
         .unwrap()
         .append_body(parent_block.header.block_number, parent_block.body)
         .unwrap()
-        .append_state_diff(parent_block.header.block_number, StateDiff::default(), IndexMap::new())
+        .append_thin_state_diff(
+            parent_block.header.block_number,
+            starknet_api::state::ThinStateDiff::default(),
+        )
+        .unwrap()
+        .append_classes(parent_block.header.block_number, &[], &[])
         .unwrap()
         .append_header(block.header.block_number, &block.header)
         .unwrap()
         .append_body(block.header.block_number, block.body.clone())
         .unwrap()
-        .append_state_diff(block.header.block_number, state_diff.clone(), IndexMap::new())
+        .append_thin_state_diff(block.header.block_number, thin_state_diff)
+        .unwrap()
+        .append_classes(
+            block.header.block_number,
+            &classes.iter().map(|(class_hash, class)| (*class_hash, class)).collect::<Vec<_>>(),
+            &deprecated_classes
+                .iter()
+                .map(|(class_hash, deprecated_class)| (*class_hash, deprecated_class))
+                .collect::<Vec<_>>(),
+        )
         .unwrap()
         .commit()
         .unwrap();
@@ -3104,11 +3131,11 @@ async fn get_deprecated_class_state_mutability() {
         ..Default::default()
     };
 
-    let state_diff = StateDiff {
-        deprecated_declared_classes: IndexMap::from([
-            (ClassHash(stark_felt!("0x0")), class_without_state_mutability),
-            (ClassHash(stark_felt!("0x1")), class_with_state_mutability),
-        ]),
+    let state_diff = starknet_api::state::ThinStateDiff {
+        deprecated_declared_classes: vec![
+            ClassHash(stark_felt!("0x0")),
+            ClassHash(stark_felt!("0x1")),
+        ],
         ..Default::default()
     };
 
@@ -3121,7 +3148,16 @@ async fn get_deprecated_class_state_mutability() {
         .unwrap()
         .append_header(header.block_number, &header)
         .unwrap()
-        .append_state_diff(header.block_number, state_diff, IndexMap::new())
+        .append_thin_state_diff(header.block_number, state_diff)
+        .unwrap()
+        .append_classes(
+            header.block_number,
+            &[],
+            &[
+                (ClassHash(stark_felt!("0x0")), &class_without_state_mutability),
+                (ClassHash(stark_felt!("0x1")), &class_with_state_mutability),
+            ],
+        )
         .unwrap()
         .commit()
         .unwrap();

--- a/crates/papyrus_rpc/src/v0_4/execution_test.rs
+++ b/crates/papyrus_rpc/src/v0_4/execution_test.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use assert_matches::assert_matches;
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
-use indexmap::{indexmap, IndexMap};
+use indexmap::indexmap;
 use jsonrpsee::core::Error;
 use jsonrpsee::RpcModule;
 use lazy_static::lazy_static;
@@ -16,6 +16,7 @@ use papyrus_execution::objects::{CallType, FunctionCall, Retdata, RevertReason};
 use papyrus_execution::testing_instances::get_storage_var_address;
 use papyrus_execution::ExecutableTransactionInput;
 use papyrus_storage::body::BodyStorageWriter;
+use papyrus_storage::class::ClassStorageWriter;
 use papyrus_storage::compiled_class::CasmStorageWriter;
 use papyrus_storage::header::HeaderStorageWriter;
 use papyrus_storage::state::StateStorageWriter;
@@ -46,7 +47,7 @@ use starknet_api::deprecated_contract_class::{
     EntryPointType,
 };
 use starknet_api::hash::{StarkFelt, StarkHash};
-use starknet_api::state::StateDiff;
+use starknet_api::state::ThinStateDiff;
 use starknet_api::transaction::{
     Calldata,
     EventContent,
@@ -701,14 +702,15 @@ async fn trace_block_transactions_regular_and_pending() {
             },
         )
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             BlockNumber(2),
-            StateDiff {
+            ThinStateDiff {
                 nonces: indexmap!(*ACCOUNT_ADDRESS => Nonce(stark_felt!(2_u128))),
                 ..Default::default()
             },
-            IndexMap::new(),
         )
+        .unwrap()
+        .append_classes(BlockNumber(2), &[], &[])
         .unwrap()
         .commit()
         .unwrap();
@@ -898,14 +900,15 @@ async fn trace_block_transactions_and_trace_transaction_execution_context() {
             },
         )
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             BlockNumber(2),
-            StateDiff {
+            ThinStateDiff {
                 nonces: indexmap!(*ACCOUNT_ADDRESS => Nonce(stark_felt!(2_u128))),
                 ..Default::default()
             },
-            IndexMap::new(),
         )
+        .unwrap()
+        .append_classes(BlockNumber(2), &[], &[])
         .unwrap()
         .commit()
         .unwrap();
@@ -1434,9 +1437,9 @@ fn prepare_storage_for_execution(mut storage_writer: StorageWriter) -> StorageWr
         .unwrap()
         .append_body(BlockNumber(0), BlockBody::default())
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             BlockNumber(0),
-            StateDiff {
+            ThinStateDiff {
                 deployed_contracts: indexmap!(
                     *DEPRECATED_CONTRACT_ADDRESS => class_hash1,
                     *CONTRACT_ADDRESS => class_hash2,
@@ -1451,15 +1454,12 @@ fn prepare_storage_for_execution(mut storage_writer: StorageWriter) -> StorageWr
                         minter_var_address => *ACCOUNT_ADDRESS.0.key()
                     ),
                 ),
-                declared_classes: indexmap!(
-                    class_hash2 =>
-                    (compiled_class_hash, class2)
-                ),
-                deprecated_declared_classes: indexmap!(
-                    class_hash1 => class1,
-                    *ACCOUNT_CLASS_HASH => account_class,
-                    *TEST_ERC20_CONTRACT_CLASS_HASH => fee_contract_class,
-                ),
+                declared_classes: indexmap!(class_hash2 => compiled_class_hash),
+                deprecated_declared_classes: vec![
+                    class_hash1,
+                    *ACCOUNT_CLASS_HASH,
+                    *TEST_ERC20_CONTRACT_CLASS_HASH,
+                ],
                 nonces: indexmap!(
                     *TEST_ERC20_CONTRACT_ADDRESS => Nonce::default(),
                     *CONTRACT_ADDRESS => Nonce::default(),
@@ -1468,7 +1468,16 @@ fn prepare_storage_for_execution(mut storage_writer: StorageWriter) -> StorageWr
                 ),
                 replaced_classes: indexmap!(),
             },
-            indexmap!(),
+        )
+        .unwrap()
+        .append_classes(
+            BlockNumber(0),
+            &[(class_hash2, &class2)],
+            &[
+                (class_hash1, &class1),
+                (*ACCOUNT_CLASS_HASH, &account_class),
+                (*TEST_ERC20_CONTRACT_CLASS_HASH, &fee_contract_class),
+            ],
         )
         .unwrap()
         .append_casm(&class_hash2, &casm)
@@ -1487,7 +1496,9 @@ fn prepare_storage_for_execution(mut storage_writer: StorageWriter) -> StorageWr
         .unwrap()
         .append_body(BlockNumber(1), BlockBody::default())
         .unwrap()
-        .append_state_diff(BlockNumber(1), StateDiff::default(), indexmap![])
+        .append_thin_state_diff(BlockNumber(1), ThinStateDiff::default())
+        .unwrap()
+        .append_classes(BlockNumber(1), &[], &[])
         .unwrap()
         .commit()
         .unwrap();
@@ -1511,7 +1522,9 @@ fn write_empty_block(mut storage_writer: StorageWriter) {
         .unwrap()
         .append_body(BlockNumber(0), BlockBody::default())
         .unwrap()
-        .append_state_diff(BlockNumber(0), StateDiff::default(), indexmap!())
+        .append_thin_state_diff(BlockNumber(0), ThinStateDiff::default())
+        .unwrap()
+        .append_classes(BlockNumber(0), &[], &[])
         .unwrap()
         .commit()
         .unwrap();

--- a/crates/papyrus_rpc/src/v0_5/api/test.rs
+++ b/crates/papyrus_rpc/src/v0_5/api/test.rs
@@ -18,6 +18,7 @@ use papyrus_common::BlockHashAndNumber;
 use papyrus_storage::base_layer::BaseLayerStorageWriter;
 use papyrus_storage::body::events::EventIndex;
 use papyrus_storage::body::{BodyStorageWriter, TransactionIndex};
+use papyrus_storage::class::ClassStorageWriter;
 use papyrus_storage::header::HeaderStorageWriter;
 use papyrus_storage::state::StateStorageWriter;
 use papyrus_storage::test_utils::get_test_storage;
@@ -265,10 +266,9 @@ async fn block_hash_and_number() {
     storage_writer
         .begin_rw_txn()
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             block.header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
         )
         .unwrap()
         .commit()
@@ -327,11 +327,7 @@ async fn block_number() {
     storage_writer
         .begin_rw_txn()
         .unwrap()
-        .append_state_diff(
-            BlockNumber(0),
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
-        )
+        .append_thin_state_diff(BlockNumber(0), starknet_api::state::ThinStateDiff::default())
         .unwrap()
         .commit()
         .unwrap();
@@ -398,10 +394,9 @@ async fn get_block_transaction_count() {
         .unwrap()
         .append_body(block.header.block_number, block.body)
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             block.header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
         )
         .unwrap()
         .commit()
@@ -497,10 +492,9 @@ async fn get_block_w_full_transactions() {
         .unwrap()
         .append_body(block.header.block_number, block.body.clone())
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             block.header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
         )
         .unwrap()
         .commit()
@@ -670,10 +664,9 @@ async fn get_block_w_transaction_hashes() {
         .unwrap()
         .append_body(block.header.block_number, block.body.clone())
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             block.header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
         )
         .unwrap()
         .commit()
@@ -835,28 +828,38 @@ async fn get_class() {
         parent_hash: parent_header.block_hash,
         ..BlockHeader::default()
     };
-    let diff = get_test_state_diff();
+    let (diff, classes, deprecated_classes) =
+        starknet_api::state::ThinStateDiff::from_state_diff(get_test_state_diff());
     storage_writer
         .begin_rw_txn()
         .unwrap()
         .append_header(parent_header.block_number, &parent_header)
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             parent_header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
+        )
+        .unwrap()
+        .append_classes(
+            parent_header.block_number,
+            &classes.iter().map(|(class_hash, class)| (*class_hash, class)).collect::<Vec<_>>(),
+            &deprecated_classes
+                .iter()
+                .map(|(class_hash, deprecated_class)| (*class_hash, deprecated_class))
+                .collect::<Vec<_>>(),
         )
         .unwrap()
         .append_header(header.block_number, &header)
         .unwrap()
-        .append_state_diff(header.block_number, diff.clone(), IndexMap::new())
+        .append_thin_state_diff(header.block_number, diff.clone())
         .unwrap()
         .commit()
         .unwrap();
 
     // Deprecated Class
-    let (class_hash, contract_class) = diff.deprecated_declared_classes.get_index(0).unwrap();
-    let expected_contract_class = contract_class.clone().try_into().unwrap();
+    let class_hash = diff.deprecated_declared_classes[0];
+    let expected_contract_class =
+        deprecated_classes.get(&class_hash).unwrap().clone().try_into().unwrap();
 
     // Get class by block hash.
     call_api_then_assert_and_validate_schema_for_result(
@@ -912,8 +915,7 @@ async fn get_class() {
     .await;
 
     // New Class
-    let (class_hash, (_compiled_class_hash, contract_class)) =
-        diff.declared_classes.get_index(0).unwrap();
+    let (class_hash, contract_class) = classes.get_index(0).unwrap();
     let expected_contract_class = contract_class.clone().into();
 
     // Get class by block hash.
@@ -1229,7 +1231,8 @@ async fn get_class_at() {
         parent_hash: parent_header.block_hash,
         ..BlockHeader::default()
     };
-    let mut diff = get_test_state_diff();
+    let (mut diff, classes, deprecated_classes) =
+        starknet_api::state::ThinStateDiff::from_state_diff(get_test_state_diff());
     // Add a deployed contract with Cairo 1 class.
     let new_class_hash = diff.declared_classes.get_index(0).unwrap().0;
     diff.deployed_contracts.insert(ContractAddress(patricia_key!("0x2")), *new_class_hash);
@@ -1238,15 +1241,23 @@ async fn get_class_at() {
         .unwrap()
         .append_header(parent_header.block_number, &parent_header)
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             parent_header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
+        )
+        .unwrap()
+        .append_classes(
+            parent_header.block_number,
+            &classes.iter().map(|(class_hash, class)| (*class_hash, class)).collect::<Vec<_>>(),
+            &deprecated_classes
+                .iter()
+                .map(|(class_hash, deprecated_class)| (*class_hash, deprecated_class))
+                .collect::<Vec<_>>(),
         )
         .unwrap()
         .append_header(header.block_number, &header)
         .unwrap()
-        .append_state_diff(header.block_number, diff.clone(), IndexMap::new())
+        .append_thin_state_diff(header.block_number, diff.clone())
         .unwrap()
         .commit()
         .unwrap();
@@ -1267,8 +1278,9 @@ async fn get_class_at() {
     pending_classes.write().await.add_class(pending_class_hash, pending_class.clone());
 
     // Deprecated Class
-    let (class_hash, contract_class) = diff.deprecated_declared_classes.get_index(0).unwrap();
-    let expected_contract_class = contract_class.clone().try_into().unwrap();
+    let class_hash = diff.deprecated_declared_classes.last().unwrap();
+    let expected_contract_class =
+        deprecated_classes.get(class_hash).unwrap().clone().try_into().unwrap();
     assert_eq!(diff.deployed_contracts.get_index(0).unwrap().1, class_hash);
     let address = diff.deployed_contracts.get_index(0).unwrap().0;
 
@@ -1297,9 +1309,8 @@ async fn get_class_at() {
     assert_eq!(res, expected_contract_class);
 
     // New Class
-    let (class_hash, (_compiled_hash, contract_class)) =
-        diff.declared_classes.get_index(0).unwrap();
-    let expected_contract_class = contract_class.clone().into();
+    let class_hash = diff.declared_classes.get_index(0).unwrap().0;
+    let expected_contract_class = classes.get(class_hash).unwrap().clone().into();
     assert_eq!(diff.deployed_contracts.get_index(1).unwrap().1, class_hash);
     let address = diff.deployed_contracts.get_index(1).unwrap().0;
 
@@ -1406,14 +1417,15 @@ async fn get_class_hash_at() {
         JsonRpcServerImpl,
     >(None, None, Some(pending_data.clone()), None, None);
     let header = BlockHeader::default();
-    let diff = get_test_state_diff();
+    let diff = starknet_api::state::ThinStateDiff::from(get_test_state_diff());
     storage_writer
         .begin_rw_txn()
         .unwrap()
         .append_header(header.block_number, &header)
         .unwrap()
-        .append_state_diff(header.block_number, diff.clone(), IndexMap::new())
+        .append_thin_state_diff(header.block_number, diff.clone())
         .unwrap()
+        // No need to write the class definitions.
         .commit()
         .unwrap();
 
@@ -1561,13 +1573,13 @@ async fn get_nonce() {
         JsonRpcServerImpl,
     >(None, None, Some(pending_data.clone()), None, None);
     let header = BlockHeader::default();
-    let diff = get_test_state_diff();
+    let diff = starknet_api::state::ThinStateDiff::from(get_test_state_diff());
     storage_writer
         .begin_rw_txn()
         .unwrap()
         .append_header(header.block_number, &header)
         .unwrap()
-        .append_state_diff(header.block_number, diff.clone(), IndexMap::new())
+        .append_thin_state_diff(header.block_number, diff.clone())
         .unwrap()
         .commit()
         .unwrap();
@@ -1698,13 +1710,13 @@ async fn get_storage_at() {
         JsonRpcServerImpl,
     >(None, None, Some(pending_data.clone()), None, None);
     let header = BlockHeader::default();
-    let diff = get_test_state_diff();
+    let diff = starknet_api::state::ThinStateDiff::from(get_test_state_diff());
     storage_writer
         .begin_rw_txn()
         .unwrap()
         .append_header(header.block_number, &header)
         .unwrap()
-        .append_state_diff(header.block_number, diff.clone(), IndexMap::new())
+        .append_thin_state_diff(header.block_number, diff.clone())
         .unwrap()
         .commit()
         .unwrap();
@@ -2046,10 +2058,9 @@ async fn get_transaction_by_block_id_and_index() {
         .unwrap()
         .append_body(block.header.block_number, block.body.clone())
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             block.header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
         )
         .unwrap()
         .commit()
@@ -2176,27 +2187,27 @@ async fn get_state_update() {
         state_root: expected_pending_old_root,
         ..BlockHeader::default()
     };
-    let diff = get_test_state_diff();
+    let diff = starknet_api::state::ThinStateDiff::from(get_test_state_diff());
     storage_writer
         .begin_rw_txn()
         .unwrap()
         .append_header(parent_header.block_number, &parent_header)
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             parent_header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
         )
         .unwrap()
         .append_header(header.block_number, &header)
         .unwrap()
-        .append_state_diff(header.block_number, diff.clone(), IndexMap::new())
+        .append_thin_state_diff(header.block_number, diff.clone())
         .unwrap()
+        // No need to write the class definitions
         .commit()
         .unwrap();
 
     let expected_old_root = parent_header.state_root;
-    let expected_state_diff = ThinStateDiff::from(starknet_api::state::ThinStateDiff::from(diff));
+    let expected_state_diff = ThinStateDiff::from(diff);
     let expected_update = StateUpdate::AcceptedStateUpdate(AcceptedStateUpdate {
         block_hash: header.block_hash,
         new_root: header.state_root,
@@ -2327,7 +2338,7 @@ async fn get_state_update_with_empty_storage_diff() {
     let (module, mut storage_writer) = get_test_rpc_server_and_storage_writer_from_params::<
         JsonRpcServerImpl,
     >(None, None, Some(pending_data.clone()), None, None);
-    let state_diff = starknet_api::state::StateDiff {
+    let state_diff = starknet_api::state::ThinStateDiff {
         storage_diffs: indexmap!(ContractAddress::default() => indexmap![]),
         ..Default::default()
     };
@@ -2336,7 +2347,7 @@ async fn get_state_update_with_empty_storage_diff() {
         .unwrap()
         .append_header(BlockNumber(0), &BlockHeader::default())
         .unwrap()
-        .append_state_diff(BlockNumber(0), state_diff, IndexMap::new())
+        .append_thin_state_diff(BlockNumber(0), state_diff)
         .unwrap()
         .commit()
         .unwrap();
@@ -2506,10 +2517,9 @@ async fn test_get_events(
             .unwrap()
             .append_body(block_number, block.body)
             .unwrap()
-            .append_state_diff(
+            .append_thin_state_diff(
                 block.header.block_number,
-                starknet_api::state::StateDiff::default(),
-                IndexMap::new(),
+                starknet_api::state::ThinStateDiff::default(),
             )
             .unwrap();
     }
@@ -3035,10 +3045,9 @@ async fn get_events_invalid_ct() {
         .unwrap()
         .append_body(block.header.block_number, block.body)
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             block.header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
         )
         .unwrap()
         .commit()
@@ -3092,6 +3101,10 @@ async fn serialize_returns_valid_json() {
         .insert(ContractAddress(patricia_key!("0x2")), ClassHash(stark_felt!("0x2")));
     // TODO(yair): handle replaced classes.
     state_diff.replaced_classes.clear();
+
+    let (thin_state_diff, classes, deprecated_classes) =
+        starknet_api::state::ThinStateDiff::from_state_diff(state_diff.clone());
+
     storage_writer
         .begin_rw_txn()
         .unwrap()
@@ -3099,13 +3112,27 @@ async fn serialize_returns_valid_json() {
         .unwrap()
         .append_body(parent_block.header.block_number, parent_block.body)
         .unwrap()
-        .append_state_diff(parent_block.header.block_number, StateDiff::default(), IndexMap::new())
+        .append_thin_state_diff(
+            parent_block.header.block_number,
+            starknet_api::state::ThinStateDiff::default(),
+        )
+        .unwrap()
+        .append_classes(parent_block.header.block_number, &[], &[])
         .unwrap()
         .append_header(block.header.block_number, &block.header)
         .unwrap()
         .append_body(block.header.block_number, block.body.clone())
         .unwrap()
-        .append_state_diff(block.header.block_number, state_diff.clone(), IndexMap::new())
+        .append_thin_state_diff(block.header.block_number, thin_state_diff)
+        .unwrap()
+        .append_classes(
+            block.header.block_number,
+            &classes.iter().map(|(class_hash, class)| (*class_hash, class)).collect::<Vec<_>>(),
+            &deprecated_classes
+                .iter()
+                .map(|(class_hash, deprecated_class)| (*class_hash, deprecated_class))
+                .collect::<Vec<_>>(),
+        )
         .unwrap()
         .commit()
         .unwrap();
@@ -3261,11 +3288,11 @@ async fn get_deprecated_class_state_mutability() {
         ..Default::default()
     };
 
-    let state_diff = StateDiff {
-        deprecated_declared_classes: IndexMap::from([
-            (ClassHash(stark_felt!("0x0")), class_without_state_mutability),
-            (ClassHash(stark_felt!("0x1")), class_with_state_mutability),
-        ]),
+    let state_diff = starknet_api::state::ThinStateDiff {
+        deprecated_declared_classes: vec![
+            ClassHash(stark_felt!("0x0")),
+            ClassHash(stark_felt!("0x1")),
+        ],
         ..Default::default()
     };
 
@@ -3278,7 +3305,16 @@ async fn get_deprecated_class_state_mutability() {
         .unwrap()
         .append_header(header.block_number, &header)
         .unwrap()
-        .append_state_diff(header.block_number, state_diff, IndexMap::new())
+        .append_thin_state_diff(header.block_number, state_diff)
+        .unwrap()
+        .append_classes(
+            header.block_number,
+            &[],
+            &[
+                (ClassHash(stark_felt!("0x0")), &class_without_state_mutability),
+                (ClassHash(stark_felt!("0x1")), &class_with_state_mutability),
+            ],
+        )
         .unwrap()
         .commit()
         .unwrap();

--- a/crates/papyrus_rpc/src/v0_5/execution_test.rs
+++ b/crates/papyrus_rpc/src/v0_5/execution_test.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use assert_matches::assert_matches;
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
-use indexmap::{indexmap, IndexMap};
+use indexmap::indexmap;
 use jsonrpsee::core::Error;
 use jsonrpsee::RpcModule;
 use lazy_static::lazy_static;
@@ -23,6 +23,7 @@ use papyrus_execution::objects::{
 use papyrus_execution::testing_instances::get_storage_var_address;
 use papyrus_execution::ExecutableTransactionInput;
 use papyrus_storage::body::BodyStorageWriter;
+use papyrus_storage::class::ClassStorageWriter;
 use papyrus_storage::compiled_class::CasmStorageWriter;
 use papyrus_storage::header::HeaderStorageWriter;
 use papyrus_storage::state::StateStorageWriter;
@@ -53,7 +54,7 @@ use starknet_api::deprecated_contract_class::{
     EntryPointType,
 };
 use starknet_api::hash::{StarkFelt, StarkHash};
-use starknet_api::state::StateDiff;
+use starknet_api::state::ThinStateDiff;
 use starknet_api::transaction::{
     Calldata,
     Fee,
@@ -707,14 +708,15 @@ async fn trace_block_transactions_regular_and_pending() {
             },
         )
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             BlockNumber(2),
-            StateDiff {
+            ThinStateDiff {
                 nonces: indexmap!(*ACCOUNT_ADDRESS => Nonce(stark_felt!(2_u128))),
                 ..Default::default()
             },
-            IndexMap::new(),
         )
+        .unwrap()
+        .append_classes(BlockNumber(2), &[], &[])
         .unwrap()
         .commit()
         .unwrap();
@@ -904,14 +906,15 @@ async fn trace_block_transactions_and_trace_transaction_execution_context() {
             },
         )
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             BlockNumber(2),
-            StateDiff {
+            ThinStateDiff {
                 nonces: indexmap!(*ACCOUNT_ADDRESS => Nonce(stark_felt!(2_u128))),
                 ..Default::default()
             },
-            IndexMap::new(),
         )
+        .unwrap()
+        .append_classes(BlockNumber(2), &[], &[])
         .unwrap()
         .commit()
         .unwrap();
@@ -1490,9 +1493,9 @@ fn prepare_storage_for_execution(mut storage_writer: StorageWriter) -> StorageWr
         .unwrap()
         .append_body(BlockNumber(0), BlockBody::default())
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             BlockNumber(0),
-            StateDiff {
+            ThinStateDiff {
                 deployed_contracts: indexmap!(
                     *DEPRECATED_CONTRACT_ADDRESS => class_hash1,
                     *CONTRACT_ADDRESS => class_hash2,
@@ -1507,15 +1510,12 @@ fn prepare_storage_for_execution(mut storage_writer: StorageWriter) -> StorageWr
                         minter_var_address => *ACCOUNT_ADDRESS.0.key()
                     ),
                 ),
-                declared_classes: indexmap!(
-                    class_hash2 =>
-                    (compiled_class_hash, class2)
-                ),
-                deprecated_declared_classes: indexmap!(
-                    class_hash1 => class1,
-                    *ACCOUNT_CLASS_HASH => account_class,
-                    *TEST_ERC20_CONTRACT_CLASS_HASH => fee_contract_class,
-                ),
+                declared_classes: indexmap!(class_hash2 => compiled_class_hash),
+                deprecated_declared_classes: vec![
+                    class_hash1,
+                    *ACCOUNT_CLASS_HASH,
+                    *TEST_ERC20_CONTRACT_CLASS_HASH,
+                ],
                 nonces: indexmap!(
                     *TEST_ERC20_CONTRACT_ADDRESS => Nonce::default(),
                     *CONTRACT_ADDRESS => Nonce::default(),
@@ -1524,7 +1524,16 @@ fn prepare_storage_for_execution(mut storage_writer: StorageWriter) -> StorageWr
                 ),
                 replaced_classes: indexmap!(),
             },
-            indexmap!(),
+        )
+        .unwrap()
+        .append_classes(
+            BlockNumber(0),
+            &[(class_hash2, &class2)],
+            &[
+                (class_hash1, &class1),
+                (*ACCOUNT_CLASS_HASH, &account_class),
+                (*TEST_ERC20_CONTRACT_CLASS_HASH, &fee_contract_class),
+            ],
         )
         .unwrap()
         .append_casm(&class_hash2, &casm)
@@ -1543,7 +1552,9 @@ fn prepare_storage_for_execution(mut storage_writer: StorageWriter) -> StorageWr
         .unwrap()
         .append_body(BlockNumber(1), BlockBody::default())
         .unwrap()
-        .append_state_diff(BlockNumber(1), StateDiff::default(), indexmap![])
+        .append_thin_state_diff(BlockNumber(1), ThinStateDiff::default())
+        .unwrap()
+        .append_classes(BlockNumber(1), &[], &[])
         .unwrap()
         .commit()
         .unwrap();
@@ -1567,7 +1578,9 @@ fn write_empty_block(mut storage_writer: StorageWriter) {
         .unwrap()
         .append_body(BlockNumber(0), BlockBody::default())
         .unwrap()
-        .append_state_diff(BlockNumber(0), StateDiff::default(), indexmap!())
+        .append_thin_state_diff(BlockNumber(0), ThinStateDiff::default())
+        .unwrap()
+        .append_classes(BlockNumber(0), &[], &[])
         .unwrap()
         .commit()
         .unwrap();

--- a/crates/papyrus_rpc/src/v0_6/api/test.rs
+++ b/crates/papyrus_rpc/src/v0_6/api/test.rs
@@ -18,6 +18,7 @@ use papyrus_common::BlockHashAndNumber;
 use papyrus_storage::base_layer::BaseLayerStorageWriter;
 use papyrus_storage::body::events::EventIndex;
 use papyrus_storage::body::{BodyStorageWriter, TransactionIndex};
+use papyrus_storage::class::ClassStorageWriter;
 use papyrus_storage::header::HeaderStorageWriter;
 use papyrus_storage::state::StateStorageWriter;
 use papyrus_storage::test_utils::get_test_storage;
@@ -266,10 +267,9 @@ async fn block_hash_and_number() {
     storage_writer
         .begin_rw_txn()
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             block.header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
         )
         .unwrap()
         .commit()
@@ -328,11 +328,7 @@ async fn block_number() {
     storage_writer
         .begin_rw_txn()
         .unwrap()
-        .append_state_diff(
-            BlockNumber(0),
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
-        )
+        .append_thin_state_diff(BlockNumber(0), starknet_api::state::ThinStateDiff::default())
         .unwrap()
         .commit()
         .unwrap();
@@ -399,10 +395,9 @@ async fn get_block_transaction_count() {
         .unwrap()
         .append_body(block.header.block_number, block.body)
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             block.header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
         )
         .unwrap()
         .commit()
@@ -498,10 +493,9 @@ async fn get_block_w_full_transactions() {
         .unwrap()
         .append_body(block.header.block_number, block.body.clone())
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             block.header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
         )
         .unwrap()
         .commit()
@@ -675,10 +669,9 @@ async fn get_block_w_transaction_hashes() {
         .unwrap()
         .append_body(block.header.block_number, block.body.clone())
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             block.header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
         )
         .unwrap()
         .commit()
@@ -845,28 +838,38 @@ async fn get_class() {
         parent_hash: parent_header.block_hash,
         ..BlockHeader::default()
     };
-    let diff = get_test_state_diff();
+    let (diff, classes, deprecated_classes) =
+        starknet_api::state::ThinStateDiff::from_state_diff(get_test_state_diff());
     storage_writer
         .begin_rw_txn()
         .unwrap()
         .append_header(parent_header.block_number, &parent_header)
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             parent_header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
+        )
+        .unwrap()
+        .append_classes(
+            parent_header.block_number,
+            &classes.iter().map(|(class_hash, class)| (*class_hash, class)).collect::<Vec<_>>(),
+            &deprecated_classes
+                .iter()
+                .map(|(class_hash, deprecated_class)| (*class_hash, deprecated_class))
+                .collect::<Vec<_>>(),
         )
         .unwrap()
         .append_header(header.block_number, &header)
         .unwrap()
-        .append_state_diff(header.block_number, diff.clone(), IndexMap::new())
+        .append_thin_state_diff(header.block_number, diff.clone())
         .unwrap()
         .commit()
         .unwrap();
 
     // Deprecated Class
-    let (class_hash, contract_class) = diff.deprecated_declared_classes.get_index(0).unwrap();
-    let expected_contract_class = contract_class.clone().try_into().unwrap();
+    let class_hash = diff.deprecated_declared_classes[0];
+    let expected_contract_class =
+        deprecated_classes.get(&class_hash).unwrap().clone().try_into().unwrap();
 
     // Get class by block hash.
     call_api_then_assert_and_validate_schema_for_result(
@@ -922,8 +925,7 @@ async fn get_class() {
     .await;
 
     // New Class
-    let (class_hash, (_compiled_class_hash, contract_class)) =
-        diff.declared_classes.get_index(0).unwrap();
+    let (class_hash, contract_class) = classes.get_index(0).unwrap();
     let expected_contract_class = contract_class.clone().into();
 
     // Get class by block hash.
@@ -1256,7 +1258,8 @@ async fn get_class_at() {
         parent_hash: parent_header.block_hash,
         ..BlockHeader::default()
     };
-    let mut diff = get_test_state_diff();
+    let (mut diff, classes, deprecated_classes) =
+        starknet_api::state::ThinStateDiff::from_state_diff(get_test_state_diff());
     // Add a deployed contract with Cairo 1 class.
     let new_class_hash = diff.declared_classes.get_index(0).unwrap().0;
     diff.deployed_contracts.insert(ContractAddress(patricia_key!("0x2")), *new_class_hash);
@@ -1265,15 +1268,23 @@ async fn get_class_at() {
         .unwrap()
         .append_header(parent_header.block_number, &parent_header)
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             parent_header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
+        )
+        .unwrap()
+        .append_classes(
+            parent_header.block_number,
+            &classes.iter().map(|(class_hash, class)| (*class_hash, class)).collect::<Vec<_>>(),
+            &deprecated_classes
+                .iter()
+                .map(|(class_hash, deprecated_class)| (*class_hash, deprecated_class))
+                .collect::<Vec<_>>(),
         )
         .unwrap()
         .append_header(header.block_number, &header)
         .unwrap()
-        .append_state_diff(header.block_number, diff.clone(), IndexMap::new())
+        .append_thin_state_diff(header.block_number, diff.clone())
         .unwrap()
         .commit()
         .unwrap();
@@ -1294,8 +1305,9 @@ async fn get_class_at() {
     pending_classes.write().await.add_class(pending_class_hash, pending_class.clone());
 
     // Deprecated Class
-    let (class_hash, contract_class) = diff.deprecated_declared_classes.get_index(0).unwrap();
-    let expected_contract_class = contract_class.clone().try_into().unwrap();
+    let class_hash = diff.deprecated_declared_classes.last().unwrap();
+    let expected_contract_class =
+        deprecated_classes.get(class_hash).unwrap().clone().try_into().unwrap();
     assert_eq!(diff.deployed_contracts.get_index(0).unwrap().1, class_hash);
     let address = diff.deployed_contracts.get_index(0).unwrap().0;
 
@@ -1324,9 +1336,8 @@ async fn get_class_at() {
     assert_eq!(res, expected_contract_class);
 
     // New Class
-    let (class_hash, (_compiled_hash, contract_class)) =
-        diff.declared_classes.get_index(0).unwrap();
-    let expected_contract_class = contract_class.clone().into();
+    let class_hash = diff.declared_classes.get_index(0).unwrap().0;
+    let expected_contract_class = classes.get(class_hash).unwrap().clone().into();
     assert_eq!(diff.deployed_contracts.get_index(1).unwrap().1, class_hash);
     let address = diff.deployed_contracts.get_index(1).unwrap().0;
 
@@ -1433,14 +1444,15 @@ async fn get_class_hash_at() {
         JsonRpcServerImpl,
     >(None, None, Some(pending_data.clone()), None, None);
     let header = BlockHeader::default();
-    let diff = get_test_state_diff();
+    let diff = starknet_api::state::ThinStateDiff::from(get_test_state_diff());
     storage_writer
         .begin_rw_txn()
         .unwrap()
         .append_header(header.block_number, &header)
         .unwrap()
-        .append_state_diff(header.block_number, diff.clone(), IndexMap::new())
+        .append_thin_state_diff(header.block_number, diff.clone())
         .unwrap()
+        // No need to write the class definitions.
         .commit()
         .unwrap();
 
@@ -1588,13 +1600,13 @@ async fn get_nonce() {
         JsonRpcServerImpl,
     >(None, None, Some(pending_data.clone()), None, None);
     let header = BlockHeader::default();
-    let diff = get_test_state_diff();
+    let diff = starknet_api::state::ThinStateDiff::from(get_test_state_diff());
     storage_writer
         .begin_rw_txn()
         .unwrap()
         .append_header(header.block_number, &header)
         .unwrap()
-        .append_state_diff(header.block_number, diff.clone(), IndexMap::new())
+        .append_thin_state_diff(header.block_number, diff.clone())
         .unwrap()
         .commit()
         .unwrap();
@@ -1725,13 +1737,13 @@ async fn get_storage_at() {
         JsonRpcServerImpl,
     >(None, None, Some(pending_data.clone()), None, None);
     let header = BlockHeader::default();
-    let diff = get_test_state_diff();
+    let diff = starknet_api::state::ThinStateDiff::from(get_test_state_diff());
     storage_writer
         .begin_rw_txn()
         .unwrap()
         .append_header(header.block_number, &header)
         .unwrap()
-        .append_state_diff(header.block_number, diff.clone(), IndexMap::new())
+        .append_thin_state_diff(header.block_number, diff.clone())
         .unwrap()
         .commit()
         .unwrap();
@@ -2077,10 +2089,9 @@ async fn get_transaction_by_block_id_and_index() {
         .unwrap()
         .append_body(block.header.block_number, block.body.clone())
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             block.header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
         )
         .unwrap()
         .commit()
@@ -2207,27 +2218,27 @@ async fn get_state_update() {
         state_root: expected_pending_old_root,
         ..BlockHeader::default()
     };
-    let diff = get_test_state_diff();
+    let diff = starknet_api::state::ThinStateDiff::from(get_test_state_diff());
     storage_writer
         .begin_rw_txn()
         .unwrap()
         .append_header(parent_header.block_number, &parent_header)
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             parent_header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
         )
         .unwrap()
         .append_header(header.block_number, &header)
         .unwrap()
-        .append_state_diff(header.block_number, diff.clone(), IndexMap::new())
+        .append_thin_state_diff(header.block_number, diff.clone())
         .unwrap()
+        // No need to write the class definitions
         .commit()
         .unwrap();
 
     let expected_old_root = parent_header.state_root;
-    let expected_state_diff = ThinStateDiff::from(starknet_api::state::ThinStateDiff::from(diff));
+    let expected_state_diff = ThinStateDiff::from(diff);
     let expected_update = StateUpdate::AcceptedStateUpdate(AcceptedStateUpdate {
         block_hash: header.block_hash,
         new_root: header.state_root,
@@ -2358,7 +2369,7 @@ async fn get_state_update_with_empty_storage_diff() {
     let (module, mut storage_writer) = get_test_rpc_server_and_storage_writer_from_params::<
         JsonRpcServerImpl,
     >(None, None, Some(pending_data.clone()), None, None);
-    let state_diff = starknet_api::state::StateDiff {
+    let state_diff = starknet_api::state::ThinStateDiff {
         storage_diffs: indexmap!(ContractAddress::default() => indexmap![]),
         ..Default::default()
     };
@@ -2367,7 +2378,7 @@ async fn get_state_update_with_empty_storage_diff() {
         .unwrap()
         .append_header(BlockNumber(0), &BlockHeader::default())
         .unwrap()
-        .append_state_diff(BlockNumber(0), state_diff, IndexMap::new())
+        .append_thin_state_diff(BlockNumber(0), state_diff)
         .unwrap()
         .commit()
         .unwrap();
@@ -2537,10 +2548,9 @@ async fn test_get_events(
             .unwrap()
             .append_body(block_number, block.body)
             .unwrap()
-            .append_state_diff(
+            .append_thin_state_diff(
                 block.header.block_number,
-                starknet_api::state::StateDiff::default(),
-                IndexMap::new(),
+                starknet_api::state::ThinStateDiff::default(),
             )
             .unwrap();
     }
@@ -3066,10 +3076,9 @@ async fn get_events_invalid_ct() {
         .unwrap()
         .append_body(block.header.block_number, block.body)
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             block.header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
         )
         .unwrap()
         .commit()
@@ -3123,6 +3132,10 @@ async fn serialize_returns_valid_json() {
         .insert(ContractAddress(patricia_key!("0x2")), ClassHash(stark_felt!("0x2")));
     // TODO(yair): handle replaced classes.
     state_diff.replaced_classes.clear();
+
+    let (thin_state_diff, classes, deprecated_classes) =
+        starknet_api::state::ThinStateDiff::from_state_diff(state_diff.clone());
+
     storage_writer
         .begin_rw_txn()
         .unwrap()
@@ -3130,13 +3143,27 @@ async fn serialize_returns_valid_json() {
         .unwrap()
         .append_body(parent_block.header.block_number, parent_block.body)
         .unwrap()
-        .append_state_diff(parent_block.header.block_number, StateDiff::default(), IndexMap::new())
+        .append_thin_state_diff(
+            parent_block.header.block_number,
+            starknet_api::state::ThinStateDiff::default(),
+        )
+        .unwrap()
+        .append_classes(parent_block.header.block_number, &[], &[])
         .unwrap()
         .append_header(block.header.block_number, &block.header)
         .unwrap()
         .append_body(block.header.block_number, block.body.clone())
         .unwrap()
-        .append_state_diff(block.header.block_number, state_diff.clone(), IndexMap::new())
+        .append_thin_state_diff(block.header.block_number, thin_state_diff)
+        .unwrap()
+        .append_classes(
+            block.header.block_number,
+            &classes.iter().map(|(class_hash, class)| (*class_hash, class)).collect::<Vec<_>>(),
+            &deprecated_classes
+                .iter()
+                .map(|(class_hash, deprecated_class)| (*class_hash, deprecated_class))
+                .collect::<Vec<_>>(),
+        )
         .unwrap()
         .commit()
         .unwrap();
@@ -3292,11 +3319,11 @@ async fn get_deprecated_class_state_mutability() {
         ..Default::default()
     };
 
-    let state_diff = StateDiff {
-        deprecated_declared_classes: IndexMap::from([
-            (ClassHash(stark_felt!("0x0")), class_without_state_mutability),
-            (ClassHash(stark_felt!("0x1")), class_with_state_mutability),
-        ]),
+    let state_diff = starknet_api::state::ThinStateDiff {
+        deprecated_declared_classes: vec![
+            ClassHash(stark_felt!("0x0")),
+            ClassHash(stark_felt!("0x1")),
+        ],
         ..Default::default()
     };
 
@@ -3309,7 +3336,16 @@ async fn get_deprecated_class_state_mutability() {
         .unwrap()
         .append_header(header.block_number, &header)
         .unwrap()
-        .append_state_diff(header.block_number, state_diff, IndexMap::new())
+        .append_thin_state_diff(header.block_number, state_diff)
+        .unwrap()
+        .append_classes(
+            header.block_number,
+            &[],
+            &[
+                (ClassHash(stark_felt!("0x0")), &class_without_state_mutability),
+                (ClassHash(stark_felt!("0x1")), &class_with_state_mutability),
+            ],
+        )
         .unwrap()
         .commit()
         .unwrap();

--- a/crates/papyrus_rpc/src/v0_6/execution_test.rs
+++ b/crates/papyrus_rpc/src/v0_6/execution_test.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use assert_matches::assert_matches;
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
-use indexmap::{indexmap, IndexMap};
+use indexmap::indexmap;
 use jsonrpsee::core::Error;
 use jsonrpsee::RpcModule;
 use lazy_static::lazy_static;
@@ -25,6 +25,7 @@ use papyrus_execution::objects::{
 use papyrus_execution::testing_instances::get_storage_var_address;
 use papyrus_execution::ExecutableTransactionInput;
 use papyrus_storage::body::BodyStorageWriter;
+use papyrus_storage::class::ClassStorageWriter;
 use papyrus_storage::compiled_class::CasmStorageWriter;
 use papyrus_storage::header::HeaderStorageWriter;
 use papyrus_storage::state::StateStorageWriter;
@@ -55,7 +56,7 @@ use starknet_api::deprecated_contract_class::{
     EntryPointType,
 };
 use starknet_api::hash::{StarkFelt, StarkHash};
-use starknet_api::state::StateDiff;
+use starknet_api::state::ThinStateDiff;
 use starknet_api::transaction::{
     Calldata,
     Fee,
@@ -768,14 +769,15 @@ async fn trace_block_transactions_regular_and_pending() {
             },
         )
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             BlockNumber(2),
-            StateDiff {
+            ThinStateDiff {
                 nonces: indexmap!(*ACCOUNT_ADDRESS => Nonce(stark_felt!(2_u128))),
                 ..Default::default()
             },
-            IndexMap::new(),
         )
+        .unwrap()
+        .append_classes(BlockNumber(2), &[], &[])
         .unwrap()
         .commit()
         .unwrap();
@@ -965,14 +967,15 @@ async fn trace_block_transactions_and_trace_transaction_execution_context() {
             },
         )
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             BlockNumber(2),
-            StateDiff {
+            ThinStateDiff {
                 nonces: indexmap!(*ACCOUNT_ADDRESS => Nonce(stark_felt!(2_u128))),
                 ..Default::default()
             },
-            IndexMap::new(),
         )
+        .unwrap()
+        .append_classes(BlockNumber(2), &[], &[])
         .unwrap()
         .commit()
         .unwrap();
@@ -1571,9 +1574,9 @@ fn prepare_storage_for_execution(mut storage_writer: StorageWriter) -> StorageWr
         .unwrap()
         .append_body(BlockNumber(0), BlockBody::default())
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             BlockNumber(0),
-            StateDiff {
+            ThinStateDiff {
                 deployed_contracts: indexmap!(
                     *DEPRECATED_CONTRACT_ADDRESS => class_hash1,
                     *CONTRACT_ADDRESS => class_hash2,
@@ -1588,15 +1591,12 @@ fn prepare_storage_for_execution(mut storage_writer: StorageWriter) -> StorageWr
                         minter_var_address => *ACCOUNT_ADDRESS.0.key()
                     ),
                 ),
-                declared_classes: indexmap!(
-                    class_hash2 =>
-                    (compiled_class_hash, class2)
-                ),
-                deprecated_declared_classes: indexmap!(
-                    class_hash1 => class1,
-                    *ACCOUNT_CLASS_HASH => account_class,
-                    *TEST_ERC20_CONTRACT_CLASS_HASH => fee_contract_class,
-                ),
+                declared_classes: indexmap!(class_hash2 => compiled_class_hash),
+                deprecated_declared_classes: vec![
+                    class_hash1,
+                    *ACCOUNT_CLASS_HASH,
+                    *TEST_ERC20_CONTRACT_CLASS_HASH,
+                ],
                 nonces: indexmap!(
                     *TEST_ERC20_CONTRACT_ADDRESS => Nonce::default(),
                     *CONTRACT_ADDRESS => Nonce::default(),
@@ -1605,7 +1605,16 @@ fn prepare_storage_for_execution(mut storage_writer: StorageWriter) -> StorageWr
                 ),
                 replaced_classes: indexmap!(),
             },
-            indexmap!(),
+        )
+        .unwrap()
+        .append_classes(
+            BlockNumber(0),
+            &[(class_hash2, &class2)],
+            &[
+                (class_hash1, &class1),
+                (*ACCOUNT_CLASS_HASH, &account_class),
+                (*TEST_ERC20_CONTRACT_CLASS_HASH, &fee_contract_class),
+            ],
         )
         .unwrap()
         .append_casm(&class_hash2, &casm)
@@ -1624,7 +1633,9 @@ fn prepare_storage_for_execution(mut storage_writer: StorageWriter) -> StorageWr
         .unwrap()
         .append_body(BlockNumber(1), BlockBody::default())
         .unwrap()
-        .append_state_diff(BlockNumber(1), StateDiff::default(), indexmap![])
+        .append_thin_state_diff(BlockNumber(1), ThinStateDiff::default())
+        .unwrap()
+        .append_classes(BlockNumber(1), &[], &[])
         .unwrap()
         .commit()
         .unwrap();
@@ -1648,7 +1659,9 @@ fn write_empty_block(mut storage_writer: StorageWriter) {
         .unwrap()
         .append_body(BlockNumber(0), BlockBody::default())
         .unwrap()
-        .append_state_diff(BlockNumber(0), StateDiff::default(), indexmap!())
+        .append_thin_state_diff(BlockNumber(0), ThinStateDiff::default())
+        .unwrap()
+        .append_classes(BlockNumber(0), &[], &[])
         .unwrap()
         .commit()
         .unwrap();

--- a/crates/papyrus_rpc/src/v0_7/api/test.rs
+++ b/crates/papyrus_rpc/src/v0_7/api/test.rs
@@ -18,6 +18,7 @@ use papyrus_common::BlockHashAndNumber;
 use papyrus_storage::base_layer::BaseLayerStorageWriter;
 use papyrus_storage::body::events::EventIndex;
 use papyrus_storage::body::{BodyStorageWriter, TransactionIndex};
+use papyrus_storage::class::ClassStorageWriter;
 use papyrus_storage::header::HeaderStorageWriter;
 use papyrus_storage::state::StateStorageWriter;
 use papyrus_storage::test_utils::get_test_storage;
@@ -270,10 +271,9 @@ async fn block_hash_and_number() {
     storage_writer
         .begin_rw_txn()
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             block.header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
         )
         .unwrap()
         .commit()
@@ -332,11 +332,7 @@ async fn block_number() {
     storage_writer
         .begin_rw_txn()
         .unwrap()
-        .append_state_diff(
-            BlockNumber(0),
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
-        )
+        .append_thin_state_diff(BlockNumber(0), starknet_api::state::ThinStateDiff::default())
         .unwrap()
         .commit()
         .unwrap();
@@ -403,10 +399,9 @@ async fn get_block_transaction_count() {
         .unwrap()
         .append_body(block.header.block_number, block.body)
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             block.header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
         )
         .unwrap()
         .commit()
@@ -501,10 +496,9 @@ async fn get_block_w_full_transactions() {
         .unwrap()
         .append_body(block.header.block_number, block.body.clone())
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             block.header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
         )
         .unwrap()
         .commit()
@@ -683,10 +677,9 @@ async fn get_block_w_full_transactions_and_receipts() {
         .unwrap()
         .append_body(block.header.block_number, block.body.clone())
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             block.header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
         )
         .unwrap()
         .commit()
@@ -878,10 +871,9 @@ async fn get_block_w_transaction_hashes() {
         .unwrap()
         .append_body(block.header.block_number, block.body.clone())
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             block.header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
         )
         .unwrap()
         .commit()
@@ -1051,28 +1043,38 @@ async fn get_class() {
         parent_hash: parent_header.block_hash,
         ..BlockHeader::default()
     };
-    let diff = get_test_state_diff();
+    let (diff, classes, deprecated_classes) =
+        starknet_api::state::ThinStateDiff::from_state_diff(get_test_state_diff());
     storage_writer
         .begin_rw_txn()
         .unwrap()
         .append_header(parent_header.block_number, &parent_header)
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             parent_header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
+        )
+        .unwrap()
+        .append_classes(
+            parent_header.block_number,
+            &classes.iter().map(|(class_hash, class)| (*class_hash, class)).collect::<Vec<_>>(),
+            &deprecated_classes
+                .iter()
+                .map(|(class_hash, deprecated_class)| (*class_hash, deprecated_class))
+                .collect::<Vec<_>>(),
         )
         .unwrap()
         .append_header(header.block_number, &header)
         .unwrap()
-        .append_state_diff(header.block_number, diff.clone(), IndexMap::new())
+        .append_thin_state_diff(header.block_number, diff.clone())
         .unwrap()
         .commit()
         .unwrap();
 
     // Deprecated Class
-    let (class_hash, contract_class) = diff.deprecated_declared_classes.get_index(0).unwrap();
-    let expected_contract_class = contract_class.clone().try_into().unwrap();
+    let class_hash = diff.deprecated_declared_classes[0];
+    let expected_contract_class =
+        deprecated_classes.get(&class_hash).unwrap().clone().try_into().unwrap();
 
     // Get class by block hash.
     call_api_then_assert_and_validate_schema_for_result(
@@ -1128,8 +1130,7 @@ async fn get_class() {
     .await;
 
     // New Class
-    let (class_hash, (_compiled_class_hash, contract_class)) =
-        diff.declared_classes.get_index(0).unwrap();
+    let (class_hash, contract_class) = classes.get_index(0).unwrap();
     let expected_contract_class = contract_class.clone().into();
 
     // Get class by block hash.
@@ -1452,7 +1453,8 @@ async fn get_class_at() {
         parent_hash: parent_header.block_hash,
         ..BlockHeader::default()
     };
-    let mut diff = get_test_state_diff();
+    let (mut diff, classes, deprecated_classes) =
+        starknet_api::state::ThinStateDiff::from_state_diff(get_test_state_diff());
     // Add a deployed contract with Cairo 1 class.
     let new_class_hash = diff.declared_classes.get_index(0).unwrap().0;
     diff.deployed_contracts.insert(ContractAddress(patricia_key!("0x2")), *new_class_hash);
@@ -1461,15 +1463,23 @@ async fn get_class_at() {
         .unwrap()
         .append_header(parent_header.block_number, &parent_header)
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             parent_header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
+        )
+        .unwrap()
+        .append_classes(
+            parent_header.block_number,
+            &classes.iter().map(|(class_hash, class)| (*class_hash, class)).collect::<Vec<_>>(),
+            &deprecated_classes
+                .iter()
+                .map(|(class_hash, deprecated_class)| (*class_hash, deprecated_class))
+                .collect::<Vec<_>>(),
         )
         .unwrap()
         .append_header(header.block_number, &header)
         .unwrap()
-        .append_state_diff(header.block_number, diff.clone(), IndexMap::new())
+        .append_thin_state_diff(header.block_number, diff.clone())
         .unwrap()
         .commit()
         .unwrap();
@@ -1490,8 +1500,9 @@ async fn get_class_at() {
     pending_classes.write().await.add_class(pending_class_hash, pending_class.clone());
 
     // Deprecated Class
-    let (class_hash, contract_class) = diff.deprecated_declared_classes.get_index(0).unwrap();
-    let expected_contract_class = contract_class.clone().try_into().unwrap();
+    let class_hash = diff.deprecated_declared_classes.last().unwrap();
+    let expected_contract_class =
+        deprecated_classes.get(class_hash).unwrap().clone().try_into().unwrap();
     assert_eq!(diff.deployed_contracts.get_index(0).unwrap().1, class_hash);
     let address = diff.deployed_contracts.get_index(0).unwrap().0;
 
@@ -1520,9 +1531,8 @@ async fn get_class_at() {
     assert_eq!(res, expected_contract_class);
 
     // New Class
-    let (class_hash, (_compiled_hash, contract_class)) =
-        diff.declared_classes.get_index(0).unwrap();
-    let expected_contract_class = contract_class.clone().into();
+    let class_hash = diff.declared_classes.get_index(0).unwrap().0;
+    let expected_contract_class = classes.get(class_hash).unwrap().clone().into();
     assert_eq!(diff.deployed_contracts.get_index(1).unwrap().1, class_hash);
     let address = diff.deployed_contracts.get_index(1).unwrap().0;
 
@@ -1629,14 +1639,15 @@ async fn get_class_hash_at() {
         JsonRpcServerImpl,
     >(None, None, Some(pending_data.clone()), None, None);
     let header = BlockHeader::default();
-    let diff = get_test_state_diff();
+    let diff = starknet_api::state::ThinStateDiff::from(get_test_state_diff());
     storage_writer
         .begin_rw_txn()
         .unwrap()
         .append_header(header.block_number, &header)
         .unwrap()
-        .append_state_diff(header.block_number, diff.clone(), IndexMap::new())
+        .append_thin_state_diff(header.block_number, diff.clone())
         .unwrap()
+        // No need to write the class definitions.
         .commit()
         .unwrap();
 
@@ -1784,13 +1795,13 @@ async fn get_nonce() {
         JsonRpcServerImpl,
     >(None, None, Some(pending_data.clone()), None, None);
     let header = BlockHeader::default();
-    let diff = get_test_state_diff();
+    let diff = starknet_api::state::ThinStateDiff::from(get_test_state_diff());
     storage_writer
         .begin_rw_txn()
         .unwrap()
         .append_header(header.block_number, &header)
         .unwrap()
-        .append_state_diff(header.block_number, diff.clone(), IndexMap::new())
+        .append_thin_state_diff(header.block_number, diff.clone())
         .unwrap()
         .commit()
         .unwrap();
@@ -1921,13 +1932,13 @@ async fn get_storage_at() {
         JsonRpcServerImpl,
     >(None, None, Some(pending_data.clone()), None, None);
     let header = BlockHeader::default();
-    let diff = get_test_state_diff();
+    let diff = starknet_api::state::ThinStateDiff::from(get_test_state_diff());
     storage_writer
         .begin_rw_txn()
         .unwrap()
         .append_header(header.block_number, &header)
         .unwrap()
-        .append_state_diff(header.block_number, diff.clone(), IndexMap::new())
+        .append_thin_state_diff(header.block_number, diff.clone())
         .unwrap()
         .commit()
         .unwrap();
@@ -2276,10 +2287,9 @@ async fn get_transaction_by_block_id_and_index() {
         .unwrap()
         .append_body(block.header.block_number, block.body.clone())
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             block.header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
         )
         .unwrap()
         .commit()
@@ -2421,6 +2431,7 @@ async fn get_state_update() {
         .unwrap()
         .append_thin_state_diff(header.block_number, diff.clone())
         .unwrap()
+        // No need to write the class definitions
         .commit()
         .unwrap();
 
@@ -2556,7 +2567,7 @@ async fn get_state_update_with_empty_storage_diff() {
     let (module, mut storage_writer) = get_test_rpc_server_and_storage_writer_from_params::<
         JsonRpcServerImpl,
     >(None, None, Some(pending_data.clone()), None, None);
-    let state_diff = starknet_api::state::StateDiff {
+    let state_diff = starknet_api::state::ThinStateDiff {
         storage_diffs: indexmap!(ContractAddress::default() => indexmap![]),
         ..Default::default()
     };
@@ -2565,7 +2576,7 @@ async fn get_state_update_with_empty_storage_diff() {
         .unwrap()
         .append_header(BlockNumber(0), &BlockHeader::default())
         .unwrap()
-        .append_state_diff(BlockNumber(0), state_diff, IndexMap::new())
+        .append_thin_state_diff(BlockNumber(0), state_diff)
         .unwrap()
         .commit()
         .unwrap();
@@ -2735,10 +2746,9 @@ async fn test_get_events(
             .unwrap()
             .append_body(block_number, block.body)
             .unwrap()
-            .append_state_diff(
+            .append_thin_state_diff(
                 block.header.block_number,
-                starknet_api::state::StateDiff::default(),
-                IndexMap::new(),
+                starknet_api::state::ThinStateDiff::default(),
             )
             .unwrap();
     }
@@ -3264,10 +3274,9 @@ async fn get_events_invalid_ct() {
         .unwrap()
         .append_body(block.header.block_number, block.body)
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             block.header.block_number,
-            starknet_api::state::StateDiff::default(),
-            IndexMap::new(),
+            starknet_api::state::ThinStateDiff::default(),
         )
         .unwrap()
         .commit()
@@ -3321,6 +3330,10 @@ async fn serialize_returns_valid_json() {
         .insert(ContractAddress(patricia_key!("0x2")), ClassHash(stark_felt!("0x2")));
     // TODO(yair): handle replaced classes.
     state_diff.replaced_classes.clear();
+
+    let (thin_state_diff, classes, deprecated_classes) =
+        starknet_api::state::ThinStateDiff::from_state_diff(state_diff.clone());
+
     storage_writer
         .begin_rw_txn()
         .unwrap()
@@ -3328,13 +3341,27 @@ async fn serialize_returns_valid_json() {
         .unwrap()
         .append_body(parent_block.header.block_number, parent_block.body)
         .unwrap()
-        .append_state_diff(parent_block.header.block_number, StateDiff::default(), IndexMap::new())
+        .append_thin_state_diff(
+            parent_block.header.block_number,
+            starknet_api::state::ThinStateDiff::default(),
+        )
+        .unwrap()
+        .append_classes(parent_block.header.block_number, &[], &[])
         .unwrap()
         .append_header(block.header.block_number, &block.header)
         .unwrap()
         .append_body(block.header.block_number, block.body.clone())
         .unwrap()
-        .append_state_diff(block.header.block_number, state_diff.clone(), IndexMap::new())
+        .append_thin_state_diff(block.header.block_number, thin_state_diff)
+        .unwrap()
+        .append_classes(
+            block.header.block_number,
+            &classes.iter().map(|(class_hash, class)| (*class_hash, class)).collect::<Vec<_>>(),
+            &deprecated_classes
+                .iter()
+                .map(|(class_hash, deprecated_class)| (*class_hash, deprecated_class))
+                .collect::<Vec<_>>(),
+        )
         .unwrap()
         .commit()
         .unwrap();
@@ -3490,11 +3517,11 @@ async fn get_deprecated_class_state_mutability() {
         ..Default::default()
     };
 
-    let state_diff = StateDiff {
-        deprecated_declared_classes: IndexMap::from([
-            (ClassHash(stark_felt!("0x0")), class_without_state_mutability),
-            (ClassHash(stark_felt!("0x1")), class_with_state_mutability),
-        ]),
+    let state_diff = starknet_api::state::ThinStateDiff {
+        deprecated_declared_classes: vec![
+            ClassHash(stark_felt!("0x0")),
+            ClassHash(stark_felt!("0x1")),
+        ],
         ..Default::default()
     };
 
@@ -3507,7 +3534,16 @@ async fn get_deprecated_class_state_mutability() {
         .unwrap()
         .append_header(header.block_number, &header)
         .unwrap()
-        .append_state_diff(header.block_number, state_diff, IndexMap::new())
+        .append_thin_state_diff(header.block_number, state_diff)
+        .unwrap()
+        .append_classes(
+            header.block_number,
+            &[],
+            &[
+                (ClassHash(stark_felt!("0x0")), &class_without_state_mutability),
+                (ClassHash(stark_felt!("0x1")), &class_with_state_mutability),
+            ],
+        )
         .unwrap()
         .commit()
         .unwrap();

--- a/crates/papyrus_rpc/src/v0_7/execution_test.rs
+++ b/crates/papyrus_rpc/src/v0_7/execution_test.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use assert_matches::assert_matches;
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
-use indexmap::{indexmap, IndexMap};
+use indexmap::indexmap;
 use jsonrpsee::core::Error;
 use jsonrpsee::RpcModule;
 use lazy_static::lazy_static;
@@ -29,6 +29,7 @@ use papyrus_execution::objects::{
 use papyrus_execution::testing_instances::get_storage_var_address;
 use papyrus_execution::ExecutableTransactionInput;
 use papyrus_storage::body::BodyStorageWriter;
+use papyrus_storage::class::ClassStorageWriter;
 use papyrus_storage::compiled_class::CasmStorageWriter;
 use papyrus_storage::header::HeaderStorageWriter;
 use papyrus_storage::state::StateStorageWriter;
@@ -59,7 +60,7 @@ use starknet_api::deprecated_contract_class::{
     EntryPointType,
 };
 use starknet_api::hash::{StarkFelt, StarkHash};
-use starknet_api::state::{StateDiff, StorageKey};
+use starknet_api::state::{StorageKey, ThinStateDiff as StarknetApiStateDiff};
 use starknet_api::transaction::{
     Calldata,
     Fee,
@@ -803,14 +804,15 @@ async fn trace_block_transactions_regular_and_pending() {
             },
         )
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             BlockNumber(3),
-            StateDiff {
+            StarknetApiStateDiff {
                 nonces: indexmap!(*ACCOUNT_ADDRESS => Nonce(stark_felt!(2_u128))),
                 ..Default::default()
             },
-            IndexMap::new(),
         )
+        .unwrap()
+        .append_classes(BlockNumber(3), &[], &[])
         .unwrap()
         .commit()
         .unwrap();
@@ -1001,14 +1003,15 @@ async fn trace_block_transactions_and_trace_transaction_execution_context() {
             },
         )
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             BlockNumber(3),
-            StateDiff {
+            StarknetApiStateDiff {
                 nonces: indexmap!(*ACCOUNT_ADDRESS => Nonce(stark_felt!(2_u128))),
                 ..Default::default()
             },
-            IndexMap::new(),
         )
+        .unwrap()
+        .append_classes(BlockNumber(3), &[], &[])
         .unwrap()
         .commit()
         .unwrap();
@@ -1656,9 +1659,9 @@ fn prepare_storage_for_execution(mut storage_writer: StorageWriter) -> StorageWr
         .unwrap()
         .append_body(BlockNumber(0), BlockBody::default())
         .unwrap()
-        .append_state_diff(
+        .append_thin_state_diff(
             BlockNumber(0),
-            StateDiff {
+            StarknetApiStateDiff {
                 deployed_contracts: indexmap!(
                     *DEPRECATED_CONTRACT_ADDRESS => class_hash1,
                     *CONTRACT_ADDRESS => class_hash2,
@@ -1673,15 +1676,12 @@ fn prepare_storage_for_execution(mut storage_writer: StorageWriter) -> StorageWr
                         minter_var_address => *ACCOUNT_ADDRESS.0.key()
                     ),
                 ),
-                declared_classes: indexmap!(
-                    class_hash2 =>
-                    (compiled_class_hash, class2)
-                ),
-                deprecated_declared_classes: indexmap!(
-                    class_hash1 => class1,
-                    *ACCOUNT_CLASS_HASH => account_class,
-                    *TEST_ERC20_CONTRACT_CLASS_HASH => fee_contract_class,
-                ),
+                declared_classes: indexmap!(class_hash2 => compiled_class_hash),
+                deprecated_declared_classes: vec![
+                    class_hash1,
+                    *ACCOUNT_CLASS_HASH,
+                    *TEST_ERC20_CONTRACT_CLASS_HASH,
+                ],
                 nonces: indexmap!(
                     *TEST_ERC20_CONTRACT_ADDRESS => Nonce::default(),
                     *CONTRACT_ADDRESS => Nonce::default(),
@@ -1690,7 +1690,16 @@ fn prepare_storage_for_execution(mut storage_writer: StorageWriter) -> StorageWr
                 ),
                 replaced_classes: indexmap!(),
             },
-            indexmap!(),
+        )
+        .unwrap()
+        .append_classes(
+            BlockNumber(0),
+            &[(class_hash2, &class2)],
+            &[
+                (class_hash1, &class1),
+                (*ACCOUNT_CLASS_HASH, &account_class),
+                (*TEST_ERC20_CONTRACT_CLASS_HASH, &fee_contract_class),
+            ],
         )
         .unwrap()
         .append_casm(&class_hash2, &casm)
@@ -1709,7 +1718,9 @@ fn prepare_storage_for_execution(mut storage_writer: StorageWriter) -> StorageWr
         .unwrap()
         .append_body(BlockNumber(1), BlockBody::default())
         .unwrap()
-        .append_state_diff(BlockNumber(1), StateDiff::default(), indexmap![])
+        .append_thin_state_diff(BlockNumber(1), StarknetApiStateDiff::default())
+        .unwrap()
+        .append_classes(BlockNumber(1), &[], &[])
         .unwrap()
         .append_header(
             BlockNumber(2),
@@ -1727,7 +1738,9 @@ fn prepare_storage_for_execution(mut storage_writer: StorageWriter) -> StorageWr
         .unwrap()
         .append_body(BlockNumber(2), BlockBody::default())
         .unwrap()
-        .append_state_diff(BlockNumber(2), StateDiff::default(), indexmap![])
+        .append_thin_state_diff(BlockNumber(2), StarknetApiStateDiff::default())
+        .unwrap()
+        .append_classes(BlockNumber(2), &[], &[])
         .unwrap()
         .commit()
         .unwrap();
@@ -1752,7 +1765,9 @@ fn write_empty_block(mut storage_writer: StorageWriter) {
         .unwrap()
         .append_body(BlockNumber(0), BlockBody::default())
         .unwrap()
-        .append_state_diff(BlockNumber(0), StateDiff::default(), indexmap!())
+        .append_thin_state_diff(BlockNumber(0), StarknetApiStateDiff::default())
+        .unwrap()
+        .append_classes(BlockNumber(0), &[], &[])
         .unwrap()
         .commit()
         .unwrap();

--- a/crates/papyrus_storage/src/state/mod.rs
+++ b/crates/papyrus_storage/src/state/mod.rs
@@ -13,7 +13,7 @@
 //! # use papyrus_storage::{db::DbConfig, StorageConfig};
 //! # use starknet_api::block::BlockNumber;
 //! # use starknet_api::core::{ChainId, ContractAddress};
-//! use starknet_api::state::{StateDiff, StateNumber, ThinStateDiff};
+//! use starknet_api::state::{StateNumber, ThinStateDiff};
 //!
 //! # let dir_handle = tempfile::tempdir().unwrap();
 //! # let dir = dir_handle.path().to_path_buf();
@@ -26,24 +26,26 @@
 //! #     growth_step: 1 << 26, // 64MB
 //! # };
 //! # let storage_config = StorageConfig{db_config, ..Default::default()};
-//! let state_diff = StateDiff::default();
+//! let state_diff = ThinStateDiff::default();
 //! let (reader, mut writer) = open_storage(storage_config)?;
 //! writer
-//!     .begin_rw_txn()?                                                    // Start a RW transaction.
-//!     .append_state_diff(BlockNumber(0), state_diff, IndexMap::new())?    // Append a state diff.
+//!     .begin_rw_txn()? // Start a RW transaction.
+//!     .append_thin_state_diff(BlockNumber(0), state_diff.clone())? // Append a state diff.
 //!     .commit()?;
 //!
-//! // Get the StateDiff stripped of the class definitions (ThinStateDiff).
-//! let thin_state_diff = reader.begin_ro_txn()?.get_state_diff(BlockNumber(0))?;
-//! assert_eq!(thin_state_diff, Some(ThinStateDiff::from(StateDiff::default())));
+//! // Get the state diff.
+//! let read_state_diff = reader.begin_ro_txn()?.get_state_diff(BlockNumber(0))?;
+//! assert_eq!(read_state_diff, Some(state_diff));
 //!
 //! # let contract_address = ContractAddress::default();
 //! // Get the class hash of a contract at a given state number.
 //! // The transaction must live at least as long as the state reader.
 //! let txn = reader.begin_ro_txn()?;
 //! let state_reader = txn.get_state_reader()?;
-//! let class_hash = state_reader
-//!     .get_class_hash_at(StateNumber::unchecked_right_after_block(BlockNumber(0)), &contract_address)?;
+//! let class_hash = state_reader.get_class_hash_at(
+//!     StateNumber::unchecked_right_after_block(BlockNumber(0)),
+//!     &contract_address,
+//! )?;
 //! # Ok::<(), papyrus_storage::StorageError>(())
 //! ```
 
@@ -61,7 +63,7 @@ use starknet_api::block::BlockNumber;
 use starknet_api::core::{ClassHash, ContractAddress, Nonce};
 use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContractClass;
 use starknet_api::hash::StarkFelt;
-use starknet_api::state::{ContractClass, StateDiff, StateNumber, StorageKey, ThinStateDiff};
+use starknet_api::state::{ContractClass, StateNumber, StorageKey, ThinStateDiff};
 use tracing::debug;
 
 use crate::db::serialization::{NoVersionValueWrapper, VersionWrapper, VersionZeroWrapper};
@@ -143,29 +145,7 @@ pub trait StateStorageWriter
 where
     Self: Sized,
 {
-    /// Appends a state diff with classes to the storage.
-    /// * Arg deployed_contract_class_definitions: Until Starknet version 0.11 users could
-    ///   implicitly
-    /// declare new classes by deploying contracts. To append a state diff with such classes, you
-    /// must pass the class definitions of the implicitly declared classes.
-    // To enforce that no commit happen after a failure, we consume and return Self on success.
-    // TODO(shahak): Remove this once we can add classes
-    // append_thin_state_diff to append_state_diff.
-    fn append_state_diff(
-        self,
-        block_number: BlockNumber,
-        state_diff: StateDiff,
-        // TODO(anatg): Remove once there are no more deployed contracts with undeclared classes.
-        // Class definitions of deployed contracts with classes that were not declared in this
-        // state diff.
-        // Note: Since 0.11 only deprecated classes can be implicitly declared by contract
-        // deployment, so there is no need to pass the classes of deployed contracts if they are of
-        // the new version.
-        deployed_contract_class_definitions: IndexMap<ClassHash, DeprecatedContractClass>,
-    ) -> StorageResult<Self>;
-
-    // TODO(shahak): Add functionality to add classes for the thin state diff we added.
-    // TODO(shahak): Rename to append_state_diff once we remove append_state_diff.
+    // TODO(shahak): Rename to append_state_diff.
     /// Appends a state diff without classes to the storage.
     fn append_thin_state_diff(
         self,
@@ -448,83 +428,6 @@ impl<'env, Mode: TransactionKind> StateReader<'env, Mode> {
 }
 
 impl<'env> StateStorageWriter for StorageTxn<'env, RW> {
-    // This function is deprecated and will be erased in the future.
-    // TODO(shahak): Erase append_state_diff.
-    #[latency_histogram("storage_append_state_diff_latency_seconds")]
-    fn append_state_diff(
-        self,
-        block_number: BlockNumber,
-        state_diff: StateDiff,
-        mut deployed_contract_class_definitions: IndexMap<ClassHash, DeprecatedContractClass>,
-    ) -> StorageResult<Self> {
-        let (thin_state_diff, declared_classes, deprecated_declared_classes) =
-            ThinStateDiff::from_state_diff(state_diff);
-
-        let new_self = self.append_thin_state_diff(block_number, thin_state_diff)?;
-
-        let file_offset_table = new_self.txn.open_table(&new_self.tables.file_offsets)?;
-        let markers_table = new_self.open_table(&new_self.tables.markers)?;
-        let declared_classes_table = new_self.open_table(&new_self.tables.declared_classes)?;
-        let deprecated_declared_classes_table =
-            new_self.open_table(&new_self.tables.deprecated_declared_classes)?;
-        let state_diffs_table = new_self.open_table(&new_self.tables.state_diffs)?;
-
-        advance_class_marker_over_blocks_without_classes(
-            &new_self.txn,
-            &markers_table,
-            &state_diffs_table,
-            &new_self.file_handlers,
-        )?;
-
-        if markers_table.get(&new_self.txn, &MarkerKind::Class)?.unwrap_or_default() == block_number
-        {
-            update_marker_to_next_block(
-                &new_self.txn,
-                &markers_table,
-                MarkerKind::Class,
-                block_number,
-            )?;
-        }
-
-        // Write declared classes.
-        write_declared_classes(
-            &declared_classes,
-            &new_self.txn,
-            &declared_classes_table,
-            &new_self.file_handlers,
-            &file_offset_table,
-        )?;
-
-        // Write deprecated declared classes.
-        if !deployed_contract_class_definitions.is_empty() {
-            // TODO(anatg): Remove this after regenesis.
-            if !deprecated_declared_classes.is_empty() {
-                deployed_contract_class_definitions.extend(deprecated_declared_classes);
-                //  TODO(anatg): Add a test for this (should fail if not sorted here).
-                deployed_contract_class_definitions.sort_unstable_keys();
-            }
-            write_deprecated_declared_classes(
-                deployed_contract_class_definitions,
-                &new_self.txn,
-                block_number,
-                &deprecated_declared_classes_table,
-                &new_self.file_handlers,
-                &file_offset_table,
-            )?;
-        } else {
-            write_deprecated_declared_classes(
-                deprecated_declared_classes,
-                &new_self.txn,
-                block_number,
-                &deprecated_declared_classes_table,
-                &new_self.file_handlers,
-                &file_offset_table,
-            )?;
-        }
-
-        Ok(new_self)
-    }
-
     #[latency_histogram("storage_append_thin_state_diff_latency_seconds")]
     fn append_thin_state_diff(
         self,
@@ -720,74 +623,6 @@ fn advance_compiled_class_marker_over_blocks_without_classes<'env>(
         }
         compiled_class_marker = compiled_class_marker.unchecked_next();
         markers_table.upsert(txn, &MarkerKind::CompiledClass, &compiled_class_marker)?;
-    }
-    Ok(())
-}
-
-fn advance_class_marker_over_blocks_without_classes<'env>(
-    txn: &DbTransaction<'env, RW>,
-    markers_table: &'env MarkersTable<'env>,
-    state_diffs_table: &'env TableHandle<
-        '_,
-        BlockNumber,
-        VersionZeroWrapper<LocationInFile>,
-        SimpleTable,
-    >,
-    file_handlers: &FileHandlers<RW>,
-) -> StorageResult<()> {
-    let state_marker = markers_table.get(txn, &MarkerKind::State)?.unwrap_or_default();
-    let mut class_marker = markers_table.get(txn, &MarkerKind::Class)?.unwrap_or_default();
-    while class_marker < state_marker {
-        let state_diff_location = state_diffs_table
-            .get(txn, &class_marker)?
-            .unwrap_or_else(|| panic!("Missing state diff for block {class_marker}"));
-        let thin_state_diff = file_handlers.get_thin_state_diff_unchecked(state_diff_location)?;
-        if !thin_state_diff.declared_classes.is_empty()
-            || !thin_state_diff.deprecated_declared_classes.is_empty()
-        {
-            break;
-        }
-        class_marker = class_marker.unchecked_next();
-        markers_table.upsert(txn, &MarkerKind::Class, &class_marker)?;
-    }
-    Ok(())
-}
-
-fn write_declared_classes<'env>(
-    declared_classes: &IndexMap<ClassHash, ContractClass>,
-    txn: &DbTransaction<'env, RW>,
-    declared_classes_table: &'env DeclaredClassesTable<'env>,
-    file_handlers: &FileHandlers<RW>,
-    file_offset_table: &'env FileOffsetTable<'env>,
-) -> StorageResult<()> {
-    for (class_hash, contract_class) in declared_classes {
-        let location = file_handlers.append_contract_class(contract_class);
-        declared_classes_table.insert(txn, class_hash, &location)?;
-        file_offset_table.upsert(txn, &OffsetKind::ContractClass, &location.next_offset())?;
-    }
-    Ok(())
-}
-
-fn write_deprecated_declared_classes<'env>(
-    deprecated_declared_classes: IndexMap<ClassHash, DeprecatedContractClass>,
-    txn: &DbTransaction<'env, RW>,
-    block_number: BlockNumber,
-    deprecated_declared_classes_table: &'env DeprecatedDeclaredClassesTable<'env>,
-    file_handlers: &FileHandlers<RW>,
-    file_offset_table: &'env FileOffsetTable<'env>,
-) -> StorageResult<()> {
-    for (class_hash, deprecated_contract_class) in deprecated_declared_classes {
-        if deprecated_declared_classes_table.get(txn, &class_hash)?.is_some() {
-            continue;
-        }
-        let location = file_handlers.append_deprecated_contract_class(&deprecated_contract_class);
-        let value = IndexedDeprecatedContractClass { block_number, location_in_file: location };
-        file_offset_table.upsert(
-            txn,
-            &OffsetKind::DeprecatedContractClass,
-            &location.next_offset(),
-        )?;
-        deprecated_declared_classes_table.insert(txn, &class_hash, &value)?;
     }
     Ok(())
 }

--- a/crates/papyrus_sync/src/sources/central_test.rs
+++ b/crates/papyrus_sync/src/sources/central_test.rs
@@ -7,6 +7,7 @@ use futures_util::pin_mut;
 use indexmap::{indexmap, IndexMap};
 use lru::LruCache;
 use mockall::predicate;
+use papyrus_storage::class::ClassStorageWriter;
 use papyrus_storage::state::StateStorageWriter;
 use papyrus_storage::test_utils::get_test_storage;
 use pretty_assertions::assert_eq;
@@ -24,7 +25,7 @@ use starknet_api::core::{
 use starknet_api::crypto::PublicKey;
 use starknet_api::deprecated_contract_class::ContractClass as DeprecatedContractClass;
 use starknet_api::hash::{StarkFelt, StarkHash};
-use starknet_api::state::{ContractClass as sn_api_ContractClass, StateDiff, StorageKey};
+use starknet_api::state::{ContractClass as sn_api_ContractClass, StorageKey, ThinStateDiff};
 use starknet_api::{patricia_key, stark_felt};
 use starknet_client::reader::objects::block::DeprecatedBlock;
 use starknet_client::reader::{
@@ -436,35 +437,59 @@ async fn stream_state_updates() {
 #[tokio::test]
 async fn stream_compiled_classes() {
     let ((reader, mut writer), _temp_dir) = get_test_storage();
-    writer.begin_rw_txn().unwrap().append_state_diff(
-        BlockNumber(0),
-        StateDiff {
-            deployed_contracts: indexmap! {},
-            storage_diffs: indexmap! {},
-            declared_classes: indexmap! {
-                ClassHash(stark_felt!("0x0")) => (CompiledClassHash(stark_felt!("0x0")), sn_api_ContractClass::default()),
-                ClassHash(stark_felt!("0x1")) => (CompiledClassHash(stark_felt!("0x1")), sn_api_ContractClass::default())
+    writer
+        .begin_rw_txn()
+        .unwrap()
+        .append_thin_state_diff(
+            BlockNumber(0),
+            ThinStateDiff {
+                deployed_contracts: indexmap! {},
+                storage_diffs: indexmap! {},
+                declared_classes: indexmap! {
+                    ClassHash(stark_felt!("0x0")) => CompiledClassHash(stark_felt!("0x0")),
+                    ClassHash(stark_felt!("0x1")) => CompiledClassHash(stark_felt!("0x1")),
+                },
+                deprecated_declared_classes: vec![],
+                nonces: indexmap! {},
+                replaced_classes: indexmap! {},
             },
-            deprecated_declared_classes: indexmap! {},
-            nonces: indexmap! {},
-            replaced_classes: indexmap! {},
-        },
-        indexmap! {},
-    ).unwrap().append_state_diff(
-        BlockNumber(1),
-        StateDiff {
-            deployed_contracts: indexmap! {},
-            storage_diffs: indexmap! {},
-            declared_classes: indexmap! {
-                ClassHash(stark_felt!("0x2")) => (CompiledClassHash(stark_felt!("0x2")), sn_api_ContractClass::default()),
-                ClassHash(stark_felt!("0x3")) => (CompiledClassHash(stark_felt!("0x3")), sn_api_ContractClass::default())
+        )
+        .unwrap()
+        .append_thin_state_diff(
+            BlockNumber(1),
+            ThinStateDiff {
+                deployed_contracts: indexmap! {},
+                storage_diffs: indexmap! {},
+                declared_classes: indexmap! {
+                    ClassHash(stark_felt!("0x2")) => CompiledClassHash(stark_felt!("0x2")),
+                    ClassHash(stark_felt!("0x3")) => CompiledClassHash(stark_felt!("0x3")),
+                },
+                deprecated_declared_classes: vec![],
+                nonces: indexmap! {},
+                replaced_classes: indexmap! {},
             },
-            deprecated_declared_classes: indexmap! {},
-            nonces: indexmap! {},
-            replaced_classes: indexmap! {},
-        },
-        indexmap! {},
-    ).unwrap().commit().unwrap();
+        )
+        .unwrap()
+        .append_classes(
+            BlockNumber(0),
+            &[
+                (ClassHash(stark_felt!("0x0")), &sn_api_ContractClass::default()),
+                (ClassHash(stark_felt!("0x1")), &sn_api_ContractClass::default()),
+            ],
+            &[],
+        )
+        .unwrap()
+        .append_classes(
+            BlockNumber(1),
+            &[
+                (ClassHash(stark_felt!("0x2")), &sn_api_ContractClass::default()),
+                (ClassHash(stark_felt!("0x3")), &sn_api_ContractClass::default()),
+            ],
+            &[],
+        )
+        .unwrap()
+        .commit()
+        .unwrap();
 
     let felts: Vec<_> = (0..4).map(|i| stark_felt!(format!("0x{i}").as_str())).collect();
     let mut mock = MockStarknetReader::new();


### PR DESCRIPTION
- fix(storage): revert_state_diff works if there are missing classes
- fix(sync): use append_thin_state_diff in sync
- fix: use append_thin_state_diff in network and execution
- fix: use append_thin_state_diff in rpc
- chore(storage): remove append_state_diff

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1890)
<!-- Reviewable:end -->
