### PR TITLE
feat(network): connect broadcast behaviour to mixed behaviour

### DIFF
--- a/crates/papyrus_network/src/broadcast/mod.rs
+++ b/crates/papyrus_network/src/broadcast/mod.rs
@@ -12,6 +12,8 @@ use libp2p::swarm::{
 };
 use libp2p::{Multiaddr, PeerId};
 
+use crate::mixed_behaviour;
+use crate::mixed_behaviour::BridgedBehaviour;
 // TODO(shahak): move Bytes to a more generic file.
 use crate::streamed_bytes::Bytes;
 
@@ -19,6 +21,7 @@ pub struct Behaviour;
 
 pub type Topic = String;
 
+#[derive(Debug)]
 pub enum ExternalEvent {
     #[allow(dead_code)]
     Received { originated_peer_id: PeerId, message: Bytes, topic: Topic },
@@ -63,14 +66,15 @@ impl NetworkBehaviour for Behaviour {
         _cx: &mut Context<'_>,
     ) -> Poll<ToSwarm<Self::ToSwarm, <Self::ConnectionHandler as ConnectionHandler>::FromBehaviour>>
     {
-        unimplemented!()
+        // TODO(shahak): Implement this.
+        Poll::Pending
     }
 }
 
 impl Behaviour {
-    #[allow(dead_code)]
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
-        unimplemented!()
+        Self
     }
 
     #[allow(dead_code)]
@@ -81,5 +85,17 @@ impl Behaviour {
     #[allow(dead_code)]
     pub fn broadcast_message(&mut self, _message: Bytes, _topic: Topic) {
         unimplemented!()
+    }
+}
+
+impl From<ExternalEvent> for mixed_behaviour::Event {
+    fn from(event: ExternalEvent) -> Self {
+        mixed_behaviour::Event::ExternalEvent(mixed_behaviour::ExternalEvent::Broadcast(event))
+    }
+}
+
+impl BridgedBehaviour for Behaviour {
+    fn on_other_behaviour_event(&mut self, _event: &mixed_behaviour::ToOtherBehaviourEvent) {
+        // TODO(shahak): Implement this.
     }
 }

--- a/crates/papyrus_network/src/mixed_behaviour.rs
+++ b/crates/papyrus_network/src/mixed_behaviour.rs
@@ -10,7 +10,7 @@ use libp2p::{identify, kad, Multiaddr, PeerId};
 use crate::discovery::identify_impl::{IdentifyToOtherBehaviourEvent, IDENTIFY_PROTOCOL_VERSION};
 use crate::discovery::kad_impl::KadToOtherBehaviourEvent;
 use crate::peer_manager::PeerManagerConfig;
-use crate::{discovery, peer_manager, streamed_bytes};
+use crate::{broadcast, discovery, peer_manager, streamed_bytes};
 
 // TODO: consider reducing the pulicity of all behaviour to pub(crate)
 #[derive(NetworkBehaviour)]
@@ -22,6 +22,7 @@ pub struct MixedBehaviour {
     // TODO(shahak): Consider using a different store.
     pub kademlia: kad::Behaviour<MemoryStore>,
     pub streamed_bytes: streamed_bytes::Behaviour,
+    pub broadcast: broadcast::Behaviour,
 }
 
 #[derive(Debug)]
@@ -33,6 +34,7 @@ pub enum Event {
 #[derive(Debug)]
 pub enum ExternalEvent {
     StreamedBytes(streamed_bytes::behaviour::ExternalEvent),
+    Broadcast(broadcast::ExternalEvent),
 }
 
 #[derive(Debug)]
@@ -77,6 +79,7 @@ impl MixedBehaviour {
             // TODO: change kademlia protocol name
             kademlia: kad::Behaviour::new(local_peer_id, MemoryStore::new(local_peer_id)),
             streamed_bytes: streamed_bytes::Behaviour::new(streamed_bytes_config),
+            broadcast: broadcast::Behaviour::new(),
         }
     }
 }

--- a/crates/papyrus_network/src/network_manager/mod.rs
+++ b/crates/papyrus_network/src/network_manager/mod.rs
@@ -210,10 +210,14 @@ impl<DBExecutorT: DBExecutorTrait, SwarmT: SwarmTrait> GenericNetworkManager<DBE
             mixed_behaviour::ExternalEvent::StreamedBytes(event) => {
                 self.handle_stream_bytes_behaviour_event(event);
             }
+            mixed_behaviour::ExternalEvent::Broadcast(_event) => {
+                unimplemented!();
+            }
         }
     }
 
     fn handle_to_other_behaviour_event(&mut self, event: mixed_behaviour::ToOtherBehaviourEvent) {
+        // TODO(shahak): Move this logic to mixed_behaviour.
         if let mixed_behaviour::ToOtherBehaviourEvent::NoOp = event {
             return;
         }
@@ -224,6 +228,7 @@ impl<DBExecutorT: DBExecutorTrait, SwarmT: SwarmTrait> GenericNetworkManager<DBE
         }
         self.swarm.behaviour_mut().streamed_bytes.on_other_behaviour_event(&event);
         self.swarm.behaviour_mut().peer_manager.on_other_behaviour_event(&event);
+        self.swarm.behaviour_mut().broadcast.on_other_behaviour_event(&event);
     }
 
     fn handle_stream_bytes_behaviour_event(


### PR DESCRIPTION
- refactor(network): mixed event contains the outputting behaviour instead of notified behaviour
- feat(network): add broadcast behaviour with unimplemented
- feat(network): connect broadcast behaviour to mixed behaviour

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1982)
<!-- Reviewable:end -->
