### PR TITLE
feat(network): add register_broadcast_subscribers without connecting to behaviour

### DIFF
--- a/crates/papyrus_network/src/broadcast/mod.rs
+++ b/crates/papyrus_network/src/broadcast/mod.rs
@@ -12,6 +12,8 @@ use libp2p::swarm::{
 };
 use libp2p::{Multiaddr, PeerId};
 
+use crate::mixed_behaviour;
+use crate::mixed_behaviour::BridgedBehaviour;
 // TODO(shahak): move Bytes to a more generic file.
 use crate::streamed_bytes::Bytes;
 
@@ -19,6 +21,7 @@ pub struct Behaviour;
 
 pub type Topic = String;
 
+#[derive(Debug)]
 pub enum ExternalEvent {
     #[allow(dead_code)]
     Received { originated_peer_id: PeerId, message: Bytes, topic: Topic },
@@ -63,14 +66,15 @@ impl NetworkBehaviour for Behaviour {
         _cx: &mut Context<'_>,
     ) -> Poll<ToSwarm<Self::ToSwarm, <Self::ConnectionHandler as ConnectionHandler>::FromBehaviour>>
     {
-        unimplemented!()
+        // TODO(shahak): Implement this.
+        Poll::Pending
     }
 }
 
 impl Behaviour {
-    #[allow(dead_code)]
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
-        unimplemented!()
+        Self
     }
 
     #[allow(dead_code)]
@@ -81,5 +85,17 @@ impl Behaviour {
     #[allow(dead_code)]
     pub fn broadcast_message(&mut self, _message: Bytes, _topic: Topic) {
         unimplemented!()
+    }
+}
+
+impl From<ExternalEvent> for mixed_behaviour::Event {
+    fn from(event: ExternalEvent) -> Self {
+        mixed_behaviour::Event::ExternalEvent(mixed_behaviour::ExternalEvent::Broadcast(event))
+    }
+}
+
+impl BridgedBehaviour for Behaviour {
+    fn on_other_behaviour_event(&mut self, _event: &mixed_behaviour::ToOtherBehaviourEvent) {
+        // TODO(shahak): Implement this.
     }
 }

