### PR TITLE
fix(network): report callback reports the originating peer

### DIFF
--- a/crates/papyrus_network/src/broadcast/mod.rs
+++ b/crates/papyrus_network/src/broadcast/mod.rs
@@ -12,6 +12,8 @@ use libp2p::swarm::{
 };
 use libp2p::{Multiaddr, PeerId};
 
+use crate::mixed_behaviour;
+use crate::mixed_behaviour::BridgedBehaviour;
 // TODO(shahak): move Bytes to a more generic file.
 use crate::streamed_bytes::Bytes;
 
@@ -19,6 +21,7 @@ pub struct Behaviour;
 
 pub type Topic = String;
 
+#[derive(Debug)]
 pub enum ExternalEvent {
     #[allow(dead_code)]
     Received { originated_peer_id: PeerId, message: Bytes, topic: Topic },
@@ -63,14 +66,15 @@ impl NetworkBehaviour for Behaviour {
         _cx: &mut Context<'_>,
     ) -> Poll<ToSwarm<Self::ToSwarm, <Self::ConnectionHandler as ConnectionHandler>::FromBehaviour>>
     {
-        unimplemented!()
+        // TODO(shahak): Implement this.
+        Poll::Pending
     }
 }
 
 impl Behaviour {
-    #[allow(dead_code)]
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
-        unimplemented!()
+        Self
     }
 
     #[allow(dead_code)]
@@ -81,5 +85,17 @@ impl Behaviour {
     #[allow(dead_code)]
     pub fn broadcast_message(&mut self, _message: Bytes, _topic: Topic) {
         unimplemented!()
+    }
+}
+
+impl From<ExternalEvent> for mixed_behaviour::Event {
+    fn from(event: ExternalEvent) -> Self {
+        mixed_behaviour::Event::ExternalEvent(mixed_behaviour::ExternalEvent::Broadcast(event))
+    }
+}
+
+impl BridgedBehaviour for Behaviour {
+    fn on_other_behaviour_event(&mut self, _event: &mixed_behaviour::ToOtherBehaviourEvent) {
+        // TODO(shahak): Implement this.
     }
 }

