### PR TITLE
feat(network): connect broadcast subscribers to behaviour

### DIFF
--- a/crates/papyrus_network/src/network_manager/swarm_trait.rs
+++ b/crates/papyrus_network/src/network_manager/swarm_trait.rs
@@ -3,8 +3,9 @@ use libp2p::swarm::dial_opts::DialOpts;
 use libp2p::swarm::{DialError, NetworkBehaviour, SwarmEvent};
 use libp2p::{Multiaddr, PeerId, Swarm};
 
+use crate::broadcast::Topic;
 use crate::streamed_bytes::behaviour::{PeerNotConnected, SessionIdNotFoundError};
-use crate::streamed_bytes::{InboundSessionId, OutboundSessionId};
+use crate::streamed_bytes::{Bytes, InboundSessionId, OutboundSessionId};
 use crate::{mixed_behaviour, Protocol};
 
 pub type Event = SwarmEvent<<mixed_behaviour::MixedBehaviour as NetworkBehaviour>::ToSwarm>;
@@ -35,6 +36,8 @@ pub trait SwarmTrait: Stream<Item = Event> + Unpin {
     fn behaviour_mut(&mut self) -> &mut mixed_behaviour::MixedBehaviour;
 
     fn add_external_address(&mut self, address: Multiaddr);
+
+    fn broadcast_message(&mut self, message: Bytes, topic: Topic);
 }
 
 impl SwarmTrait for Swarm<mixed_behaviour::MixedBehaviour> {
@@ -76,5 +79,9 @@ impl SwarmTrait for Swarm<mixed_behaviour::MixedBehaviour> {
 
     fn add_external_address(&mut self, address: Multiaddr) {
         self.add_external_address(address);
+    }
+
+    fn broadcast_message(&mut self, message: Bytes, topic: Topic) {
+        self.behaviour_mut().broadcast.broadcast_message(message, topic);
     }
 }

--- a/crates/papyrus_network/src/network_manager/test.rs
+++ b/crates/papyrus_network/src/network_manager/test.rs
@@ -23,6 +23,7 @@ use tokio::time::sleep;
 
 use super::swarm_trait::{Event, SwarmTrait};
 use super::GenericNetworkManager;
+use crate::broadcast::Topic;
 use crate::db_executor::{
     poll_query_execution_set,
     DBExecutorError,
@@ -33,7 +34,7 @@ use crate::db_executor::{
 };
 use crate::protobuf_messages::protobuf;
 use crate::streamed_bytes::behaviour::{PeerNotConnected, SessionIdNotFoundError};
-use crate::streamed_bytes::{GenericEvent, InboundSessionId, OutboundSessionId};
+use crate::streamed_bytes::{Bytes, GenericEvent, InboundSessionId, OutboundSessionId};
 use crate::{mixed_behaviour, BlockHashOrNumber, DataType, Direction, InternalQuery, Query};
 
 #[derive(Default)]
@@ -176,6 +177,11 @@ impl SwarmTrait for MockSwarm {
     }
 
     fn add_external_address(&mut self, _address: Multiaddr) {}
+
+    fn broadcast_message(&mut self, _message: Bytes, _topic: Topic) {
+        // TODO(shahak): Test broadcast flow and received broadcast message flow.
+        unimplemented!()
+    }
 }
 
 #[derive(Default)]

--- a/crates/papyrus_network/src/utils.rs
+++ b/crates/papyrus_network/src/utils.rs
@@ -34,6 +34,10 @@ impl<K: Unpin + Clone + Eq + Hash, V: Stream + Unpin> StreamHashMap<K, V> {
     pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
         self.map.get_mut(key)
     }
+
+    pub fn insert(&mut self, key: K, value: V) -> Option<V> {
+        self.map.insert(key, value)
+    }
 }
 
 impl<K: Unpin + Clone + Eq + Hash, V: Stream + Unpin> Stream for StreamHashMap<K, V> {


### PR DESCRIPTION
- refactor(network): mixed event contains the outputting behaviour instead of notified behaviour
- feat(network): add broadcast behaviour with unimplemented
- feat(network): connect broadcast behaviour to mixed behaviour
- feat(network): add register_broadcast_subscribers without connecting to behaviour
- refactor(network): move code
- refactor(network): make StreamHashMap usable in source code (not tests only)
- feat(network): connect broadcast subscribers to behaviour

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1986)
<!-- Reviewable:end -->