--- a/crates/papyrus_network/src/broadcast/mod.rs
+++ b/crates/papyrus_network/src/broadcast/mod.rs
@@ -1,0 +1,85 @@
+use std::task::{Context, Poll};
+
+use libp2p::core::Endpoint;
+use libp2p::swarm::{
+    dummy,
+    ConnectionDenied,
+    ConnectionHandler,
+    ConnectionId,
+    FromSwarm,
+    NetworkBehaviour,
+    ToSwarm,
+};
+use libp2p::{Multiaddr, PeerId};
+
+// TODO(shahak): move Bytes to a more generic file.
+use crate::streamed_bytes::Bytes;
+
+pub struct Behaviour;
+
+pub type Topic = String;
+
+pub enum ExternalEvent {
+    #[allow(dead_code)]
+    Received { originated_peer_id: PeerId, message: Bytes, topic: Topic },
+}
+
+impl NetworkBehaviour for Behaviour {
+    type ConnectionHandler = dummy::ConnectionHandler;
+    type ToSwarm = ExternalEvent;
+
+    fn handle_established_inbound_connection(
+        &mut self,
+        _connection_id: ConnectionId,
+        _peer: PeerId,
+        _local_addr: &Multiaddr,
+        _remote_addr: &Multiaddr,
+    ) -> Result<Self::ConnectionHandler, ConnectionDenied> {
+        Ok(dummy::ConnectionHandler)
+    }
+
+    fn handle_established_outbound_connection(
+        &mut self,
+        _connection_id: ConnectionId,
+        _peer: PeerId,
+        _addr: &Multiaddr,
+        _role_override: Endpoint,
+    ) -> Result<Self::ConnectionHandler, ConnectionDenied> {
+        Ok(dummy::ConnectionHandler)
+    }
+
+    fn on_swarm_event(&mut self, _event: FromSwarm<'_>) {}
+
+    fn on_connection_handler_event(
+        &mut self,
+        _peer_id: PeerId,
+        _connection_id: ConnectionId,
+        _event: <Self::ConnectionHandler as ConnectionHandler>::ToBehaviour,
+    ) {
+    }
+
+    fn poll(
+        &mut self,
+        _cx: &mut Context<'_>,
+    ) -> Poll<ToSwarm<Self::ToSwarm, <Self::ConnectionHandler as ConnectionHandler>::FromBehaviour>>
+    {
+        unimplemented!()
+    }
+}
+
+impl Behaviour {
+    #[allow(dead_code)]
+    pub fn new() -> Self {
+        unimplemented!()
+    }
+
+    #[allow(dead_code)]
+    pub fn subscribe_to_topic(&mut self, _topic: Topic) {
+        unimplemented!()
+    }
+
+    #[allow(dead_code)]
+    pub fn broadcast_message(&mut self, _message: Bytes, _topic: Topic) {
+        unimplemented!()
+    }
+}

--- a/crates/papyrus_network/src/discovery/discovery_test.rs
+++ b/crates/papyrus_network/src/discovery/discovery_test.rs
@@ -24,11 +24,11 @@ use tokio::sync::Mutex;
 use tokio::time::timeout;
 use void::Void;
 
-use super::kad_impl::KadFromOtherBehaviourEvent;
-use super::{Behaviour, FromOtherBehaviourEvent, ToOtherBehaviourEvent, DIAL_SLEEP};
-use crate::mixed_behaviour;
+use super::kad_impl::KadToOtherBehaviourEvent;
+use super::{Behaviour, ToOtherBehaviourEvent, DIAL_SLEEP};
 use crate::mixed_behaviour::BridgedBehaviour;
 use crate::test_utils::next_on_mutex_stream;
+use crate::{mixed_behaviour, peer_manager};
 
 const TIMEOUT: Duration = Duration::from_secs(1);
 const SLEEP_DURATION: Duration = Duration::from_millis(10);
@@ -184,12 +184,11 @@ async fn create_behaviour_and_connect_to_bootstrap_node() -> Behaviour {
     let event = timeout(TIMEOUT, behaviour.next()).await.unwrap().unwrap();
     assert_matches!(
         event,
-        ToSwarm::GenerateEvent(ToOtherBehaviourEvent(
-            KadFromOtherBehaviourEvent::FoundListenAddresses {
+        ToSwarm::GenerateEvent(ToOtherBehaviourEvent::FoundListenAddresses {
                 peer_id,
                 listen_addresses,
             }
-        )) if peer_id == bootstrap_peer_id && listen_addresses == vec![bootstrap_peer_address]
+        ) if peer_id == bootstrap_peer_id && listen_addresses == vec![bootstrap_peer_address]
     );
 
     behaviour
@@ -202,9 +201,7 @@ async fn discovery_outputs_single_query_after_connecting() {
     let event = timeout(TIMEOUT, behaviour.next()).await.unwrap().unwrap();
     assert_matches!(
         event,
-        ToSwarm::GenerateEvent(ToOtherBehaviourEvent(KadFromOtherBehaviourEvent::RequestKadQuery(
-            _peer_id
-        )))
+        ToSwarm::GenerateEvent(ToOtherBehaviourEvent::RequestKadQuery(_peer_id))
     );
 
     assert_no_event(&mut behaviour);
@@ -214,20 +211,18 @@ async fn discovery_outputs_single_query_after_connecting() {
 async fn discovery_doesnt_output_queries_while_paused() {
     let mut behaviour = create_behaviour_and_connect_to_bootstrap_node().await;
 
-    behaviour.on_other_behaviour_event(mixed_behaviour::InternalEvent::NotifyDiscovery(
-        FromOtherBehaviourEvent::PauseDiscovery,
+    behaviour.on_other_behaviour_event(&mixed_behaviour::ToOtherBehaviourEvent::PeerManager(
+        peer_manager::ToOtherBehaviourEvent::PauseDiscovery,
     ));
     assert_no_event(&mut behaviour);
 
-    behaviour.on_other_behaviour_event(mixed_behaviour::InternalEvent::NotifyDiscovery(
-        FromOtherBehaviourEvent::ResumeDiscovery,
+    behaviour.on_other_behaviour_event(&mixed_behaviour::ToOtherBehaviourEvent::PeerManager(
+        peer_manager::ToOtherBehaviourEvent::ResumeDiscovery,
     ));
     let event = timeout(TIMEOUT, behaviour.next()).await.unwrap().unwrap();
     assert_matches!(
         event,
-        ToSwarm::GenerateEvent(ToOtherBehaviourEvent(KadFromOtherBehaviourEvent::RequestKadQuery(
-            _peer_id
-        )))
+        ToSwarm::GenerateEvent(ToOtherBehaviourEvent::RequestKadQuery(_peer_id))
     );
 }
 
@@ -238,15 +233,13 @@ async fn discovery_outputs_single_query_on_query_finished() {
     // Consume the initial query event.
     timeout(TIMEOUT, behaviour.next()).await.unwrap();
 
-    behaviour.on_other_behaviour_event(mixed_behaviour::InternalEvent::NotifyDiscovery(
-        FromOtherBehaviourEvent::KadQueryFinished,
+    behaviour.on_other_behaviour_event(&mixed_behaviour::ToOtherBehaviourEvent::Kad(
+        KadToOtherBehaviourEvent::KadQueryFinished,
     ));
     let event = timeout(TIMEOUT, behaviour.next()).await.unwrap().unwrap();
     assert_matches!(
         event,
-        ToSwarm::GenerateEvent(ToOtherBehaviourEvent(KadFromOtherBehaviourEvent::RequestKadQuery(
-            _peer_id
-        )))
+        ToSwarm::GenerateEvent(ToOtherBehaviourEvent::RequestKadQuery(_peer_id))
     );
 }
 
@@ -257,14 +250,14 @@ async fn discovery_doesnt_output_queries_if_query_finished_while_paused() {
     // Consume the initial query event.
     timeout(TIMEOUT, behaviour.next()).await.unwrap();
 
-    behaviour.on_other_behaviour_event(mixed_behaviour::InternalEvent::NotifyDiscovery(
-        FromOtherBehaviourEvent::PauseDiscovery,
+    behaviour.on_other_behaviour_event(&mixed_behaviour::ToOtherBehaviourEvent::PeerManager(
+        peer_manager::ToOtherBehaviourEvent::PauseDiscovery,
     ));
     assert_no_event(&mut behaviour);
 
     // Simulate that the query has finished.
-    behaviour.on_other_behaviour_event(mixed_behaviour::InternalEvent::NotifyDiscovery(
-        FromOtherBehaviourEvent::KadQueryFinished,
+    behaviour.on_other_behaviour_event(&mixed_behaviour::ToOtherBehaviourEvent::Kad(
+        KadToOtherBehaviourEvent::KadQueryFinished,
     ));
     assert_no_event(&mut behaviour);
 }
@@ -273,8 +266,8 @@ async fn discovery_doesnt_output_queries_if_query_finished_while_paused() {
 async fn discovery_awakes_on_resume() {
     let mut behaviour = create_behaviour_and_connect_to_bootstrap_node().await;
 
-    behaviour.on_other_behaviour_event(mixed_behaviour::InternalEvent::NotifyDiscovery(
-        FromOtherBehaviourEvent::PauseDiscovery,
+    behaviour.on_other_behaviour_event(&mixed_behaviour::ToOtherBehaviourEvent::PeerManager(
+        peer_manager::ToOtherBehaviourEvent::PauseDiscovery,
     ));
 
     // There should be an event once we resume because discovery has just started.
@@ -285,8 +278,8 @@ async fn discovery_awakes_on_resume() {
         _ = async {
             tokio::time::sleep(SLEEP_DURATION).await;
             mutex.lock().await.on_other_behaviour_event(
-                mixed_behaviour::InternalEvent::NotifyDiscovery(
-                    FromOtherBehaviourEvent::ResumeDiscovery,
+                &mixed_behaviour::ToOtherBehaviourEvent::PeerManager(
+                    peer_manager::ToOtherBehaviourEvent::ResumeDiscovery,
                 )
             );
             timeout(TIMEOUT, pending::<()>()).await.unwrap();
@@ -308,9 +301,8 @@ async fn discovery_awakes_on_query_finished() {
         _ = async {
             tokio::time::sleep(SLEEP_DURATION).await;
             mutex.lock().await.on_other_behaviour_event(
-                mixed_behaviour::InternalEvent::NotifyDiscovery(
-                    FromOtherBehaviourEvent::KadQueryFinished,
-
+                &mixed_behaviour::ToOtherBehaviourEvent::Kad(
+                    KadToOtherBehaviourEvent::KadQueryFinished,
                 )
             );
             timeout(TIMEOUT, pending::<()>()).await.unwrap();

--- a/crates/papyrus_network/src/discovery/flow_test.rs
+++ b/crates/papyrus_network/src/discovery/flow_test.rs
@@ -85,21 +85,17 @@ async fn all_nodes_have_same_bootstrap_peer() {
             _ => continue,
         };
 
-        let mixed_behaviour::Event::InternalEvent(event) = mixed_event else {
+        let mixed_behaviour::Event::ToOtherBehaviourEvent(event) = mixed_event else {
+            continue;
+        };
+        if let mixed_behaviour::ToOtherBehaviourEvent::NoOp = event {
             continue;
         };
         let behaviour_ref = swarms_stream.get_mut(&peer_id).unwrap().behaviour_mut();
-        match event {
-            mixed_behaviour::InternalEvent::NoOp => {}
-            mixed_behaviour::InternalEvent::NotifyKad(_) => {
-                behaviour_ref.kademlia.on_other_behaviour_event(event)
-            }
-            mixed_behaviour::InternalEvent::NotifyDiscovery(_) => {
-                if let Some(discovery) = behaviour_ref.discovery.as_mut() {
-                    discovery.on_other_behaviour_event(event);
-                }
-            }
-            _ => {}
+        behaviour_ref.identify.on_other_behaviour_event(&event);
+        behaviour_ref.kademlia.on_other_behaviour_event(&event);
+        if let Some(discovery) = behaviour_ref.discovery.as_mut() {
+            discovery.on_other_behaviour_event(&event);
         }
     }
 }

--- a/crates/papyrus_network/src/discovery/identify_impl.rs
+++ b/crates/papyrus_network/src/discovery/identify_impl.rs
@@ -1,23 +1,36 @@
-use libp2p::identify;
+use libp2p::{identify, Multiaddr, PeerId};
 
-use super::kad_impl::KadFromOtherBehaviourEvent;
 use crate::mixed_behaviour;
+use crate::mixed_behaviour::BridgedBehaviour;
 
 pub const IDENTIFY_PROTOCOL_VERSION: &str = "/staknet/identify/0.1.0-rc.0";
+
+#[derive(Debug)]
+pub enum IdentifyToOtherBehaviourEvent {
+    FoundListenAddresses { peer_id: PeerId, listen_addresses: Vec<Multiaddr> },
+}
 
 impl From<identify::Event> for mixed_behaviour::Event {
     fn from(event: identify::Event) -> Self {
         match event {
             identify::Event::Received { peer_id, info } => {
-                mixed_behaviour::Event::InternalEvent(mixed_behaviour::InternalEvent::NotifyKad(
-                    KadFromOtherBehaviourEvent::FoundListenAddresses {
-                        peer_id,
-                        listen_addresses: info.listen_addrs,
-                    },
-                ))
+                mixed_behaviour::Event::ToOtherBehaviourEvent(
+                    mixed_behaviour::ToOtherBehaviourEvent::Identify(
+                        IdentifyToOtherBehaviourEvent::FoundListenAddresses {
+                            peer_id,
+                            listen_addresses: info.listen_addrs,
+                        },
+                    ),
+                )
             }
             // TODO(shahak): Consider logging error events.
-            _ => mixed_behaviour::Event::InternalEvent(mixed_behaviour::InternalEvent::NoOp),
+            _ => mixed_behaviour::Event::ToOtherBehaviourEvent(
+                mixed_behaviour::ToOtherBehaviourEvent::NoOp,
+            ),
         }
     }
+}
+
+impl BridgedBehaviour for identify::Behaviour {
+    fn on_other_behaviour_event(&mut self, _event: &mixed_behaviour::ToOtherBehaviourEvent) {}
 }

--- a/crates/papyrus_network/src/discovery/kad_impl.rs
+++ b/crates/papyrus_network/src/discovery/kad_impl.rs
@@ -1,13 +1,13 @@
-use libp2p::{kad, Multiaddr, PeerId};
+use libp2p::kad;
 use tracing::error;
 
+use super::identify_impl::IdentifyToOtherBehaviourEvent;
+use crate::mixed_behaviour;
 use crate::mixed_behaviour::BridgedBehaviour;
-use crate::{discovery, mixed_behaviour};
 
 #[derive(Debug)]
-pub enum KadFromOtherBehaviourEvent {
-    RequestKadQuery(PeerId),
-    FoundListenAddresses { peer_id: PeerId, listen_addresses: Vec<Multiaddr> },
+pub enum KadToOtherBehaviourEvent {
+    KadQueryFinished,
 }
 
 impl From<kad::Event> for mixed_behaviour::Event {
@@ -21,31 +21,38 @@ impl From<kad::Event> for mixed_behaviour::Event {
                 if let Err(err) = result {
                     error!("Kademlia query failed on {err:?}");
                 }
-                mixed_behaviour::Event::InternalEvent(
-                    mixed_behaviour::InternalEvent::NotifyDiscovery(
-                        discovery::FromOtherBehaviourEvent::KadQueryFinished,
+                mixed_behaviour::Event::ToOtherBehaviourEvent(
+                    mixed_behaviour::ToOtherBehaviourEvent::Kad(
+                        KadToOtherBehaviourEvent::KadQueryFinished,
                     ),
                 )
             }
-            _ => mixed_behaviour::Event::InternalEvent(mixed_behaviour::InternalEvent::NoOp),
+            _ => mixed_behaviour::Event::ToOtherBehaviourEvent(
+                mixed_behaviour::ToOtherBehaviourEvent::NoOp,
+            ),
         }
     }
 }
 
 impl<TStore: kad::store::RecordStore + Send + 'static> BridgedBehaviour for kad::Behaviour<TStore> {
-    fn on_other_behaviour_event(&mut self, event: mixed_behaviour::InternalEvent) {
-        let mixed_behaviour::InternalEvent::NotifyKad(event) = event else {
-            return;
-        };
+    fn on_other_behaviour_event(&mut self, event: &mixed_behaviour::ToOtherBehaviourEvent) {
         match event {
-            KadFromOtherBehaviourEvent::RequestKadQuery(peer_id) => {
-                self.get_closest_peers(peer_id);
+            mixed_behaviour::ToOtherBehaviourEvent::Discovery(
+                super::ToOtherBehaviourEvent::RequestKadQuery(peer_id),
+            ) => {
+                self.get_closest_peers(*peer_id);
             }
-            KadFromOtherBehaviourEvent::FoundListenAddresses { peer_id, listen_addresses } => {
+            mixed_behaviour::ToOtherBehaviourEvent::Identify(
+                IdentifyToOtherBehaviourEvent::FoundListenAddresses { peer_id, listen_addresses },
+            )
+            | mixed_behaviour::ToOtherBehaviourEvent::Discovery(
+                super::ToOtherBehaviourEvent::FoundListenAddresses { peer_id, listen_addresses },
+            ) => {
                 for address in listen_addresses {
-                    self.add_address(&peer_id, address);
+                    self.add_address(peer_id, address.clone());
                 }
             }
+            _ => {}
         }
     }
 }

--- a/crates/papyrus_network/src/lib.rs
+++ b/crates/papyrus_network/src/lib.rs
@@ -3,6 +3,7 @@
 ///
 /// [`Starknet p2p specs`]: https://github.com/starknet-io/starknet-p2p-specs/
 pub mod bin_utils;
+mod broadcast;
 mod converters;
 mod db_executor;
 mod discovery;

--- a/crates/papyrus_network/src/lib.rs
+++ b/crates/papyrus_network/src/lib.rs
@@ -14,6 +14,7 @@ pub mod protobuf_messages;
 pub mod streamed_bytes;
 #[cfg(test)]
 mod test_utils;
+
 use std::collections::{BTreeMap, HashMap};
 use std::pin::Pin;
 use std::time::Duration;

--- a/crates/papyrus_network/src/mixed_behaviour.rs
+++ b/crates/papyrus_network/src/mixed_behaviour.rs
@@ -7,8 +7,8 @@ use libp2p::swarm::dial_opts::DialOpts;
 use libp2p::swarm::NetworkBehaviour;
 use libp2p::{identify, kad, Multiaddr, PeerId};
 
-use crate::discovery::identify_impl::IDENTIFY_PROTOCOL_VERSION;
-use crate::discovery::kad_impl::KadFromOtherBehaviourEvent;
+use crate::discovery::identify_impl::{IdentifyToOtherBehaviourEvent, IDENTIFY_PROTOCOL_VERSION};
+use crate::discovery::kad_impl::KadToOtherBehaviourEvent;
 use crate::peer_manager::PeerManagerConfig;
 use crate::{discovery, peer_manager, streamed_bytes};
 
@@ -27,7 +27,7 @@ pub struct MixedBehaviour {
 #[derive(Debug)]
 pub enum Event {
     ExternalEvent(ExternalEvent),
-    InternalEvent(InternalEvent),
+    ToOtherBehaviourEvent(ToOtherBehaviourEvent),
 }
 
 #[derive(Debug)]
@@ -36,16 +36,17 @@ pub enum ExternalEvent {
 }
 
 #[derive(Debug)]
-pub enum InternalEvent {
+pub enum ToOtherBehaviourEvent {
     NoOp,
-    NotifyKad(KadFromOtherBehaviourEvent),
-    NotifyDiscovery(discovery::FromOtherBehaviourEvent),
-    NotifyPeerManager(peer_manager::FromOtherBehaviour),
-    NotifyStreamedBytes(streamed_bytes::behaviour::FromOtherBehaviour),
+    Identify(IdentifyToOtherBehaviourEvent),
+    Kad(KadToOtherBehaviourEvent),
+    Discovery(discovery::ToOtherBehaviourEvent),
+    PeerManager(peer_manager::ToOtherBehaviourEvent),
+    StreamedBytes(streamed_bytes::ToOtherBehaviourEvent),
 }
 
 pub trait BridgedBehaviour {
-    fn on_other_behaviour_event(&mut self, event: InternalEvent);
+    fn on_other_behaviour_event(&mut self, event: &ToOtherBehaviourEvent);
 }
 
 impl MixedBehaviour {

--- a/crates/papyrus_network/src/mixed_behaviour.rs
+++ b/crates/papyrus_network/src/mixed_behaviour.rs
@@ -10,7 +10,7 @@ use libp2p::{identify, kad, Multiaddr, PeerId};
 use crate::discovery::identify_impl::{IdentifyToOtherBehaviourEvent, IDENTIFY_PROTOCOL_VERSION};
 use crate::discovery::kad_impl::KadToOtherBehaviourEvent;
 use crate::peer_manager::PeerManagerConfig;
-use crate::{discovery, peer_manager, streamed_bytes};
+use crate::{broadcast, discovery, peer_manager, streamed_bytes};
 
 // TODO: consider reducing the pulicity of all behaviour to pub(crate)
 #[derive(NetworkBehaviour)]
@@ -22,6 +22,7 @@ pub struct MixedBehaviour {
     // TODO(shahak): Consider using a different store.
     pub kademlia: kad::Behaviour<MemoryStore>,
     pub streamed_bytes: streamed_bytes::Behaviour,
+    pub broadcast: broadcast::Behaviour,
 }
 
 #[derive(Debug)]
@@ -33,6 +34,7 @@ pub enum Event {
 #[derive(Debug)]
 pub enum ExternalEvent {
     StreamedBytes(streamed_bytes::behaviour::ExternalEvent),
+    Broadcast(broadcast::ExternalEvent),
 }
 
 #[derive(Debug)]
@@ -77,6 +79,7 @@ impl MixedBehaviour {
             // TODO: change kademlia protocol name
             kademlia: kad::Behaviour::new(local_peer_id, MemoryStore::new(local_peer_id)),
             streamed_bytes: streamed_bytes::Behaviour::new(streamed_bytes_config),
+            broadcast: broadcast::Behaviour::new(),
         }
     }
 }

--- a/crates/papyrus_network/src/network_manager/mod.rs
+++ b/crates/papyrus_network/src/network_manager/mod.rs
@@ -182,10 +182,14 @@ impl<DBExecutorT: DBExecutor, SwarmT: SwarmTrait> GenericNetworkManager<DBExecut
             mixed_behaviour::ExternalEvent::StreamedBytes(event) => {
                 self.handle_stream_bytes_behaviour_event(event);
             }
+            mixed_behaviour::ExternalEvent::Broadcast(_event) => {
+                unimplemented!();
+            }
         }
     }
 
     fn handle_to_other_behaviour_event(&mut self, event: mixed_behaviour::ToOtherBehaviourEvent) {
+        // TODO(shahak): Move this logic to mixed_behaviour.
         if let mixed_behaviour::ToOtherBehaviourEvent::NoOp = event {
             return;
         }
@@ -196,6 +200,7 @@ impl<DBExecutorT: DBExecutor, SwarmT: SwarmTrait> GenericNetworkManager<DBExecut
         }
         self.swarm.behaviour_mut().streamed_bytes.on_other_behaviour_event(&event);
         self.swarm.behaviour_mut().peer_manager.on_other_behaviour_event(&event);
+        self.swarm.behaviour_mut().broadcast.on_other_behaviour_event(&event);
     }
 
     fn handle_stream_bytes_behaviour_event(

--- a/crates/papyrus_network/src/peer_manager/behaviour_impl.rs
+++ b/crates/papyrus_network/src/peer_manager/behaviour_impl.rs
@@ -1,18 +1,31 @@
 use std::task::Poll;
 
 use libp2p::swarm::behaviour::ConnectionEstablished;
-use libp2p::swarm::{dummy, ConnectionClosed, DialError, DialFailure, NetworkBehaviour, ToSwarm};
-use libp2p::Multiaddr;
+use libp2p::swarm::{
+    dummy,
+    ConnectionClosed,
+    ConnectionId,
+    DialError,
+    DialFailure,
+    NetworkBehaviour,
+    ToSwarm,
+};
+use libp2p::{Multiaddr, PeerId};
 use tracing::{debug, error};
 
 use super::peer::PeerTrait;
 use super::{PeerManager, PeerManagerError};
-use crate::{discovery, streamed_bytes};
+use crate::streamed_bytes::OutboundSessionId;
 
 #[derive(Debug)]
-pub enum Event {
-    NotifyStreamedBytes(streamed_bytes::behaviour::FromOtherBehaviour),
-    NotifyDiscovery(discovery::FromOtherBehaviourEvent),
+pub enum ToOtherBehaviourEvent {
+    SessionAssigned {
+        outbound_session_id: OutboundSessionId,
+        peer_id: PeerId,
+        connection_id: ConnectionId,
+    },
+    PauseDiscovery,
+    ResumeDiscovery,
 }
 
 impl<P: 'static> NetworkBehaviour for PeerManager<P>
@@ -20,7 +33,7 @@ where
     P: PeerTrait,
 {
     type ConnectionHandler = dummy::ConnectionHandler;
-    type ToSwarm = Event;
+    type ToSwarm = ToOtherBehaviourEvent;
 
     fn handle_established_inbound_connection(
         &mut self,
@@ -116,13 +129,11 @@ where
             }) => {
                 if let Some(sessions) = self.peers_pending_dial_with_sessions.remove(&peer_id) {
                     self.pending_events.extend(sessions.iter().map(|outbound_session_id| {
-                        ToSwarm::GenerateEvent(Event::NotifyStreamedBytes(
-                            streamed_bytes::behaviour::FromOtherBehaviour::SessionAssigned {
-                                outbound_session_id: *outbound_session_id,
-                                peer_id,
-                                connection_id,
-                            },
-                        ))
+                        ToSwarm::GenerateEvent(ToOtherBehaviourEvent::SessionAssigned {
+                            outbound_session_id: *outbound_session_id,
+                            peer_id,
+                            connection_id,
+                        })
                     }));
                     self.peers
                         .get_mut(&peer_id)
@@ -138,9 +149,7 @@ where
                     if !self.more_peers_needed() {
                         // TODO: consider how and in which cases we resume discovery
                         self.pending_events.push(libp2p::swarm::ToSwarm::GenerateEvent(
-                            Event::NotifyDiscovery(
-                                discovery::FromOtherBehaviourEvent::PauseDiscovery,
-                            ),
+                            ToOtherBehaviourEvent::PauseDiscovery,
                         ))
                     }
                 }

--- a/crates/papyrus_network/src/peer_manager/test.rs
+++ b/crates/papyrus_network/src/peer_manager/test.rs
@@ -11,11 +11,10 @@ use libp2p::{Multiaddr, PeerId};
 use mockall::predicate::eq;
 use tokio::time::sleep;
 
-use super::behaviour_impl::Event;
+use super::behaviour_impl::ToOtherBehaviourEvent;
 use crate::peer_manager::peer::{MockPeerTrait, Peer, PeerTrait};
 use crate::peer_manager::{PeerManager, PeerManagerConfig, ReputationModifier};
 use crate::streamed_bytes::OutboundSessionId;
-use crate::{discovery, streamed_bytes};
 
 #[test]
 fn peer_assignment_round_robin() {
@@ -56,13 +55,11 @@ fn peer_assignment_round_robin() {
 
     // check assignment events
     for event in peer_manager.pending_events {
-        let ToSwarm::GenerateEvent(Event::NotifyStreamedBytes(
-            streamed_bytes::behaviour::FromOtherBehaviour::SessionAssigned {
-                outbound_session_id,
-                peer_id,
-                connection_id,
-            },
-        )) = event
+        let ToSwarm::GenerateEvent(ToOtherBehaviourEvent::SessionAssigned {
+            outbound_session_id,
+            peer_id,
+            connection_id,
+        }) = event
         else {
             continue;
         };
@@ -123,13 +120,12 @@ fn peer_assignment_no_peers() {
     assert_eq!(peer_manager.pending_events.len(), 1);
     assert_matches!(
         peer_manager.pending_events.first().unwrap(),
-        ToSwarm::GenerateEvent(Event::NotifyStreamedBytes(
-            streamed_bytes::behaviour::FromOtherBehaviour::SessionAssigned {
+        ToSwarm::GenerateEvent(ToOtherBehaviourEvent::SessionAssigned {
                 outbound_session_id: event_outbound_session_id,
                 peer_id: event_peer_id,
                 connection_id: event_connection_id,
             }
-        )) if outbound_session_id == *event_outbound_session_id &&
+        ) if outbound_session_id == *event_outbound_session_id &&
             peer_id == *event_peer_id &&
             connection_id == *event_connection_id
     );
@@ -425,10 +421,10 @@ async fn flow_test_assign_non_connected_peer() {
         },
     ));
 
-    // Expect NotifyStreamedBytes event
+    // Expect SessionAssigned event
     assert_matches!(
         poll_fn(|cx| peer_manager.poll(cx)).await,
-        ToSwarm::GenerateEvent(Event::NotifyStreamedBytes(_))
+        ToSwarm::GenerateEvent(ToOtherBehaviourEvent::SessionAssigned { .. })
     );
 }
 
@@ -486,10 +482,7 @@ fn no_more_peers_needed_stops_discovery() {
 
     // Check that the discovery pause event emitted
     for event in peer_manager.pending_events {
-        if let ToSwarm::GenerateEvent(Event::NotifyDiscovery(
-            discovery::FromOtherBehaviourEvent::PauseDiscovery,
-        )) = event
-        {
+        if let ToSwarm::GenerateEvent(ToOtherBehaviourEvent::PauseDiscovery) = event {
             return;
         }
     }

--- a/crates/papyrus_network/src/streamed_bytes/mod.rs
+++ b/crates/papyrus_network/src/streamed_bytes/mod.rs
@@ -8,7 +8,7 @@ mod flow_test;
 
 use std::time::Duration;
 
-pub use behaviour::Behaviour;
+pub use behaviour::{Behaviour, ToOtherBehaviourEvent};
 use derive_more::Display;
 use libp2p::swarm::StreamProtocol;
 use libp2p::PeerId;


### PR DESCRIPTION
- refactor(network): mixed event contains the outputting behaviour instead of notified behaviour
- feat(network): add broadcast behaviour with unimplemented
- feat(network): connect broadcast behaviour to mixed behaviour
- feat(network): add register_broadcast_subscribers without connecting to behaviour

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1983)
<!-- Reviewable:end -->