--- a/crates/papyrus_network/src/broadcast/mod.rs
+++ b/crates/papyrus_network/src/broadcast/mod.rs
@@ -1,0 +1,85 @@
+use std::task::{Context, Poll};
+
+use libp2p::core::Endpoint;
+use libp2p::swarm::{
+    dummy,
+    ConnectionDenied,
+    ConnectionHandler,
+    ConnectionId,
+    FromSwarm,
+    NetworkBehaviour,
+    ToSwarm,
+};
+use libp2p::{Multiaddr, PeerId};
+
+// TODO(shahak): move Bytes to a more generic file.
+use crate::streamed_bytes::Bytes;
+
+pub struct Behaviour;
+
+pub type Topic = String;
+
+pub enum ExternalEvent {
+    #[allow(dead_code)]
+    Received { originated_peer_id: PeerId, message: Bytes, topic: Topic },
+}
+
+impl NetworkBehaviour for Behaviour {
+    type ConnectionHandler = dummy::ConnectionHandler;
+    type ToSwarm = ExternalEvent;
+
+    fn handle_established_inbound_connection(
+        &mut self,
+        _connection_id: ConnectionId,
+        _peer: PeerId,
+        _local_addr: &Multiaddr,
+        _remote_addr: &Multiaddr,
+    ) -> Result<Self::ConnectionHandler, ConnectionDenied> {
+        Ok(dummy::ConnectionHandler)
+    }
+
+    fn handle_established_outbound_connection(
+        &mut self,
+        _connection_id: ConnectionId,
+        _peer: PeerId,
+        _addr: &Multiaddr,
+        _role_override: Endpoint,
+    ) -> Result<Self::ConnectionHandler, ConnectionDenied> {
+        Ok(dummy::ConnectionHandler)
+    }
+
+    fn on_swarm_event(&mut self, _event: FromSwarm<'_>) {}
+
+    fn on_connection_handler_event(
+        &mut self,
+        _peer_id: PeerId,
+        _connection_id: ConnectionId,
+        _event: <Self::ConnectionHandler as ConnectionHandler>::ToBehaviour,
+    ) {
+    }
+
+    fn poll(
+        &mut self,
+        _cx: &mut Context<'_>,
+    ) -> Poll<ToSwarm<Self::ToSwarm, <Self::ConnectionHandler as ConnectionHandler>::FromBehaviour>>
+    {
+        unimplemented!()
+    }
+}
+
+impl Behaviour {
+    #[allow(dead_code)]
+    pub fn new() -> Self {
+        unimplemented!()
+    }
+
+    #[allow(dead_code)]
+    pub fn subscribe_to_topic(&mut self, _topic: Topic) {
+        unimplemented!()
+    }
+
+    #[allow(dead_code)]
+    pub fn broadcast_message(&mut self, _message: Bytes, _topic: Topic) {
+        unimplemented!()
+    }
+}

--- a/crates/papyrus_network/src/discovery/discovery_test.rs
+++ b/crates/papyrus_network/src/discovery/discovery_test.rs
@@ -24,11 +24,11 @@ use tokio::sync::Mutex;
 use tokio::time::timeout;
 use void::Void;
 
-use super::kad_impl::KadFromOtherBehaviourEvent;
-use super::{Behaviour, FromOtherBehaviourEvent, ToOtherBehaviourEvent, DIAL_SLEEP};
-use crate::mixed_behaviour;
+use super::kad_impl::KadToOtherBehaviourEvent;
+use super::{Behaviour, ToOtherBehaviourEvent, DIAL_SLEEP};
 use crate::mixed_behaviour::BridgedBehaviour;
 use crate::test_utils::next_on_mutex_stream;
+use crate::{mixed_behaviour, peer_manager};
 
 const TIMEOUT: Duration = Duration::from_secs(1);
 const SLEEP_DURATION: Duration = Duration::from_millis(10);
@@ -184,12 +184,11 @@ async fn create_behaviour_and_connect_to_bootstrap_node() -> Behaviour {
     let event = timeout(TIMEOUT, behaviour.next()).await.unwrap().unwrap();
     assert_matches!(
         event,
-        ToSwarm::GenerateEvent(ToOtherBehaviourEvent(
-            KadFromOtherBehaviourEvent::FoundListenAddresses {
+        ToSwarm::GenerateEvent(ToOtherBehaviourEvent::FoundListenAddresses {
                 peer_id,
                 listen_addresses,
             }
-        )) if peer_id == bootstrap_peer_id && listen_addresses == vec![bootstrap_peer_address]
+        ) if peer_id == bootstrap_peer_id && listen_addresses == vec![bootstrap_peer_address]
     );
 
     behaviour
@@ -202,9 +201,7 @@ async fn discovery_outputs_single_query_after_connecting() {
     let event = timeout(TIMEOUT, behaviour.next()).await.unwrap().unwrap();
     assert_matches!(
         event,
-        ToSwarm::GenerateEvent(ToOtherBehaviourEvent(KadFromOtherBehaviourEvent::RequestKadQuery(
-            _peer_id
-        )))
+        ToSwarm::GenerateEvent(ToOtherBehaviourEvent::RequestKadQuery(_peer_id))
     );
 
     assert_no_event(&mut behaviour);
@@ -214,20 +211,18 @@ async fn discovery_outputs_single_query_after_connecting() {
 async fn discovery_doesnt_output_queries_while_paused() {
     let mut behaviour = create_behaviour_and_connect_to_bootstrap_node().await;
 
-    behaviour.on_other_behaviour_event(mixed_behaviour::InternalEvent::NotifyDiscovery(
-        FromOtherBehaviourEvent::PauseDiscovery,
+    behaviour.on_other_behaviour_event(&mixed_behaviour::ToOtherBehaviourEvent::PeerManager(
+        peer_manager::ToOtherBehaviourEvent::PauseDiscovery,
     ));
     assert_no_event(&mut behaviour);
 
-    behaviour.on_other_behaviour_event(mixed_behaviour::InternalEvent::NotifyDiscovery(
-        FromOtherBehaviourEvent::ResumeDiscovery,
+    behaviour.on_other_behaviour_event(&mixed_behaviour::ToOtherBehaviourEvent::PeerManager(
+        peer_manager::ToOtherBehaviourEvent::ResumeDiscovery,
     ));
     let event = timeout(TIMEOUT, behaviour.next()).await.unwrap().unwrap();
     assert_matches!(
         event,
-        ToSwarm::GenerateEvent(ToOtherBehaviourEvent(KadFromOtherBehaviourEvent::RequestKadQuery(
-            _peer_id
-        )))
+        ToSwarm::GenerateEvent(ToOtherBehaviourEvent::RequestKadQuery(_peer_id))
     );
 }
 
@@ -238,15 +233,13 @@ async fn discovery_outputs_single_query_on_query_finished() {
     // Consume the initial query event.
     timeout(TIMEOUT, behaviour.next()).await.unwrap();
 
-    behaviour.on_other_behaviour_event(mixed_behaviour::InternalEvent::NotifyDiscovery(
-        FromOtherBehaviourEvent::KadQueryFinished,
+    behaviour.on_other_behaviour_event(&mixed_behaviour::ToOtherBehaviourEvent::Kad(
+        KadToOtherBehaviourEvent::KadQueryFinished,
     ));
     let event = timeout(TIMEOUT, behaviour.next()).await.unwrap().unwrap();
     assert_matches!(
         event,
-        ToSwarm::GenerateEvent(ToOtherBehaviourEvent(KadFromOtherBehaviourEvent::RequestKadQuery(
-            _peer_id
-        )))
+        ToSwarm::GenerateEvent(ToOtherBehaviourEvent::RequestKadQuery(_peer_id))
     );
 }
 
@@ -257,14 +250,14 @@ async fn discovery_doesnt_output_queries_if_query_finished_while_paused() {
     // Consume the initial query event.
     timeout(TIMEOUT, behaviour.next()).await.unwrap();
 
-    behaviour.on_other_behaviour_event(mixed_behaviour::InternalEvent::NotifyDiscovery(
-        FromOtherBehaviourEvent::PauseDiscovery,
+    behaviour.on_other_behaviour_event(&mixed_behaviour::ToOtherBehaviourEvent::PeerManager(
+        peer_manager::ToOtherBehaviourEvent::PauseDiscovery,
     ));
     assert_no_event(&mut behaviour);
 
     // Simulate that the query has finished.
-    behaviour.on_other_behaviour_event(mixed_behaviour::InternalEvent::NotifyDiscovery(
-        FromOtherBehaviourEvent::KadQueryFinished,
+    behaviour.on_other_behaviour_event(&mixed_behaviour::ToOtherBehaviourEvent::Kad(
+        KadToOtherBehaviourEvent::KadQueryFinished,
     ));
     assert_no_event(&mut behaviour);
 }
@@ -273,8 +266,8 @@ async fn discovery_doesnt_output_queries_if_query_finished_while_paused() {
 async fn discovery_awakes_on_resume() {
     let mut behaviour = create_behaviour_and_connect_to_bootstrap_node().await;
 
-    behaviour.on_other_behaviour_event(mixed_behaviour::InternalEvent::NotifyDiscovery(
-        FromOtherBehaviourEvent::PauseDiscovery,
+    behaviour.on_other_behaviour_event(&mixed_behaviour::ToOtherBehaviourEvent::PeerManager(
+        peer_manager::ToOtherBehaviourEvent::PauseDiscovery,
     ));
 
     // There should be an event once we resume because discovery has just started.
@@ -285,8 +278,8 @@ async fn discovery_awakes_on_resume() {
         _ = async {
             tokio::time::sleep(SLEEP_DURATION).await;
             mutex.lock().await.on_other_behaviour_event(
-                mixed_behaviour::InternalEvent::NotifyDiscovery(
-                    FromOtherBehaviourEvent::ResumeDiscovery,
+                &mixed_behaviour::ToOtherBehaviourEvent::PeerManager(
+                    peer_manager::ToOtherBehaviourEvent::ResumeDiscovery,
                 )
             );
             timeout(TIMEOUT, pending::<()>()).await.unwrap();
@@ -308,9 +301,8 @@ async fn discovery_awakes_on_query_finished() {
         _ = async {
             tokio::time::sleep(SLEEP_DURATION).await;
             mutex.lock().await.on_other_behaviour_event(
-                mixed_behaviour::InternalEvent::NotifyDiscovery(
-                    FromOtherBehaviourEvent::KadQueryFinished,
-
+                &mixed_behaviour::ToOtherBehaviourEvent::Kad(
+                    KadToOtherBehaviourEvent::KadQueryFinished,
                 )
             );
             timeout(TIMEOUT, pending::<()>()).await.unwrap();

--- a/crates/papyrus_network/src/discovery/flow_test.rs
+++ b/crates/papyrus_network/src/discovery/flow_test.rs
@@ -13,7 +13,7 @@ use libp2p_swarm_test::SwarmExt;
 use super::Behaviour;
 use crate::mixed_behaviour;
 use crate::mixed_behaviour::{BridgedBehaviour, MixedBehaviour};
-use crate::test_utils::StreamHashMap;
+use crate::utils::StreamHashMap;
 
 #[derive(NetworkBehaviour)]
 struct DiscoveryMixedBehaviour {

--- a/crates/papyrus_network/src/discovery/flow_test.rs
+++ b/crates/papyrus_network/src/discovery/flow_test.rs
@@ -85,21 +85,17 @@ async fn all_nodes_have_same_bootstrap_peer() {
             _ => continue,
         };
 
-        let mixed_behaviour::Event::InternalEvent(event) = mixed_event else {
+        let mixed_behaviour::Event::ToOtherBehaviourEvent(event) = mixed_event else {
+            continue;
+        };
+        if let mixed_behaviour::ToOtherBehaviourEvent::NoOp = event {
             continue;
         };
         let behaviour_ref = swarms_stream.get_mut(&peer_id).unwrap().behaviour_mut();
-        match event {
-            mixed_behaviour::InternalEvent::NoOp => {}
-            mixed_behaviour::InternalEvent::NotifyKad(_) => {
-                behaviour_ref.kademlia.on_other_behaviour_event(event)
-            }
-            mixed_behaviour::InternalEvent::NotifyDiscovery(_) => {
-                if let Some(discovery) = behaviour_ref.discovery.as_mut() {
-                    discovery.on_other_behaviour_event(event);
-                }
-            }
-            _ => {}
+        behaviour_ref.identify.on_other_behaviour_event(&event);
+        behaviour_ref.kademlia.on_other_behaviour_event(&event);
+        if let Some(discovery) = behaviour_ref.discovery.as_mut() {
+            discovery.on_other_behaviour_event(&event);
         }
     }
 }

--- a/crates/papyrus_network/src/discovery/identify_impl.rs
+++ b/crates/papyrus_network/src/discovery/identify_impl.rs
@@ -1,23 +1,36 @@
-use libp2p::identify;
+use libp2p::{identify, Multiaddr, PeerId};
 
-use super::kad_impl::KadFromOtherBehaviourEvent;
 use crate::mixed_behaviour;
+use crate::mixed_behaviour::BridgedBehaviour;
 
 pub const IDENTIFY_PROTOCOL_VERSION: &str = "/staknet/identify/0.1.0-rc.0";
+
+#[derive(Debug)]
+pub enum IdentifyToOtherBehaviourEvent {
+    FoundListenAddresses { peer_id: PeerId, listen_addresses: Vec<Multiaddr> },
+}
 
 impl From<identify::Event> for mixed_behaviour::Event {
     fn from(event: identify::Event) -> Self {
         match event {
             identify::Event::Received { peer_id, info } => {
-                mixed_behaviour::Event::InternalEvent(mixed_behaviour::InternalEvent::NotifyKad(
-                    KadFromOtherBehaviourEvent::FoundListenAddresses {
-                        peer_id,
-                        listen_addresses: info.listen_addrs,
-                    },
-                ))
+                mixed_behaviour::Event::ToOtherBehaviourEvent(
+                    mixed_behaviour::ToOtherBehaviourEvent::Identify(
+                        IdentifyToOtherBehaviourEvent::FoundListenAddresses {
+                            peer_id,
+                            listen_addresses: info.listen_addrs,
+                        },
+                    ),
+                )
             }
             // TODO(shahak): Consider logging error events.
-            _ => mixed_behaviour::Event::InternalEvent(mixed_behaviour::InternalEvent::NoOp),
+            _ => mixed_behaviour::Event::ToOtherBehaviourEvent(
+                mixed_behaviour::ToOtherBehaviourEvent::NoOp,
+            ),
         }
     }
+}
+
+impl BridgedBehaviour for identify::Behaviour {
+    fn on_other_behaviour_event(&mut self, _event: &mixed_behaviour::ToOtherBehaviourEvent) {}
 }

--- a/crates/papyrus_network/src/discovery/kad_impl.rs
+++ b/crates/papyrus_network/src/discovery/kad_impl.rs
@@ -1,13 +1,13 @@
-use libp2p::{kad, Multiaddr, PeerId};
+use libp2p::kad;
 use tracing::error;
 
+use super::identify_impl::IdentifyToOtherBehaviourEvent;
+use crate::mixed_behaviour;
 use crate::mixed_behaviour::BridgedBehaviour;
-use crate::{discovery, mixed_behaviour};
 
 #[derive(Debug)]
-pub enum KadFromOtherBehaviourEvent {
-    RequestKadQuery(PeerId),
-    FoundListenAddresses { peer_id: PeerId, listen_addresses: Vec<Multiaddr> },
+pub enum KadToOtherBehaviourEvent {
+    KadQueryFinished,
 }
 
 impl From<kad::Event> for mixed_behaviour::Event {
@@ -21,31 +21,38 @@ impl From<kad::Event> for mixed_behaviour::Event {
                 if let Err(err) = result {
                     error!("Kademlia query failed on {err:?}");
                 }
-                mixed_behaviour::Event::InternalEvent(
-                    mixed_behaviour::InternalEvent::NotifyDiscovery(
-                        discovery::FromOtherBehaviourEvent::KadQueryFinished,
+                mixed_behaviour::Event::ToOtherBehaviourEvent(
+                    mixed_behaviour::ToOtherBehaviourEvent::Kad(
+                        KadToOtherBehaviourEvent::KadQueryFinished,
                     ),
                 )
             }
-            _ => mixed_behaviour::Event::InternalEvent(mixed_behaviour::InternalEvent::NoOp),
+            _ => mixed_behaviour::Event::ToOtherBehaviourEvent(
+                mixed_behaviour::ToOtherBehaviourEvent::NoOp,
+            ),
         }
     }
 }
 
 impl<TStore: kad::store::RecordStore + Send + 'static> BridgedBehaviour for kad::Behaviour<TStore> {
-    fn on_other_behaviour_event(&mut self, event: mixed_behaviour::InternalEvent) {
-        let mixed_behaviour::InternalEvent::NotifyKad(event) = event else {
-            return;
-        };
+    fn on_other_behaviour_event(&mut self, event: &mixed_behaviour::ToOtherBehaviourEvent) {
         match event {
-            KadFromOtherBehaviourEvent::RequestKadQuery(peer_id) => {
-                self.get_closest_peers(peer_id);
+            mixed_behaviour::ToOtherBehaviourEvent::Discovery(
+                super::ToOtherBehaviourEvent::RequestKadQuery(peer_id),
+            ) => {
+                self.get_closest_peers(*peer_id);
             }
-            KadFromOtherBehaviourEvent::FoundListenAddresses { peer_id, listen_addresses } => {
+            mixed_behaviour::ToOtherBehaviourEvent::Identify(
+                IdentifyToOtherBehaviourEvent::FoundListenAddresses { peer_id, listen_addresses },
+            )
+            | mixed_behaviour::ToOtherBehaviourEvent::Discovery(
+                super::ToOtherBehaviourEvent::FoundListenAddresses { peer_id, listen_addresses },
+            ) => {
                 for address in listen_addresses {
-                    self.add_address(&peer_id, address);
+                    self.add_address(peer_id, address.clone());
                 }
             }
+            _ => {}
         }
     }
 }

--- a/crates/papyrus_network/src/lib.rs
+++ b/crates/papyrus_network/src/lib.rs
@@ -14,6 +14,7 @@ pub mod protobuf_messages;
 pub mod streamed_bytes;
 #[cfg(test)]
 mod test_utils;
+mod utils;
 
 use std::collections::{BTreeMap, HashMap};
 use std::pin::Pin;

--- a/crates/papyrus_network/src/lib.rs
+++ b/crates/papyrus_network/src/lib.rs
@@ -3,6 +3,7 @@
 ///
 /// [`Starknet p2p specs`]: https://github.com/starknet-io/starknet-p2p-specs/
 pub mod bin_utils;
+mod broadcast;
 mod converters;
 mod db_executor;
 mod discovery;

--- a/crates/papyrus_network/src/lib.rs
+++ b/crates/papyrus_network/src/lib.rs
@@ -14,6 +14,7 @@ pub mod protobuf_messages;
 pub mod streamed_bytes;
 #[cfg(test)]
 mod test_utils;
+
 use std::collections::{BTreeMap, HashMap};
 use std::pin::Pin;
 use std::time::Duration;

--- a/crates/papyrus_network/src/mixed_behaviour.rs
+++ b/crates/papyrus_network/src/mixed_behaviour.rs
@@ -7,8 +7,8 @@ use libp2p::swarm::dial_opts::DialOpts;
 use libp2p::swarm::NetworkBehaviour;
 use libp2p::{identify, kad, Multiaddr, PeerId};
 
-use crate::discovery::identify_impl::IDENTIFY_PROTOCOL_VERSION;
-use crate::discovery::kad_impl::KadFromOtherBehaviourEvent;
+use crate::discovery::identify_impl::{IdentifyToOtherBehaviourEvent, IDENTIFY_PROTOCOL_VERSION};
+use crate::discovery::kad_impl::KadToOtherBehaviourEvent;
 use crate::peer_manager::PeerManagerConfig;
 use crate::{discovery, peer_manager, streamed_bytes};
 
@@ -27,7 +27,7 @@ pub struct MixedBehaviour {
 #[derive(Debug)]
 pub enum Event {
     ExternalEvent(ExternalEvent),
-    InternalEvent(InternalEvent),
+    ToOtherBehaviourEvent(ToOtherBehaviourEvent),
 }
 
 #[derive(Debug)]
@@ -36,16 +36,17 @@ pub enum ExternalEvent {
 }
 
 #[derive(Debug)]
-pub enum InternalEvent {
+pub enum ToOtherBehaviourEvent {
     NoOp,
-    NotifyKad(KadFromOtherBehaviourEvent),
-    NotifyDiscovery(discovery::FromOtherBehaviourEvent),
-    NotifyPeerManager(peer_manager::FromOtherBehaviour),
-    NotifyStreamedBytes(streamed_bytes::behaviour::FromOtherBehaviour),
+    Identify(IdentifyToOtherBehaviourEvent),
+    Kad(KadToOtherBehaviourEvent),
+    Discovery(discovery::ToOtherBehaviourEvent),
+    PeerManager(peer_manager::ToOtherBehaviourEvent),
+    StreamedBytes(streamed_bytes::ToOtherBehaviourEvent),
 }
 
 pub trait BridgedBehaviour {
-    fn on_other_behaviour_event(&mut self, event: InternalEvent);
+    fn on_other_behaviour_event(&mut self, event: &ToOtherBehaviourEvent);
 }
 
 impl MixedBehaviour {

--- a/crates/papyrus_network/src/mixed_behaviour.rs
+++ b/crates/papyrus_network/src/mixed_behaviour.rs
@@ -10,7 +10,7 @@ use libp2p::{identify, kad, Multiaddr, PeerId};
 use crate::discovery::identify_impl::{IdentifyToOtherBehaviourEvent, IDENTIFY_PROTOCOL_VERSION};
 use crate::discovery::kad_impl::KadToOtherBehaviourEvent;
 use crate::peer_manager::PeerManagerConfig;
-use crate::{discovery, peer_manager, streamed_bytes};
+use crate::{broadcast, discovery, peer_manager, streamed_bytes};
 
 // TODO: consider reducing the pulicity of all behaviour to pub(crate)
 #[derive(NetworkBehaviour)]
@@ -22,6 +22,7 @@ pub struct MixedBehaviour {
     // TODO(shahak): Consider using a different store.
     pub kademlia: kad::Behaviour<MemoryStore>,
     pub streamed_bytes: streamed_bytes::Behaviour,
+    pub broadcast: broadcast::Behaviour,
 }
 
 #[derive(Debug)]
@@ -33,6 +34,7 @@ pub enum Event {
 #[derive(Debug)]
 pub enum ExternalEvent {
     StreamedBytes(streamed_bytes::behaviour::ExternalEvent),
+    Broadcast(broadcast::ExternalEvent),
 }
 
 #[derive(Debug)]
@@ -77,6 +79,7 @@ impl MixedBehaviour {
             // TODO: change kademlia protocol name
             kademlia: kad::Behaviour::new(local_peer_id, MemoryStore::new(local_peer_id)),
             streamed_bytes: streamed_bytes::Behaviour::new(streamed_bytes_config),
+            broadcast: broadcast::Behaviour::new(),
         }
     }
 }

--- a/crates/papyrus_network/src/network_manager/mod.rs
+++ b/crates/papyrus_network/src/network_manager/mod.rs
@@ -24,7 +24,8 @@ use crate::converters::{Router, RouterError};
 use crate::db_executor::{self, BlockHeaderDBExecutor, DBExecutor, Data, QueryId};
 use crate::mixed_behaviour::{self, BridgedBehaviour};
 use crate::streamed_bytes::{self, InboundSessionId, OutboundSessionId, SessionId};
-use crate::{DataType, NetworkConfig, Protocol, Query, ResponseReceivers};
+use crate::utils::StreamHashMap;
+use crate::{broadcast, DataType, NetworkConfig, Protocol, Query, ResponseReceivers};
 
 type StreamCollection = SelectAll<BoxStream<'static, (Data, InboundSessionId)>>;
 type SubscriberChannels = (Receiver<Query>, Router);
@@ -41,7 +42,8 @@ pub struct GenericNetworkManager<DBExecutorT: DBExecutor, SwarmT: SwarmTrait> {
     header_buffer_size: usize,
     query_results_router: StreamCollection,
     sync_subscriber_channels: Option<SubscriberChannels>,
-    broadcast_subscriber_channels: HashMap<Topic, BroadcastNetworkChannels>,
+    messages_to_broadcast_receivers: StreamHashMap<Topic, Receiver<Bytes>>,
+    broadcasted_messages_senders: HashMap<Topic, Sender<(Bytes, ReportCallback)>>,
     query_id_to_inbound_session_id: HashMap<QueryId, InboundSessionId>,
     outbound_session_id_to_protocol: HashMap<OutboundSessionId, Protocol>,
     // Fields for metrics
@@ -59,6 +61,7 @@ impl<DBExecutorT: DBExecutor, SwarmT: SwarmTrait> GenericNetworkManager<DBExecut
                 Some(res) = self.sync_subscriber_channels.as_mut()
                 .map(|(query_receiver, _)| query_receiver.next().boxed())
                 .unwrap_or(pending().boxed()) => self.handle_sync_subscriber_query(res),
+                Some((topic, message)) = self.messages_to_broadcast_receivers.next() => self.broadcast_message(message, topic),
             }
         }
     }
@@ -75,7 +78,8 @@ impl<DBExecutorT: DBExecutor, SwarmT: SwarmTrait> GenericNetworkManager<DBExecut
             header_buffer_size,
             query_results_router: StreamCollection::new(),
             sync_subscriber_channels: None,
-            broadcast_subscriber_channels: HashMap::new(),
+            messages_to_broadcast_receivers: StreamHashMap::new(HashMap::new()),
+            broadcasted_messages_senders: HashMap::new(),
             query_id_to_inbound_session_id: HashMap::new(),
             outbound_session_id_to_protocol: HashMap::new(),
             num_active_inbound_sessions: 0,
@@ -105,16 +109,20 @@ impl<DBExecutorT: DBExecutor, SwarmT: SwarmTrait> GenericNetworkManager<DBExecut
             futures::channel::mpsc::channel(buffer_size);
         let (broadcasted_messages_sender, broadcasted_messages_receiver) =
             futures::channel::mpsc::channel(buffer_size);
-        let insert_result = self.broadcast_subscriber_channels.insert(
-            topic.clone(),
-            BroadcastNetworkChannels {
-                messages_to_broadcast_receiver,
-                broadcasted_messages_sender,
-            },
-        );
+
+        let insert_result = self
+            .messages_to_broadcast_receivers
+            .insert(topic.clone(), messages_to_broadcast_receiver);
         if insert_result.is_some() {
             panic!("Topic {} was registered twice", topic);
         }
+
+        let insert_result =
+            self.broadcasted_messages_senders.insert(topic.clone(), broadcasted_messages_sender);
+        if insert_result.is_some() {
+            panic!("Topic {} was registered twice", topic);
+        }
+
         BroadcastSubscriberChannels { messages_to_broadcast_sender, broadcasted_messages_receiver }
     }
 
@@ -210,8 +218,8 @@ impl<DBExecutorT: DBExecutor, SwarmT: SwarmTrait> GenericNetworkManager<DBExecut
             mixed_behaviour::ExternalEvent::StreamedBytes(event) => {
                 self.handle_stream_bytes_behaviour_event(event);
             }
-            mixed_behaviour::ExternalEvent::Broadcast(_event) => {
-                unimplemented!();
+            mixed_behaviour::ExternalEvent::Broadcast(event) => {
+                self.handle_broadcast_behaviour_event(event);
             }
         }
     }
@@ -320,6 +328,29 @@ impl<DBExecutorT: DBExecutor, SwarmT: SwarmTrait> GenericNetworkManager<DBExecut
         }
     }
 
+    fn handle_broadcast_behaviour_event(&mut self, event: broadcast::ExternalEvent) {
+        match event {
+            broadcast::ExternalEvent::Received { originated_peer_id: _peer_id, message, topic } => {
+                let Some(sender) = self.broadcasted_messages_senders.get_mut(&topic) else {
+                    error!("Received a message from a topic we're not subscribed to {topic:?}");
+                    return;
+                };
+                // TODO(shahak): Implement the report callback.
+                let send_result = sender.try_send((message, Box::new(|| {})));
+                if let Err(e) = send_result {
+                    if e.is_disconnected() {
+                        panic!("Receiver was dropped. This should never happen.")
+                    } else if e.is_full() {
+                        error!(
+                            "Receiver buffer is full. Dropping broadcasted message for topic \
+                             {topic:?}."
+                        );
+                    }
+                }
+            }
+        }
+    }
+
     fn handle_query_result_routing_to_other_peer(&mut self, res: (Data, InboundSessionId)) {
         if self.query_results_router.is_empty() {
             // We're done handling all the queries we had and the stream is exhausted.
@@ -368,6 +399,10 @@ impl<DBExecutorT: DBExecutor, SwarmT: SwarmTrait> GenericNetworkManager<DBExecut
                 );
             }
         }
+    }
+
+    fn broadcast_message(&mut self, message: Bytes, topic: Topic) {
+        self.swarm.broadcast_message(message, topic);
     }
 
     fn report_session_removed_to_metrics(&mut self, session_id: SessionId) {
@@ -439,11 +474,4 @@ pub type ReportCallback = Box<dyn Fn() + Send>;
 pub struct BroadcastSubscriberChannels {
     pub messages_to_broadcast_sender: Sender<Bytes>,
     pub broadcasted_messages_receiver: Receiver<(Bytes, ReportCallback)>,
-}
-
-struct BroadcastNetworkChannels {
-    #[allow(dead_code)]
-    messages_to_broadcast_receiver: Receiver<Bytes>,
-    #[allow(dead_code)]
-    broadcasted_messages_sender: Sender<(Bytes, ReportCallback)>,
 }

--- a/crates/papyrus_network/src/network_manager/mod.rs
+++ b/crates/papyrus_network/src/network_manager/mod.rs
@@ -5,7 +5,7 @@ mod test;
 
 use std::collections::HashMap;
 
-use futures::channel::mpsc::{Receiver, Sender};
+use futures::channel::mpsc::{Receiver, Sender, UnboundedReceiver, UnboundedSender};
 use futures::future::pending;
 use futures::stream::{self, BoxStream, SelectAll};
 use futures::{FutureExt, StreamExt};
@@ -46,6 +46,9 @@ pub struct GenericNetworkManager<DBExecutorT: DBExecutor, SwarmT: SwarmTrait> {
     broadcasted_messages_senders: HashMap<Topic, Sender<(Bytes, ReportCallback)>>,
     query_id_to_inbound_session_id: HashMap<QueryId, InboundSessionId>,
     outbound_session_id_to_protocol: HashMap<OutboundSessionId, Protocol>,
+    reported_peer_receiver: UnboundedReceiver<PeerId>,
+    // We keep this just for giving a clone of it for subscribers.
+    reported_peer_sender: UnboundedSender<PeerId>,
     // Fields for metrics
     num_active_inbound_sessions: usize,
     num_active_outbound_sessions: usize,
@@ -62,6 +65,7 @@ impl<DBExecutorT: DBExecutor, SwarmT: SwarmTrait> GenericNetworkManager<DBExecut
                 .map(|(query_receiver, _)| query_receiver.next().boxed())
                 .unwrap_or(pending().boxed()) => self.handle_sync_subscriber_query(res),
                 Some((topic, message)) = self.messages_to_broadcast_receivers.next() => self.broadcast_message(message, topic),
+                Some(peer_id) = self.reported_peer_receiver.next() => self.swarm.report_peer(peer_id),
             }
         }
     }
@@ -72,6 +76,7 @@ impl<DBExecutorT: DBExecutor, SwarmT: SwarmTrait> GenericNetworkManager<DBExecut
         header_buffer_size: usize,
     ) -> Self {
         gauge!(papyrus_metrics::PAPYRUS_NUM_CONNECTED_PEERS, 0f64);
+        let (reported_peer_sender, reported_peer_receiver) = futures::channel::mpsc::unbounded();
         Self {
             swarm,
             db_executor,
@@ -82,6 +87,8 @@ impl<DBExecutorT: DBExecutor, SwarmT: SwarmTrait> GenericNetworkManager<DBExecut
             broadcasted_messages_senders: HashMap::new(),
             query_id_to_inbound_session_id: HashMap::new(),
             outbound_session_id_to_protocol: HashMap::new(),
+            reported_peer_sender,
+            reported_peer_receiver,
             num_active_inbound_sessions: 0,
             num_active_outbound_sessions: 0,
         }
@@ -330,13 +337,19 @@ impl<DBExecutorT: DBExecutor, SwarmT: SwarmTrait> GenericNetworkManager<DBExecut
 
     fn handle_broadcast_behaviour_event(&mut self, event: broadcast::ExternalEvent) {
         match event {
-            broadcast::ExternalEvent::Received { originated_peer_id: _peer_id, message, topic } => {
+            broadcast::ExternalEvent::Received { originated_peer_id, message, topic } => {
                 let Some(sender) = self.broadcasted_messages_senders.get_mut(&topic) else {
                     error!("Received a message from a topic we're not subscribed to {topic:?}");
                     return;
                 };
-                // TODO(shahak): Implement the report callback.
-                let send_result = sender.try_send((message, Box::new(|| {})));
+                let reported_peer_sender = self.reported_peer_sender.clone();
+                let send_result = sender.try_send((
+                    message,
+                    Box::new(move || {
+                        // TODO(shahak): Check if we can panic in case of error.
+                        let _ = reported_peer_sender.unbounded_send(originated_peer_id);
+                    }),
+                ));
                 if let Err(e) = send_result {
                     if e.is_disconnected() {
                         panic!("Receiver was dropped. This should never happen.")

--- a/crates/papyrus_network/src/network_manager/mod.rs
+++ b/crates/papyrus_network/src/network_manager/mod.rs
@@ -182,10 +182,14 @@ impl<DBExecutorT: DBExecutor, SwarmT: SwarmTrait> GenericNetworkManager<DBExecut
             mixed_behaviour::ExternalEvent::StreamedBytes(event) => {
                 self.handle_stream_bytes_behaviour_event(event);
             }
+            mixed_behaviour::ExternalEvent::Broadcast(_event) => {
+                unimplemented!();
+            }
         }
     }
 
     fn handle_to_other_behaviour_event(&mut self, event: mixed_behaviour::ToOtherBehaviourEvent) {
+        // TODO(shahak): Move this logic to mixed_behaviour.
         if let mixed_behaviour::ToOtherBehaviourEvent::NoOp = event {
             return;
         }
@@ -196,6 +200,7 @@ impl<DBExecutorT: DBExecutor, SwarmT: SwarmTrait> GenericNetworkManager<DBExecut
         }
         self.swarm.behaviour_mut().streamed_bytes.on_other_behaviour_event(&event);
         self.swarm.behaviour_mut().peer_manager.on_other_behaviour_event(&event);
+        self.swarm.behaviour_mut().broadcast.on_other_behaviour_event(&event);
     }
 
     fn handle_stream_bytes_behaviour_event(

--- a/crates/papyrus_network/src/network_manager/swarm_trait.rs
+++ b/crates/papyrus_network/src/network_manager/swarm_trait.rs
@@ -4,6 +4,7 @@ use libp2p::swarm::{DialError, NetworkBehaviour, SwarmEvent};
 use libp2p::{Multiaddr, PeerId, Swarm};
 
 use crate::broadcast::Topic;
+use crate::peer_manager::ReputationModifier;
 use crate::streamed_bytes::behaviour::{PeerNotConnected, SessionIdNotFoundError};
 use crate::streamed_bytes::{Bytes, InboundSessionId, OutboundSessionId};
 use crate::{mixed_behaviour, Protocol};
@@ -38,6 +39,8 @@ pub trait SwarmTrait: Stream<Item = Event> + Unpin {
     fn add_external_address(&mut self, address: Multiaddr);
 
     fn broadcast_message(&mut self, message: Bytes, topic: Topic);
+
+    fn report_peer(&mut self, peer_id: PeerId);
 }
 
 impl SwarmTrait for Swarm<mixed_behaviour::MixedBehaviour> {
@@ -83,5 +86,9 @@ impl SwarmTrait for Swarm<mixed_behaviour::MixedBehaviour> {
 
     fn broadcast_message(&mut self, message: Bytes, topic: Topic) {
         self.behaviour_mut().broadcast.broadcast_message(message, topic);
+    }
+
+    fn report_peer(&mut self, peer_id: PeerId) {
+        let _ = self.behaviour_mut().peer_manager.report_peer(peer_id, ReputationModifier::Bad {});
     }
 }

--- a/crates/papyrus_network/src/network_manager/swarm_trait.rs
+++ b/crates/papyrus_network/src/network_manager/swarm_trait.rs
@@ -3,8 +3,9 @@ use libp2p::swarm::dial_opts::DialOpts;
 use libp2p::swarm::{DialError, NetworkBehaviour, SwarmEvent};
 use libp2p::{Multiaddr, PeerId, Swarm};
 
+use crate::broadcast::Topic;
 use crate::streamed_bytes::behaviour::{PeerNotConnected, SessionIdNotFoundError};
-use crate::streamed_bytes::{InboundSessionId, OutboundSessionId};
+use crate::streamed_bytes::{Bytes, InboundSessionId, OutboundSessionId};
 use crate::{mixed_behaviour, Protocol};
 
 pub type Event = SwarmEvent<<mixed_behaviour::MixedBehaviour as NetworkBehaviour>::ToSwarm>;
@@ -35,6 +36,8 @@ pub trait SwarmTrait: Stream<Item = Event> + Unpin {
     fn behaviour_mut(&mut self) -> &mut mixed_behaviour::MixedBehaviour;
 
     fn add_external_address(&mut self, address: Multiaddr);
+
+    fn broadcast_message(&mut self, message: Bytes, topic: Topic);
 }
 
 impl SwarmTrait for Swarm<mixed_behaviour::MixedBehaviour> {
@@ -76,5 +79,9 @@ impl SwarmTrait for Swarm<mixed_behaviour::MixedBehaviour> {
 
     fn add_external_address(&mut self, address: Multiaddr) {
         self.add_external_address(address);
+    }
+
+    fn broadcast_message(&mut self, message: Bytes, topic: Topic) {
+        self.behaviour_mut().broadcast.broadcast_message(message, topic);
     }
 }

--- a/crates/papyrus_network/src/network_manager/test.rs
+++ b/crates/papyrus_network/src/network_manager/test.rs
@@ -35,12 +35,23 @@ use crate::db_executor::{
 use crate::protobuf_messages::protobuf;
 use crate::streamed_bytes::behaviour::{PeerNotConnected, SessionIdNotFoundError};
 use crate::streamed_bytes::{Bytes, GenericEvent, InboundSessionId, OutboundSessionId};
-use crate::{mixed_behaviour, BlockHashOrNumber, DataType, Direction, InternalQuery, Query};
+use crate::{
+    broadcast,
+    mixed_behaviour,
+    BlockHashOrNumber,
+    DataType,
+    Direction,
+    InternalQuery,
+    Query,
+};
+
+const TIMEOUT: Duration = Duration::from_secs(1);
 
 #[derive(Default)]
 struct MockSwarm {
     pub pending_events: Queue<Event>,
     pub sent_queries: Vec<(InternalQuery, PeerId)>,
+    broadcasted_messages_senders: Vec<UnboundedSender<(Bytes, Topic)>>,
     inbound_session_id_to_data_sender: HashMap<InboundSessionId, UnboundedSender<Data>>,
     next_outbound_session_id: usize,
     first_polled_event_notifier: Option<oneshot::Sender<()>>,
@@ -77,6 +88,12 @@ impl MockSwarm {
             panic!("Called get_data_sent_to_inbound_session on {inbound_session_id:?} twice");
         }
         data_receiver.collect()
+    }
+
+    pub fn get_messages_we_broadcasted_stream(&mut self) -> impl Stream<Item = (Bytes, Topic)> {
+        let (sender, receiver) = unbounded();
+        self.broadcasted_messages_senders.push(sender);
+        receiver
     }
 
     fn create_received_data_events_for_query(
@@ -178,9 +195,10 @@ impl SwarmTrait for MockSwarm {
 
     fn add_external_address(&mut self, _address: Multiaddr) {}
 
-    fn broadcast_message(&mut self, _message: Bytes, _topic: Topic) {
-        // TODO(shahak): Test broadcast flow and received broadcast message flow.
-        unimplemented!()
+    fn broadcast_message(&mut self, message: Bytes, topic: Topic) {
+        for sender in &self.broadcasted_messages_senders {
+            sender.unbounded_send((message.clone(), topic.clone())).unwrap();
+        }
     }
 }
 
@@ -230,7 +248,7 @@ impl DBExecutor for MockDBExecutor {
     }
 }
 
-const HEADER_BUFFER_SIZE: usize = 100;
+const BUFFER_SIZE: usize = 100;
 
 #[tokio::test]
 async fn register_subscriber_and_use_channels() {
@@ -242,11 +260,8 @@ async fn register_subscriber_and_use_channels() {
     mock_swarm.first_polled_event_notifier = Some(event_notifier);
 
     // network manager to register subscriber and send query
-    let mut network_manager = GenericNetworkManager::generic_new(
-        mock_swarm,
-        MockDBExecutor::default(),
-        HEADER_BUFFER_SIZE,
-    );
+    let mut network_manager =
+        GenericNetworkManager::generic_new(mock_swarm, MockDBExecutor::default(), BUFFER_SIZE);
     // define query
     let query_limit = 5;
     let start_block_number = 0;
@@ -334,7 +349,7 @@ async fn process_incoming_query() {
     let get_data_fut = mock_swarm.get_data_sent_to_inbound_session(inbound_session_id);
 
     let network_manager =
-        GenericNetworkManager::generic_new(mock_swarm, mock_db_executor, HEADER_BUFFER_SIZE);
+        GenericNetworkManager::generic_new(mock_swarm, mock_db_executor, BUFFER_SIZE);
 
     select! {
         inbound_session_data = get_data_fut => {
@@ -406,12 +421,75 @@ async fn close_inbound_session() {
 
     // Create network manager and run it
     let network_manager =
-        GenericNetworkManager::generic_new(mock_swarm, mock_db_executor, HEADER_BUFFER_SIZE);
+        GenericNetworkManager::generic_new(mock_swarm, mock_db_executor, BUFFER_SIZE);
     tokio::select! {
         _ = network_manager.run() => panic!("network manager ended"),
         _ = inbound_session_closed_receiver => {}
         _ = sleep(Duration::from_secs(5)) => {
             panic!("Test timed out");
+        }
+    }
+}
+
+#[tokio::test]
+async fn broadcast_message() {
+    let topic = "TOPIC".to_owned();
+    let message = vec![1u8, 2u8, 3u8];
+
+    let mut mock_swarm = MockSwarm::default();
+    let mut messages_we_broadcasted_stream = mock_swarm.get_messages_we_broadcasted_stream();
+
+    let mock_db_executor = MockDBExecutor::default();
+    let mut network_manager =
+        GenericNetworkManager::generic_new(mock_swarm, mock_db_executor, BUFFER_SIZE);
+
+    let mut messages_to_broadcast_sender = network_manager
+        .register_broadcast_subscriber(topic.clone(), BUFFER_SIZE)
+        .messages_to_broadcast_sender;
+    messages_to_broadcast_sender.try_send(message.clone()).unwrap();
+
+    tokio::select! {
+        _ = network_manager.run() => panic!("network manager ended"),
+        result = tokio::time::timeout(
+            TIMEOUT, messages_we_broadcasted_stream.next()
+        ) => {
+            let (actual_message, actual_topic) = result.unwrap().unwrap();
+            assert_eq!(message, actual_message);
+            assert_eq!(topic, actual_topic);
+        }
+    }
+}
+
+#[tokio::test]
+async fn receive_broadcasted_message() {
+    let topic = "TOPIC".to_owned();
+    let message = vec![1u8, 2u8, 3u8];
+
+    let mock_swarm = MockSwarm::default();
+    mock_swarm.pending_events.push(Event::Behaviour(mixed_behaviour::Event::ExternalEvent(
+        mixed_behaviour::ExternalEvent::Broadcast(broadcast::ExternalEvent::Received {
+            originated_peer_id: PeerId::random(),
+            message: message.clone(),
+            topic: topic.clone(),
+        }),
+    )));
+
+    let mock_db_executor = MockDBExecutor::default();
+    let mut network_manager =
+        GenericNetworkManager::generic_new(mock_swarm, mock_db_executor, BUFFER_SIZE);
+
+    let mut broadcasted_messages_receiver = network_manager
+        .register_broadcast_subscriber(topic.clone(), BUFFER_SIZE)
+        .broadcasted_messages_receiver;
+
+    tokio::select! {
+        _ = network_manager.run() => panic!("network manager ended"),
+        result = tokio::time::timeout(
+            TIMEOUT, broadcasted_messages_receiver.next()
+        ) => {
+            let (actual_message, _report_callback) = result.unwrap().unwrap();
+            assert_eq!(message, actual_message);
+            // TODO(shahak): Call the report callback once it's implemented.
         }
     }
 }

--- a/crates/papyrus_network/src/network_manager/test.rs
+++ b/crates/papyrus_network/src/network_manager/test.rs
@@ -23,6 +23,7 @@ use tokio::time::sleep;
 
 use super::swarm_trait::{Event, SwarmTrait};
 use super::GenericNetworkManager;
+use crate::broadcast::Topic;
 use crate::db_executor::{
     poll_query_execution_set,
     DBExecutor,
@@ -33,7 +34,7 @@ use crate::db_executor::{
 };
 use crate::protobuf_messages::protobuf;
 use crate::streamed_bytes::behaviour::{PeerNotConnected, SessionIdNotFoundError};
-use crate::streamed_bytes::{GenericEvent, InboundSessionId, OutboundSessionId};
+use crate::streamed_bytes::{Bytes, GenericEvent, InboundSessionId, OutboundSessionId};
 use crate::{mixed_behaviour, BlockHashOrNumber, DataType, Direction, InternalQuery, Query};
 
 #[derive(Default)]
@@ -176,6 +177,11 @@ impl SwarmTrait for MockSwarm {
     }
 
     fn add_external_address(&mut self, _address: Multiaddr) {}
+
+    fn broadcast_message(&mut self, _message: Bytes, _topic: Topic) {
+        // TODO(shahak): Test broadcast flow and received broadcast message flow.
+        unimplemented!()
+    }
 }
 
 #[derive(Default)]

--- a/crates/papyrus_network/src/network_manager/test.rs
+++ b/crates/papyrus_network/src/network_manager/test.rs
@@ -52,6 +52,7 @@ struct MockSwarm {
     pub pending_events: Queue<Event>,
     pub sent_queries: Vec<(InternalQuery, PeerId)>,
     broadcasted_messages_senders: Vec<UnboundedSender<(Bytes, Topic)>>,
+    reported_peer_senders: Vec<UnboundedSender<PeerId>>,
     inbound_session_id_to_data_sender: HashMap<InboundSessionId, UnboundedSender<Data>>,
     next_outbound_session_id: usize,
     first_polled_event_notifier: Option<oneshot::Sender<()>>,
@@ -93,6 +94,12 @@ impl MockSwarm {
     pub fn get_messages_we_broadcasted_stream(&mut self) -> impl Stream<Item = (Bytes, Topic)> {
         let (sender, receiver) = unbounded();
         self.broadcasted_messages_senders.push(sender);
+        receiver
+    }
+
+    pub fn get_reported_peers_stream(&mut self) -> impl Stream<Item = PeerId> {
+        let (sender, receiver) = unbounded();
+        self.reported_peer_senders.push(sender);
         receiver
     }
 
@@ -198,6 +205,12 @@ impl SwarmTrait for MockSwarm {
     fn broadcast_message(&mut self, message: Bytes, topic: Topic) {
         for sender in &self.broadcasted_messages_senders {
             sender.unbounded_send((message.clone(), topic.clone())).unwrap();
+        }
+    }
+
+    fn report_peer(&mut self, peer_id: PeerId) {
+        for sender in &self.reported_peer_senders {
+            sender.unbounded_send(peer_id).unwrap();
         }
     }
 }
@@ -461,18 +474,20 @@ async fn broadcast_message() {
 }
 
 #[tokio::test]
-async fn receive_broadcasted_message() {
+async fn receive_broadcasted_message_and_report_it() {
     let topic = "TOPIC".to_owned();
     let message = vec![1u8, 2u8, 3u8];
+    let originated_peer_id = PeerId::random();
 
-    let mock_swarm = MockSwarm::default();
+    let mut mock_swarm = MockSwarm::default();
     mock_swarm.pending_events.push(Event::Behaviour(mixed_behaviour::Event::ExternalEvent(
         mixed_behaviour::ExternalEvent::Broadcast(broadcast::ExternalEvent::Received {
-            originated_peer_id: PeerId::random(),
+            originated_peer_id,
             message: message.clone(),
             topic: topic.clone(),
         }),
     )));
+    let mut reported_peer_receiver = mock_swarm.get_reported_peers_stream();
 
     let mock_db_executor = MockDBExecutor::default();
     let mut network_manager =
@@ -485,11 +500,15 @@ async fn receive_broadcasted_message() {
     tokio::select! {
         _ = network_manager.run() => panic!("network manager ended"),
         result = tokio::time::timeout(
-            TIMEOUT, broadcasted_messages_receiver.next()
+            TIMEOUT, async move {
+                let (actual_message, report_callback) =
+                    broadcasted_messages_receiver.next().await.unwrap();
+                assert_eq!(message, actual_message);
+                report_callback();
+                assert_eq!(originated_peer_id, reported_peer_receiver.next().await.unwrap());
+            }
         ) => {
-            let (actual_message, _report_callback) = result.unwrap().unwrap();
-            assert_eq!(message, actual_message);
-            // TODO(shahak): Call the report callback once it's implemented.
+            result.unwrap()
         }
     }
 }

--- a/crates/papyrus_network/src/peer_manager/behaviour_impl.rs
+++ b/crates/papyrus_network/src/peer_manager/behaviour_impl.rs
@@ -1,18 +1,31 @@
 use std::task::Poll;
 
 use libp2p::swarm::behaviour::ConnectionEstablished;
-use libp2p::swarm::{dummy, ConnectionClosed, DialError, DialFailure, NetworkBehaviour, ToSwarm};
-use libp2p::Multiaddr;
+use libp2p::swarm::{
+    dummy,
+    ConnectionClosed,
+    ConnectionId,
+    DialError,
+    DialFailure,
+    NetworkBehaviour,
+    ToSwarm,
+};
+use libp2p::{Multiaddr, PeerId};
 use tracing::{debug, error};
 
 use super::peer::PeerTrait;
 use super::{PeerManager, PeerManagerError};
-use crate::{discovery, streamed_bytes};
+use crate::streamed_bytes::OutboundSessionId;
 
 #[derive(Debug)]
-pub enum Event {
-    NotifyStreamedBytes(streamed_bytes::behaviour::FromOtherBehaviour),
-    NotifyDiscovery(discovery::FromOtherBehaviourEvent),
+pub enum ToOtherBehaviourEvent {
+    SessionAssigned {
+        outbound_session_id: OutboundSessionId,
+        peer_id: PeerId,
+        connection_id: ConnectionId,
+    },
+    PauseDiscovery,
+    ResumeDiscovery,
 }
 
 impl<P: 'static> NetworkBehaviour for PeerManager<P>
@@ -20,7 +33,7 @@ where
     P: PeerTrait,
 {
     type ConnectionHandler = dummy::ConnectionHandler;
-    type ToSwarm = Event;
+    type ToSwarm = ToOtherBehaviourEvent;
 
     fn handle_established_inbound_connection(
         &mut self,
@@ -116,13 +129,11 @@ where
             }) => {
                 if let Some(sessions) = self.peers_pending_dial_with_sessions.remove(&peer_id) {
                     self.pending_events.extend(sessions.iter().map(|outbound_session_id| {
-                        ToSwarm::GenerateEvent(Event::NotifyStreamedBytes(
-                            streamed_bytes::behaviour::FromOtherBehaviour::SessionAssigned {
-                                outbound_session_id: *outbound_session_id,
-                                peer_id,
-                                connection_id,
-                            },
-                        ))
+                        ToSwarm::GenerateEvent(ToOtherBehaviourEvent::SessionAssigned {
+                            outbound_session_id: *outbound_session_id,
+                            peer_id,
+                            connection_id,
+                        })
                     }));
                     self.peers
                         .get_mut(&peer_id)
@@ -138,9 +149,7 @@ where
                     if !self.more_peers_needed() {
                         // TODO: consider how and in which cases we resume discovery
                         self.pending_events.push(libp2p::swarm::ToSwarm::GenerateEvent(
-                            Event::NotifyDiscovery(
-                                discovery::FromOtherBehaviourEvent::PauseDiscovery,
-                            ),
+                            ToOtherBehaviourEvent::PauseDiscovery,
                         ))
                     }
                 }

--- a/crates/papyrus_network/src/peer_manager/mod.rs
+++ b/crates/papyrus_network/src/peer_manager/mod.rs
@@ -141,7 +141,7 @@ where
         })
     }
 
-    fn report_peer(
+    pub(crate) fn report_peer(
         &mut self,
         peer_id: PeerId,
         reason: ReputationModifier,

--- a/crates/papyrus_network/src/peer_manager/test.rs
+++ b/crates/papyrus_network/src/peer_manager/test.rs
@@ -11,11 +11,10 @@ use libp2p::{Multiaddr, PeerId};
 use mockall::predicate::eq;
 use tokio::time::sleep;
 
-use super::behaviour_impl::Event;
+use super::behaviour_impl::ToOtherBehaviourEvent;
 use crate::peer_manager::peer::{MockPeerTrait, Peer, PeerTrait};
 use crate::peer_manager::{PeerManager, PeerManagerConfig, ReputationModifier};
 use crate::streamed_bytes::OutboundSessionId;
-use crate::{discovery, streamed_bytes};
 
 #[test]
 fn peer_assignment_round_robin() {
@@ -56,13 +55,11 @@ fn peer_assignment_round_robin() {
 
     // check assignment events
     for event in peer_manager.pending_events {
-        let ToSwarm::GenerateEvent(Event::NotifyStreamedBytes(
-            streamed_bytes::behaviour::FromOtherBehaviour::SessionAssigned {
-                outbound_session_id,
-                peer_id,
-                connection_id,
-            },
-        )) = event
+        let ToSwarm::GenerateEvent(ToOtherBehaviourEvent::SessionAssigned {
+            outbound_session_id,
+            peer_id,
+            connection_id,
+        }) = event
         else {
             continue;
         };
@@ -123,13 +120,12 @@ fn peer_assignment_no_peers() {
     assert_eq!(peer_manager.pending_events.len(), 1);
     assert_matches!(
         peer_manager.pending_events.first().unwrap(),
-        ToSwarm::GenerateEvent(Event::NotifyStreamedBytes(
-            streamed_bytes::behaviour::FromOtherBehaviour::SessionAssigned {
+        ToSwarm::GenerateEvent(ToOtherBehaviourEvent::SessionAssigned {
                 outbound_session_id: event_outbound_session_id,
                 peer_id: event_peer_id,
                 connection_id: event_connection_id,
             }
-        )) if outbound_session_id == *event_outbound_session_id &&
+        ) if outbound_session_id == *event_outbound_session_id &&
             peer_id == *event_peer_id &&
             connection_id == *event_connection_id
     );
@@ -425,10 +421,10 @@ async fn flow_test_assign_non_connected_peer() {
         },
     ));
 
-    // Expect NotifyStreamedBytes event
+    // Expect SessionAssigned event
     assert_matches!(
         poll_fn(|cx| peer_manager.poll(cx)).await,
-        ToSwarm::GenerateEvent(Event::NotifyStreamedBytes(_))
+        ToSwarm::GenerateEvent(ToOtherBehaviourEvent::SessionAssigned { .. })
     );
 }
 
@@ -486,10 +482,7 @@ fn no_more_peers_needed_stops_discovery() {
 
     // Check that the discovery pause event emitted
     for event in peer_manager.pending_events {
-        if let ToSwarm::GenerateEvent(Event::NotifyDiscovery(
-            discovery::FromOtherBehaviourEvent::PauseDiscovery,
-        )) = event
-        {
+        if let ToSwarm::GenerateEvent(ToOtherBehaviourEvent::PauseDiscovery) = event {
             return;
         }
     }

--- a/crates/papyrus_network/src/streamed_bytes/flow_test.rs
+++ b/crates/papyrus_network/src/streamed_bytes/flow_test.rs
@@ -11,7 +11,8 @@ use libp2p::{PeerId, Swarm};
 use super::behaviour::{Behaviour, Event, ExternalEvent};
 use super::messages::with_length_prefix;
 use super::{Bytes, Config, InboundSessionId, OutboundSessionId, SessionId};
-use crate::test_utils::{create_fully_connected_swarms_stream, StreamHashMap};
+use crate::test_utils::create_fully_connected_swarms_stream;
+use crate::utils::StreamHashMap;
 
 const NUM_PEERS: usize = 3;
 const NUM_MESSAGES_PER_SESSION: usize = 5;

--- a/crates/papyrus_network/src/streamed_bytes/mod.rs
+++ b/crates/papyrus_network/src/streamed_bytes/mod.rs
@@ -8,7 +8,7 @@ mod flow_test;
 
 use std::time::Duration;
 
-pub use behaviour::Behaviour;
+pub use behaviour::{Behaviour, ToOtherBehaviourEvent};
 use derive_more::Display;
 use libp2p::swarm::StreamProtocol;
 use libp2p::PeerId;

--- a/crates/papyrus_network/src/test_utils/mod.rs
+++ b/crates/papyrus_network/src/test_utils/mod.rs
@@ -57,58 +57,6 @@ impl crate::streamed_bytes::Config {
     }
 }
 
-// This is an implementation of `StreamMap` from tokio_stream. The reason we're implementing it
-// ourselves is that the implementation in tokio_stream requires that the values implement the
-// Stream trait from tokio_stream and not from futures.
-pub(crate) struct StreamHashMap<K: Unpin + Clone + Eq + Hash, V: StreamTrait + Unpin> {
-    map: HashMap<K, V>,
-    finished_streams: HashSet<K>,
-}
-
-impl<K: Unpin + Clone + Eq + Hash, V: StreamTrait + Unpin> StreamHashMap<K, V> {
-    pub fn new(map: HashMap<K, V>) -> Self {
-        Self { map, finished_streams: Default::default() }
-    }
-
-    pub fn values_mut(&mut self) -> ValuesMut<'_, K, V> {
-        self.map.values_mut()
-    }
-
-    pub fn keys(&self) -> Keys<'_, K, V> {
-        self.map.keys()
-    }
-
-    pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
-        self.map.get_mut(key)
-    }
-}
-
-impl<K: Unpin + Clone + Eq + Hash, V: StreamTrait + Unpin> StreamTrait for StreamHashMap<K, V> {
-    type Item = (K, <V as StreamTrait>::Item);
-
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let unpinned_self = Pin::into_inner(self);
-        let mut finished = true;
-        for (key, stream) in &mut unpinned_self.map {
-            match stream.poll_next_unpin(cx) {
-                Poll::Ready(Some(value)) => {
-                    return Poll::Ready(Some((key.clone(), value)));
-                }
-                Poll::Ready(None) => {
-                    unpinned_self.finished_streams.insert(key.clone());
-                }
-                Poll::Pending => {
-                    finished = false;
-                }
-            }
-        }
-        if finished {
-            return Poll::Ready(None);
-        }
-        Poll::Pending
-    }
-}
-
 /// Create num_swarms swarms and connect each pair of swarms. Return them as a combined stream of
 /// events.
 pub(crate) async fn create_fully_connected_swarms_stream<TBehaviour: NetworkBehaviour + Send>(

--- a/crates/papyrus_network/src/utils/mod.rs
+++ b/crates/papyrus_network/src/utils/mod.rs
@@ -1,0 +1,51 @@
+// This is an implementation of `StreamMap` from tokio_stream. The reason we're implementing it
+// ourselves is that the implementation in tokio_stream requires that the values implement the
+// Stream trait from tokio_stream and not from futures.
+pub(crate) struct StreamHashMap<K: Unpin + Clone + Eq + Hash, V: StreamTrait + Unpin> {
+    map: HashMap<K, V>,
+    finished_streams: HashSet<K>,
+}
+
+impl<K: Unpin + Clone + Eq + Hash, V: StreamTrait + Unpin> StreamHashMap<K, V> {
+    pub fn new(map: HashMap<K, V>) -> Self {
+        Self { map, finished_streams: Default::default() }
+    }
+
+    pub fn values_mut(&mut self) -> ValuesMut<'_, K, V> {
+        self.map.values_mut()
+    }
+
+    pub fn keys(&self) -> Keys<'_, K, V> {
+        self.map.keys()
+    }
+
+    pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+        self.map.get_mut(key)
+    }
+}
+
+impl<K: Unpin + Clone + Eq + Hash, V: StreamTrait + Unpin> StreamTrait for StreamHashMap<K, V> {
+    type Item = (K, <V as StreamTrait>::Item);
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let unpinned_self = Pin::into_inner(self);
+        let mut finished = true;
+        for (key, stream) in &mut unpinned_self.map {
+            match stream.poll_next_unpin(cx) {
+                Poll::Ready(Some(value)) => {
+                    return Poll::Ready(Some((key.clone(), value)));
+                }
+                Poll::Ready(None) => {
+                    unpinned_self.finished_streams.insert(key.clone());
+                }
+                Poll::Pending => {
+                    finished = false;
+                }
+            }
+        }
+        if finished {
+            return Poll::Ready(None);
+        }
+        Poll::Pending
+    }
+}

--- a/crates/papyrus_network/src/utils/mod.rs
+++ b/crates/papyrus_network/src/utils/mod.rs
@@ -1,31 +1,43 @@
+use std::collections::hash_map::{Keys, ValuesMut};
+use std::collections::{HashMap, HashSet};
+use std::hash::Hash;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures::stream::{Stream, StreamExt};
+
 // This is an implementation of `StreamMap` from tokio_stream. The reason we're implementing it
 // ourselves is that the implementation in tokio_stream requires that the values implement the
 // Stream trait from tokio_stream and not from futures.
-pub(crate) struct StreamHashMap<K: Unpin + Clone + Eq + Hash, V: StreamTrait + Unpin> {
+pub(crate) struct StreamHashMap<K: Unpin + Clone + Eq + Hash, V: Stream + Unpin> {
     map: HashMap<K, V>,
     finished_streams: HashSet<K>,
 }
 
-impl<K: Unpin + Clone + Eq + Hash, V: StreamTrait + Unpin> StreamHashMap<K, V> {
+impl<K: Unpin + Clone + Eq + Hash, V: Stream + Unpin> StreamHashMap<K, V> {
+    #[allow(dead_code)]
     pub fn new(map: HashMap<K, V>) -> Self {
         Self { map, finished_streams: Default::default() }
     }
 
+    #[allow(dead_code)]
     pub fn values_mut(&mut self) -> ValuesMut<'_, K, V> {
         self.map.values_mut()
     }
 
+    #[allow(dead_code)]
     pub fn keys(&self) -> Keys<'_, K, V> {
         self.map.keys()
     }
 
+    #[allow(dead_code)]
     pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
         self.map.get_mut(key)
     }
 }
 
-impl<K: Unpin + Clone + Eq + Hash, V: StreamTrait + Unpin> StreamTrait for StreamHashMap<K, V> {
-    type Item = (K, <V as StreamTrait>::Item);
+impl<K: Unpin + Clone + Eq + Hash, V: Stream + Unpin> Stream for StreamHashMap<K, V> {
+    type Item = (K, <V as Stream>::Item);
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let unpinned_self = Pin::into_inner(self);

--- a/crates/papyrus_network/src/utils/mod.rs
+++ b/crates/papyrus_network/src/utils/mod.rs
@@ -34,6 +34,10 @@ impl<K: Unpin + Clone + Eq + Hash, V: Stream + Unpin> StreamHashMap<K, V> {
     pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
         self.map.get_mut(key)
     }
+
+    pub fn insert(&mut self, key: K, value: V) -> Option<V> {
+        self.map.insert(key, value)
+    }
 }
 
 impl<K: Unpin + Clone + Eq + Hash, V: Stream + Unpin> Stream for StreamHashMap<K, V> {


### PR DESCRIPTION
- refactor(network): mixed event contains the outputting behaviour instead of notified behaviour
- feat(network): add broadcast behaviour with unimplemented
- feat(network): connect broadcast behaviour to mixed behaviour
- feat(network): add register_broadcast_subscribers without connecting to behaviour
- refactor(network): move code
- refactor(network): make StreamHashMap usable in source code (not tests only)
- feat(network): connect broadcast subscribers to behaviour
- test(network): add tests for broadcast subscriber in network manager
- fix(network): report callback reports the originating peer
