### PR TITLE
fix(network): peer manager finds new peers through identify instead of ConnectionEstablished

### DIFF
--- a/crates/papyrus_network/src/discovery/discovery_test.rs
+++ b/crates/papyrus_network/src/discovery/discovery_test.rs
@@ -24,11 +24,11 @@ use tokio::sync::Mutex;
 use tokio::time::timeout;
 use void::Void;
 
-use super::kad_impl::KadFromOtherBehaviourEvent;
-use super::{Behaviour, FromOtherBehaviourEvent, ToOtherBehaviourEvent, DIAL_SLEEP};
-use crate::mixed_behaviour;
+use super::kad_impl::KadToOtherBehaviourEvent;
+use super::{Behaviour, ToOtherBehaviourEvent, DIAL_SLEEP};
 use crate::mixed_behaviour::BridgedBehaviour;
 use crate::test_utils::next_on_mutex_stream;
+use crate::{mixed_behaviour, peer_manager};
 
 const TIMEOUT: Duration = Duration::from_secs(1);
 const SLEEP_DURATION: Duration = Duration::from_millis(10);
@@ -184,12 +184,11 @@ async fn create_behaviour_and_connect_to_bootstrap_node() -> Behaviour {
     let event = timeout(TIMEOUT, behaviour.next()).await.unwrap().unwrap();
     assert_matches!(
         event,
-        ToSwarm::GenerateEvent(ToOtherBehaviourEvent(
-            KadFromOtherBehaviourEvent::FoundListenAddresses {
+        ToSwarm::GenerateEvent(ToOtherBehaviourEvent::FoundListenAddresses {
                 peer_id,
                 listen_addresses,
             }
-        )) if peer_id == bootstrap_peer_id && listen_addresses == vec![bootstrap_peer_address]
+        ) if peer_id == bootstrap_peer_id && listen_addresses == vec![bootstrap_peer_address]
     );
 
     behaviour
@@ -202,9 +201,7 @@ async fn discovery_outputs_single_query_after_connecting() {
     let event = timeout(TIMEOUT, behaviour.next()).await.unwrap().unwrap();
     assert_matches!(
         event,
-        ToSwarm::GenerateEvent(ToOtherBehaviourEvent(KadFromOtherBehaviourEvent::RequestKadQuery(
-            _peer_id
-        )))
+        ToSwarm::GenerateEvent(ToOtherBehaviourEvent::RequestKadQuery(_peer_id))
     );
 
     assert_no_event(&mut behaviour);
@@ -214,20 +211,18 @@ async fn discovery_outputs_single_query_after_connecting() {
 async fn discovery_doesnt_output_queries_while_paused() {
     let mut behaviour = create_behaviour_and_connect_to_bootstrap_node().await;
 
-    behaviour.on_other_behaviour_event(mixed_behaviour::InternalEvent::NotifyDiscovery(
-        FromOtherBehaviourEvent::PauseDiscovery,
+    behaviour.on_other_behaviour_event(&mixed_behaviour::ToOtherBehaviourEvent::PeerManager(
+        peer_manager::ToOtherBehaviourEvent::PauseDiscovery,
     ));
     assert_no_event(&mut behaviour);
 
-    behaviour.on_other_behaviour_event(mixed_behaviour::InternalEvent::NotifyDiscovery(
-        FromOtherBehaviourEvent::ResumeDiscovery,
+    behaviour.on_other_behaviour_event(&mixed_behaviour::ToOtherBehaviourEvent::PeerManager(
+        peer_manager::ToOtherBehaviourEvent::ResumeDiscovery,
     ));
     let event = timeout(TIMEOUT, behaviour.next()).await.unwrap().unwrap();
     assert_matches!(
         event,
-        ToSwarm::GenerateEvent(ToOtherBehaviourEvent(KadFromOtherBehaviourEvent::RequestKadQuery(
-            _peer_id
-        )))
+        ToSwarm::GenerateEvent(ToOtherBehaviourEvent::RequestKadQuery(_peer_id))
     );
 }
 
@@ -238,15 +233,13 @@ async fn discovery_outputs_single_query_on_query_finished() {
     // Consume the initial query event.
     timeout(TIMEOUT, behaviour.next()).await.unwrap();
 
-    behaviour.on_other_behaviour_event(mixed_behaviour::InternalEvent::NotifyDiscovery(
-        FromOtherBehaviourEvent::KadQueryFinished,
+    behaviour.on_other_behaviour_event(&mixed_behaviour::ToOtherBehaviourEvent::Kad(
+        KadToOtherBehaviourEvent::KadQueryFinished,
     ));
     let event = timeout(TIMEOUT, behaviour.next()).await.unwrap().unwrap();
     assert_matches!(
         event,
-        ToSwarm::GenerateEvent(ToOtherBehaviourEvent(KadFromOtherBehaviourEvent::RequestKadQuery(
-            _peer_id
-        )))
+        ToSwarm::GenerateEvent(ToOtherBehaviourEvent::RequestKadQuery(_peer_id))
     );
 }
 
@@ -257,14 +250,14 @@ async fn discovery_doesnt_output_queries_if_query_finished_while_paused() {
     // Consume the initial query event.
     timeout(TIMEOUT, behaviour.next()).await.unwrap();
 
-    behaviour.on_other_behaviour_event(mixed_behaviour::InternalEvent::NotifyDiscovery(
-        FromOtherBehaviourEvent::PauseDiscovery,
+    behaviour.on_other_behaviour_event(&mixed_behaviour::ToOtherBehaviourEvent::PeerManager(
+        peer_manager::ToOtherBehaviourEvent::PauseDiscovery,
     ));
     assert_no_event(&mut behaviour);
 
     // Simulate that the query has finished.
-    behaviour.on_other_behaviour_event(mixed_behaviour::InternalEvent::NotifyDiscovery(
-        FromOtherBehaviourEvent::KadQueryFinished,
+    behaviour.on_other_behaviour_event(&mixed_behaviour::ToOtherBehaviourEvent::Kad(
+        KadToOtherBehaviourEvent::KadQueryFinished,
     ));
     assert_no_event(&mut behaviour);
 }
@@ -273,8 +266,8 @@ async fn discovery_doesnt_output_queries_if_query_finished_while_paused() {
 async fn discovery_awakes_on_resume() {
     let mut behaviour = create_behaviour_and_connect_to_bootstrap_node().await;
 
-    behaviour.on_other_behaviour_event(mixed_behaviour::InternalEvent::NotifyDiscovery(
-        FromOtherBehaviourEvent::PauseDiscovery,
+    behaviour.on_other_behaviour_event(&mixed_behaviour::ToOtherBehaviourEvent::PeerManager(
+        peer_manager::ToOtherBehaviourEvent::PauseDiscovery,
     ));
 
     // There should be an event once we resume because discovery has just started.
@@ -285,8 +278,8 @@ async fn discovery_awakes_on_resume() {
         _ = async {
             tokio::time::sleep(SLEEP_DURATION).await;
             mutex.lock().await.on_other_behaviour_event(
-                mixed_behaviour::InternalEvent::NotifyDiscovery(
-                    FromOtherBehaviourEvent::ResumeDiscovery,
+                &mixed_behaviour::ToOtherBehaviourEvent::PeerManager(
+                    peer_manager::ToOtherBehaviourEvent::ResumeDiscovery,
                 )
             );
             timeout(TIMEOUT, pending::<()>()).await.unwrap();
@@ -308,9 +301,8 @@ async fn discovery_awakes_on_query_finished() {
         _ = async {
             tokio::time::sleep(SLEEP_DURATION).await;
             mutex.lock().await.on_other_behaviour_event(
-                mixed_behaviour::InternalEvent::NotifyDiscovery(
-                    FromOtherBehaviourEvent::KadQueryFinished,
-
+                &mixed_behaviour::ToOtherBehaviourEvent::Kad(
+                    KadToOtherBehaviourEvent::KadQueryFinished,
                 )
             );
             timeout(TIMEOUT, pending::<()>()).await.unwrap();

--- a/crates/papyrus_network/src/discovery/flow_test.rs
+++ b/crates/papyrus_network/src/discovery/flow_test.rs
@@ -85,21 +85,17 @@ async fn all_nodes_have_same_bootstrap_peer() {
             _ => continue,
         };
 
-        let mixed_behaviour::Event::InternalEvent(event) = mixed_event else {
+        let mixed_behaviour::Event::ToOtherBehaviourEvent(event) = mixed_event else {
+            continue;
+        };
+        if let mixed_behaviour::ToOtherBehaviourEvent::NoOp = event {
             continue;
         };
         let behaviour_ref = swarms_stream.get_mut(&peer_id).unwrap().behaviour_mut();
-        match event {
-            mixed_behaviour::InternalEvent::NoOp => {}
-            mixed_behaviour::InternalEvent::NotifyKad(_) => {
-                behaviour_ref.kademlia.on_other_behaviour_event(event)
-            }
-            mixed_behaviour::InternalEvent::NotifyDiscovery(_) => {
-                if let Some(discovery) = behaviour_ref.discovery.as_mut() {
-                    discovery.on_other_behaviour_event(event);
-                }
-            }
-            _ => {}
+        behaviour_ref.identify.on_other_behaviour_event(&event);
+        behaviour_ref.kademlia.on_other_behaviour_event(&event);
+        if let Some(discovery) = behaviour_ref.discovery.as_mut() {
+            discovery.on_other_behaviour_event(&event);
         }
     }
 }

--- a/crates/papyrus_network/src/discovery/identify_impl.rs
+++ b/crates/papyrus_network/src/discovery/identify_impl.rs
@@ -1,23 +1,36 @@
-use libp2p::identify;
+use libp2p::{identify, Multiaddr, PeerId};
 
-use super::kad_impl::KadFromOtherBehaviourEvent;
 use crate::mixed_behaviour;
+use crate::mixed_behaviour::BridgedBehaviour;
 
 pub const IDENTIFY_PROTOCOL_VERSION: &str = "/staknet/identify/0.1.0-rc.0";
+
+#[derive(Debug)]
+pub enum IdentifyToOtherBehaviourEvent {
+    FoundListenAddresses { peer_id: PeerId, listen_addresses: Vec<Multiaddr> },
+}
 
 impl From<identify::Event> for mixed_behaviour::Event {
     fn from(event: identify::Event) -> Self {
         match event {
             identify::Event::Received { peer_id, info } => {
-                mixed_behaviour::Event::InternalEvent(mixed_behaviour::InternalEvent::NotifyKad(
-                    KadFromOtherBehaviourEvent::FoundListenAddresses {
-                        peer_id,
-                        listen_addresses: info.listen_addrs,
-                    },
-                ))
+                mixed_behaviour::Event::ToOtherBehaviourEvent(
+                    mixed_behaviour::ToOtherBehaviourEvent::Identify(
+                        IdentifyToOtherBehaviourEvent::FoundListenAddresses {
+                            peer_id,
+                            listen_addresses: info.listen_addrs,
+                        },
+                    ),
+                )
             }
             // TODO(shahak): Consider logging error events.
-            _ => mixed_behaviour::Event::InternalEvent(mixed_behaviour::InternalEvent::NoOp),
+            _ => mixed_behaviour::Event::ToOtherBehaviourEvent(
+                mixed_behaviour::ToOtherBehaviourEvent::NoOp,
+            ),
         }
     }
+}
+
+impl BridgedBehaviour for identify::Behaviour {
+    fn on_other_behaviour_event(&mut self, _event: &mixed_behaviour::ToOtherBehaviourEvent) {}
 }

--- a/crates/papyrus_network/src/discovery/kad_impl.rs
+++ b/crates/papyrus_network/src/discovery/kad_impl.rs
@@ -1,13 +1,13 @@
-use libp2p::{kad, Multiaddr, PeerId};
+use libp2p::kad;
 use tracing::error;
 
+use super::identify_impl::IdentifyToOtherBehaviourEvent;
+use crate::mixed_behaviour;
 use crate::mixed_behaviour::BridgedBehaviour;
-use crate::{discovery, mixed_behaviour};
 
 #[derive(Debug)]
-pub enum KadFromOtherBehaviourEvent {
-    RequestKadQuery(PeerId),
-    FoundListenAddresses { peer_id: PeerId, listen_addresses: Vec<Multiaddr> },
+pub enum KadToOtherBehaviourEvent {
+    KadQueryFinished,
 }
 
 impl From<kad::Event> for mixed_behaviour::Event {
@@ -21,31 +21,38 @@ impl From<kad::Event> for mixed_behaviour::Event {
                 if let Err(err) = result {
                     error!("Kademlia query failed on {err:?}");
                 }
-                mixed_behaviour::Event::InternalEvent(
-                    mixed_behaviour::InternalEvent::NotifyDiscovery(
-                        discovery::FromOtherBehaviourEvent::KadQueryFinished,
+                mixed_behaviour::Event::ToOtherBehaviourEvent(
+                    mixed_behaviour::ToOtherBehaviourEvent::Kad(
+                        KadToOtherBehaviourEvent::KadQueryFinished,
                     ),
                 )
             }
-            _ => mixed_behaviour::Event::InternalEvent(mixed_behaviour::InternalEvent::NoOp),
+            _ => mixed_behaviour::Event::ToOtherBehaviourEvent(
+                mixed_behaviour::ToOtherBehaviourEvent::NoOp,
+            ),
         }
     }
 }
 
 impl<TStore: kad::store::RecordStore + Send + 'static> BridgedBehaviour for kad::Behaviour<TStore> {
-    fn on_other_behaviour_event(&mut self, event: mixed_behaviour::InternalEvent) {
-        let mixed_behaviour::InternalEvent::NotifyKad(event) = event else {
-            return;
-        };
+    fn on_other_behaviour_event(&mut self, event: &mixed_behaviour::ToOtherBehaviourEvent) {
         match event {
-            KadFromOtherBehaviourEvent::RequestKadQuery(peer_id) => {
-                self.get_closest_peers(peer_id);
+            mixed_behaviour::ToOtherBehaviourEvent::Discovery(
+                super::ToOtherBehaviourEvent::RequestKadQuery(peer_id),
+            ) => {
+                self.get_closest_peers(*peer_id);
             }
-            KadFromOtherBehaviourEvent::FoundListenAddresses { peer_id, listen_addresses } => {
+            mixed_behaviour::ToOtherBehaviourEvent::Identify(
+                IdentifyToOtherBehaviourEvent::FoundListenAddresses { peer_id, listen_addresses },
+            )
+            | mixed_behaviour::ToOtherBehaviourEvent::Discovery(
+                super::ToOtherBehaviourEvent::FoundListenAddresses { peer_id, listen_addresses },
+            ) => {
                 for address in listen_addresses {
-                    self.add_address(&peer_id, address);
+                    self.add_address(peer_id, address.clone());
                 }
             }
+            _ => {}
         }
     }
 }

--- a/crates/papyrus_network/src/mixed_behaviour.rs
+++ b/crates/papyrus_network/src/mixed_behaviour.rs
@@ -7,8 +7,8 @@ use libp2p::swarm::dial_opts::DialOpts;
 use libp2p::swarm::NetworkBehaviour;
 use libp2p::{identify, kad, Multiaddr, PeerId};
 
-use crate::discovery::identify_impl::IDENTIFY_PROTOCOL_VERSION;
-use crate::discovery::kad_impl::KadFromOtherBehaviourEvent;
+use crate::discovery::identify_impl::{IdentifyToOtherBehaviourEvent, IDENTIFY_PROTOCOL_VERSION};
+use crate::discovery::kad_impl::KadToOtherBehaviourEvent;
 use crate::peer_manager::PeerManagerConfig;
 use crate::{discovery, peer_manager, streamed_bytes};
 
@@ -27,7 +27,7 @@ pub struct MixedBehaviour {
 #[derive(Debug)]
 pub enum Event {
     ExternalEvent(ExternalEvent),
-    InternalEvent(InternalEvent),
+    ToOtherBehaviourEvent(ToOtherBehaviourEvent),
 }
 
 #[derive(Debug)]
@@ -36,16 +36,17 @@ pub enum ExternalEvent {
 }
 
 #[derive(Debug)]
-pub enum InternalEvent {
+pub enum ToOtherBehaviourEvent {
     NoOp,
-    NotifyKad(KadFromOtherBehaviourEvent),
-    NotifyDiscovery(discovery::FromOtherBehaviourEvent),
-    NotifyPeerManager(peer_manager::FromOtherBehaviour),
-    NotifyStreamedBytes(streamed_bytes::behaviour::FromOtherBehaviour),
+    Identify(IdentifyToOtherBehaviourEvent),
+    Kad(KadToOtherBehaviourEvent),
+    Discovery(discovery::ToOtherBehaviourEvent),
+    PeerManager(peer_manager::ToOtherBehaviourEvent),
+    StreamedBytes(streamed_bytes::ToOtherBehaviourEvent),
 }
 
 pub trait BridgedBehaviour {
-    fn on_other_behaviour_event(&mut self, event: InternalEvent);
+    fn on_other_behaviour_event(&mut self, event: &ToOtherBehaviourEvent);
 }
 
 impl MixedBehaviour {

--- a/crates/papyrus_network/src/peer_manager/behaviour_impl.rs
+++ b/crates/papyrus_network/src/peer_manager/behaviour_impl.rs
@@ -1,18 +1,31 @@
 use std::task::Poll;
 
 use libp2p::swarm::behaviour::ConnectionEstablished;
-use libp2p::swarm::{dummy, ConnectionClosed, DialError, DialFailure, NetworkBehaviour, ToSwarm};
-use libp2p::Multiaddr;
+use libp2p::swarm::{
+    dummy,
+    ConnectionClosed,
+    ConnectionId,
+    DialError,
+    DialFailure,
+    NetworkBehaviour,
+    ToSwarm,
+};
+use libp2p::{Multiaddr, PeerId};
 use tracing::{debug, error};
 
 use super::peer::PeerTrait;
 use super::{PeerManager, PeerManagerError};
-use crate::{discovery, streamed_bytes};
+use crate::streamed_bytes::OutboundSessionId;
 
 #[derive(Debug)]
-pub enum Event {
-    NotifyStreamedBytes(streamed_bytes::behaviour::FromOtherBehaviour),
-    NotifyDiscovery(discovery::FromOtherBehaviourEvent),
+pub enum ToOtherBehaviourEvent {
+    SessionAssigned {
+        outbound_session_id: OutboundSessionId,
+        peer_id: PeerId,
+        connection_id: ConnectionId,
+    },
+    PauseDiscovery,
+    ResumeDiscovery,
 }
 
 impl<P: 'static> NetworkBehaviour for PeerManager<P>
@@ -20,7 +33,7 @@ where
     P: PeerTrait,
 {
     type ConnectionHandler = dummy::ConnectionHandler;
-    type ToSwarm = Event;
+    type ToSwarm = ToOtherBehaviourEvent;
 
     fn handle_established_inbound_connection(
         &mut self,
@@ -116,13 +129,11 @@ where
             }) => {
                 if let Some(sessions) = self.peers_pending_dial_with_sessions.remove(&peer_id) {
                     self.pending_events.extend(sessions.iter().map(|outbound_session_id| {
-                        ToSwarm::GenerateEvent(Event::NotifyStreamedBytes(
-                            streamed_bytes::behaviour::FromOtherBehaviour::SessionAssigned {
-                                outbound_session_id: *outbound_session_id,
-                                peer_id,
-                                connection_id,
-                            },
-                        ))
+                        ToSwarm::GenerateEvent(ToOtherBehaviourEvent::SessionAssigned {
+                            outbound_session_id: *outbound_session_id,
+                            peer_id,
+                            connection_id,
+                        })
                     }));
                     self.peers
                         .get_mut(&peer_id)
@@ -138,9 +149,7 @@ where
                     if !self.more_peers_needed() {
                         // TODO: consider how and in which cases we resume discovery
                         self.pending_events.push(libp2p::swarm::ToSwarm::GenerateEvent(
-                            Event::NotifyDiscovery(
-                                discovery::FromOtherBehaviourEvent::PauseDiscovery,
-                            ),
+                            ToOtherBehaviourEvent::PauseDiscovery,
                         ))
                     }
                 }

--- a/crates/papyrus_network/src/peer_manager/mod.rs
+++ b/crates/papyrus_network/src/peer_manager/mod.rs
@@ -8,9 +8,10 @@ use tracing::info;
 
 pub use self::behaviour_impl::ToOtherBehaviourEvent;
 use self::peer::PeerTrait;
+use crate::discovery::identify_impl::IdentifyToOtherBehaviourEvent;
 use crate::mixed_behaviour::BridgedBehaviour;
 use crate::streamed_bytes::OutboundSessionId;
-use crate::{mixed_behaviour, streamed_bytes};
+use crate::{discovery, mixed_behaviour, streamed_bytes};
 
 pub(crate) mod behaviour_impl;
 pub(crate) mod peer;
@@ -188,12 +189,42 @@ impl From<ToOtherBehaviourEvent> for mixed_behaviour::Event {
 
 impl<P: PeerTrait + 'static> BridgedBehaviour for PeerManager<P> {
     fn on_other_behaviour_event(&mut self, event: &mixed_behaviour::ToOtherBehaviourEvent) {
-        let mixed_behaviour::ToOtherBehaviourEvent::StreamedBytes(
-            streamed_bytes::ToOtherBehaviourEvent::RequestPeerAssignment { outbound_session_id },
-        ) = event
-        else {
-            return;
-        };
-        self.assign_peer_to_session(*outbound_session_id);
+        match event {
+            mixed_behaviour::ToOtherBehaviourEvent::StreamedBytes(
+                streamed_bytes::ToOtherBehaviourEvent::RequestPeerAssignment {
+                    outbound_session_id,
+                },
+            ) => {
+                self.assign_peer_to_session(*outbound_session_id);
+            }
+            mixed_behaviour::ToOtherBehaviourEvent::Identify(
+                IdentifyToOtherBehaviourEvent::FoundListenAddresses { peer_id, listen_addresses },
+            )
+            | mixed_behaviour::ToOtherBehaviourEvent::Discovery(
+                discovery::ToOtherBehaviourEvent::FoundListenAddresses {
+                    peer_id,
+                    listen_addresses,
+                },
+            ) => {
+                // TODO(shahak): Handle changed addresses
+                if self.peers.contains_key(&peer_id) {
+                    return;
+                }
+                // TODO(shahak): Track multiple addresses per peer.
+                let Some(address) = listen_addresses.first() else {
+                    return;
+                };
+
+                let peer = P::new(*peer_id, address.clone());
+                self.add_peer(peer);
+                if !self.more_peers_needed() {
+                    // TODO: consider how and in which cases we resume discovery
+                    self.pending_events.push(libp2p::swarm::ToSwarm::GenerateEvent(
+                        ToOtherBehaviourEvent::PauseDiscovery,
+                    ))
+                }
+            }
+            _ => {}
+        }
     }
 }

--- a/crates/papyrus_network/src/peer_manager/test.rs
+++ b/crates/papyrus_network/src/peer_manager/test.rs
@@ -12,6 +12,9 @@ use mockall::predicate::eq;
 use tokio::time::sleep;
 
 use super::behaviour_impl::ToOtherBehaviourEvent;
+use crate::discovery::identify_impl::IdentifyToOtherBehaviourEvent;
+use crate::mixed_behaviour;
+use crate::mixed_behaviour::BridgedBehaviour;
 use crate::peer_manager::peer::{MockPeerTrait, Peer, PeerTrait};
 use crate::peer_manager::{PeerManager, PeerManagerConfig, ReputationModifier};
 use crate::streamed_bytes::OutboundSessionId;
@@ -429,24 +432,18 @@ async fn flow_test_assign_non_connected_peer() {
 }
 
 #[test]
-fn connection_established_unknown_peer_is_added_to_peer_manager() {
+fn identify_on_unknown_peer_is_added_to_peer_manager() {
     // Create a new peer manager
     let config = PeerManagerConfig::default();
     let mut peer_manager: PeerManager<Peer> = PeerManager::new(config.clone());
 
-    // Send ConnectionEstablished event from swarm
+    // Send Identify event
     let peer_id = PeerId::random();
     let address = Multiaddr::empty().with_p2p(peer_id).unwrap();
-    peer_manager.on_swarm_event(libp2p::swarm::FromSwarm::ConnectionEstablished(
-        ConnectionEstablished {
+    peer_manager.on_other_behaviour_event(&mixed_behaviour::ToOtherBehaviourEvent::Identify(
+        IdentifyToOtherBehaviourEvent::FoundListenAddresses {
             peer_id,
-            connection_id: ConnectionId::new_unchecked(0),
-            endpoint: &libp2p::core::ConnectedPoint::Dialer {
-                address: address.clone(),
-                role_override: libp2p::core::Endpoint::Dialer,
-            },
-            failed_addresses: &[],
-            other_established: 0,
+            listen_addresses: vec![address.clone()],
         },
     ));
 
@@ -462,18 +459,12 @@ fn no_more_peers_needed_stops_discovery() {
     let config = PeerManagerConfig { target_num_for_peers: 1, ..Default::default() };
     let mut peer_manager: PeerManager<Peer> = PeerManager::new(config.clone());
 
-    // Send ConnectionEstablished event from swarm for new peer
+    // Send Identify event
     let peer_id = PeerId::random();
-    peer_manager.on_swarm_event(libp2p::swarm::FromSwarm::ConnectionEstablished(
-        ConnectionEstablished {
+    peer_manager.on_other_behaviour_event(&mixed_behaviour::ToOtherBehaviourEvent::Identify(
+        IdentifyToOtherBehaviourEvent::FoundListenAddresses {
             peer_id,
-            connection_id: ConnectionId::new_unchecked(0),
-            endpoint: &libp2p::core::ConnectedPoint::Dialer {
-                address: Multiaddr::empty(),
-                role_override: libp2p::core::Endpoint::Dialer,
-            },
-            failed_addresses: &[],
-            other_established: 0,
+            listen_addresses: vec![Multiaddr::empty()],
         },
     ));
 

--- a/crates/papyrus_network/src/peer_manager/test.rs
+++ b/crates/papyrus_network/src/peer_manager/test.rs
@@ -11,11 +11,10 @@ use libp2p::{Multiaddr, PeerId};
 use mockall::predicate::eq;
 use tokio::time::sleep;
 
-use super::behaviour_impl::Event;
+use super::behaviour_impl::ToOtherBehaviourEvent;
 use crate::peer_manager::peer::{MockPeerTrait, Peer, PeerTrait};
 use crate::peer_manager::{PeerManager, PeerManagerConfig, ReputationModifier};
 use crate::streamed_bytes::OutboundSessionId;
-use crate::{discovery, streamed_bytes};
 
 #[test]
 fn peer_assignment_round_robin() {
@@ -56,13 +55,11 @@ fn peer_assignment_round_robin() {
 
     // check assignment events
     for event in peer_manager.pending_events {
-        let ToSwarm::GenerateEvent(Event::NotifyStreamedBytes(
-            streamed_bytes::behaviour::FromOtherBehaviour::SessionAssigned {
-                outbound_session_id,
-                peer_id,
-                connection_id,
-            },
-        )) = event
+        let ToSwarm::GenerateEvent(ToOtherBehaviourEvent::SessionAssigned {
+            outbound_session_id,
+            peer_id,
+            connection_id,
+        }) = event
         else {
             continue;
         };
@@ -123,13 +120,12 @@ fn peer_assignment_no_peers() {
     assert_eq!(peer_manager.pending_events.len(), 1);
     assert_matches!(
         peer_manager.pending_events.first().unwrap(),
-        ToSwarm::GenerateEvent(Event::NotifyStreamedBytes(
-            streamed_bytes::behaviour::FromOtherBehaviour::SessionAssigned {
+        ToSwarm::GenerateEvent(ToOtherBehaviourEvent::SessionAssigned {
                 outbound_session_id: event_outbound_session_id,
                 peer_id: event_peer_id,
                 connection_id: event_connection_id,
             }
-        )) if outbound_session_id == *event_outbound_session_id &&
+        ) if outbound_session_id == *event_outbound_session_id &&
             peer_id == *event_peer_id &&
             connection_id == *event_connection_id
     );
@@ -425,10 +421,10 @@ async fn flow_test_assign_non_connected_peer() {
         },
     ));
 
-    // Expect NotifyStreamedBytes event
+    // Expect SessionAssigned event
     assert_matches!(
         poll_fn(|cx| peer_manager.poll(cx)).await,
-        ToSwarm::GenerateEvent(Event::NotifyStreamedBytes(_))
+        ToSwarm::GenerateEvent(ToOtherBehaviourEvent::SessionAssigned { .. })
     );
 }
 
@@ -486,10 +482,7 @@ fn no_more_peers_needed_stops_discovery() {
 
     // Check that the discovery pause event emitted
     for event in peer_manager.pending_events {
-        if let ToSwarm::GenerateEvent(Event::NotifyDiscovery(
-            discovery::FromOtherBehaviourEvent::PauseDiscovery,
-        )) = event
-        {
+        if let ToSwarm::GenerateEvent(ToOtherBehaviourEvent::PauseDiscovery) = event {
             return;
         }
     }

--- a/crates/papyrus_network/src/streamed_bytes/mod.rs
+++ b/crates/papyrus_network/src/streamed_bytes/mod.rs
@@ -8,7 +8,7 @@ mod flow_test;
 
 use std::time::Duration;
 
-pub use behaviour::Behaviour;
+pub use behaviour::{Behaviour, ToOtherBehaviourEvent};
 use derive_more::Display;
 use libp2p::swarm::StreamProtocol;
 use libp2p::PeerId;


### PR DESCRIPTION
- refactor(network): mixed event contains the outputting behaviour instead of notified behaviour
- fix(network): peer manager finds new peers through identify instead of ConnectionEstablished

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/1989)
<!-- Reviewable:end -->
