### PR TITLE
refactor(network): rename BlockHeaderDBExecutor to DBExecutor

### DIFF
--- a/crates/papyrus_network/src/db_executor/mod.rs
+++ b/crates/papyrus_network/src/db_executor/mod.rs
@@ -182,10 +182,10 @@ impl DBExecutorError {
     }
 }
 
-/// Db executor is a stream of queries. Each result is marks the end of a query fulfillment.
+/// DBExecutorTrait is a stream of queries. Each result is marks the end of a query fulfillment.
 /// A query can either succeed (and return Ok(QueryId)) or fail (and return Err(DBExecutorError)).
 /// The stream is never exhausted, and it is the responsibility of the user to poll it.
-pub trait DBExecutor: Stream<Item = Result<QueryId, DBExecutorError>> + Unpin {
+pub trait DBExecutorTrait: Stream<Item = Result<QueryId, DBExecutorError>> + Unpin {
     // TODO: add writer functionality
     fn register_query(
         &mut self,
@@ -196,19 +196,19 @@ pub trait DBExecutor: Stream<Item = Result<QueryId, DBExecutorError>> + Unpin {
 }
 
 // TODO: currently this executor returns only block headers and signatures.
-pub struct BlockHeaderDBExecutor {
+pub struct DBExecutor {
     next_query_id: usize,
     storage_reader: StorageReader,
     query_execution_set: FuturesUnordered<JoinHandle<Result<QueryId, DBExecutorError>>>,
 }
 
-impl BlockHeaderDBExecutor {
+impl DBExecutor {
     pub fn new(storage_reader: StorageReader) -> Self {
         Self { next_query_id: 0, storage_reader, query_execution_set: FuturesUnordered::new() }
     }
 }
 
-impl DBExecutor for BlockHeaderDBExecutor {
+impl DBExecutorTrait for DBExecutor {
     fn register_query(
         &mut self,
         query: InternalQuery,
@@ -266,7 +266,7 @@ impl DBExecutor for BlockHeaderDBExecutor {
     }
 }
 
-impl Stream for BlockHeaderDBExecutor {
+impl Stream for DBExecutor {
     type Item = Result<QueryId, DBExecutorError>;
 
     fn poll_next(

--- a/crates/papyrus_network/src/network_manager/test.rs
+++ b/crates/papyrus_network/src/network_manager/test.rs
@@ -25,8 +25,8 @@ use super::swarm_trait::{Event, SwarmTrait};
 use super::GenericNetworkManager;
 use crate::db_executor::{
     poll_query_execution_set,
-    DBExecutor,
     DBExecutorError,
+    DBExecutorTrait,
     Data,
     FetchBlockDataFromDb,
     QueryId,
@@ -193,8 +193,8 @@ impl Stream for MockDBExecutor {
     }
 }
 
-impl DBExecutor for MockDBExecutor {
-    // TODO(shahak): Consider fixing code duplication with BlockHeaderDBExecutor.
+impl DBExecutorTrait for MockDBExecutor {
+    // TODO(shahak): Consider fixing code duplication with DBExecutor.
     fn register_query(
         &mut self,
         query: InternalQuery,


### PR DESCRIPTION
rename `DBExecutor` to `DBExecutorTrait`, and `BlockHeaderDBExecutor` to `DBExecutor`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1977)
<!-- Reviewable:end -->
