### PR TITLE
feat(network): register_broadcast_subscriber receives any type with TryFrom/Into<Bytes>

### DIFF
--- a/crates/papyrus_network/src/network_manager/mod.rs
+++ b/crates/papyrus_network/src/network_manager/mod.rs
@@ -5,10 +5,11 @@ mod test;
 
 use std::collections::HashMap;
 
-use futures::channel::mpsc::{Receiver, Sender};
-use futures::future::pending;
-use futures::stream::{self, BoxStream, SelectAll};
-use futures::{FutureExt, StreamExt};
+use futures::channel::mpsc::{Receiver, SendError, Sender};
+use futures::future::{pending, ready, Ready};
+use futures::sink::With;
+use futures::stream::{self, BoxStream, Map, SelectAll};
+use futures::{FutureExt, SinkExt, StreamExt};
 use libp2p::swarm::SwarmEvent;
 use libp2p::{PeerId, Swarm};
 use metrics::gauge;
@@ -103,11 +104,15 @@ impl<DBExecutorT: DBExecutorTrait, SwarmT: SwarmTrait> GenericNetworkManager<DBE
 
     /// Register a new subscriber for broadcasting and receiving broadcasts for a given topic.
     /// Panics if this topic is already subscribed.
-    pub fn register_broadcast_subscriber(
+    pub fn register_broadcast_subscriber<T>(
         &mut self,
         topic: Topic,
         buffer_size: usize,
-    ) -> BroadcastSubscriberChannels {
+    ) -> BroadcastSubscriberChannels<T, <T as TryFrom<Bytes>>::Error>
+    where
+        T: TryFrom<Bytes>,
+        Bytes: From<T>,
+    {
         let (messages_to_broadcast_sender, messages_to_broadcast_receiver) =
             futures::channel::mpsc::channel(buffer_size);
         let (broadcasted_messages_sender, broadcasted_messages_receiver) =
@@ -125,6 +130,18 @@ impl<DBExecutorT: DBExecutorTrait, SwarmT: SwarmTrait> GenericNetworkManager<DBE
         if insert_result.is_some() {
             panic!("Topic '{}' has already been registered.", topic);
         }
+
+        let messages_to_broadcast_fn: fn(T) -> Ready<Result<Bytes, SendError>> =
+            |x| ready(Ok(Bytes::from(x)));
+        let messages_to_broadcast_sender =
+            messages_to_broadcast_sender.with(messages_to_broadcast_fn);
+
+        let broadcasted_messages_fn: BroadcastedMessagesConverterFn<
+            T,
+            <T as TryFrom<Bytes>>::Error,
+        > = |(x, report_callback)| (T::try_from(x), report_callback);
+        let broadcasted_messages_receiver =
+            broadcasted_messages_receiver.map(broadcasted_messages_fn);
 
         BroadcastSubscriberChannels { messages_to_broadcast_sender, broadcasted_messages_receiver }
     }
@@ -472,8 +489,21 @@ impl NetworkManager {
 // TODO(shahak): Change to a wrapper of PeerId if Box dyn becomes an overhead.
 pub type ReportCallback = Box<dyn Fn() + Send>;
 
-// TODO(shahak): Make this generic in a type that implements TryFrom<Bytes> and Into<Bytes>.
-pub struct BroadcastSubscriberChannels {
-    pub messages_to_broadcast_sender: Sender<Bytes>,
-    pub broadcasted_messages_receiver: Receiver<(Bytes, ReportCallback)>,
+pub type MessagesToBroadcastSender<T> = With<
+    Sender<Bytes>,
+    Bytes,
+    T,
+    Ready<Result<Bytes, SendError>>,
+    fn(T) -> Ready<Result<Bytes, SendError>>,
+>;
+
+pub type BroadcastedMessagesReceiver<T, E> =
+    Map<Receiver<(Bytes, ReportCallback)>, BroadcastedMessagesConverterFn<T, E>>;
+
+type BroadcastedMessagesConverterFn<T, E> =
+    fn((Bytes, ReportCallback)) -> (Result<T, E>, ReportCallback);
+
+pub struct BroadcastSubscriberChannels<T, E> {
+    pub messages_to_broadcast_sender: MessagesToBroadcastSender<T>,
+    pub broadcasted_messages_receiver: BroadcastedMessagesReceiver<T, E>,
 }

--- a/crates/papyrus_network/src/network_manager/test.rs
+++ b/crates/papyrus_network/src/network_manager/test.rs
@@ -446,7 +446,7 @@ async fn broadcast_message() {
     let mut messages_to_broadcast_sender = network_manager
         .register_broadcast_subscriber(topic.clone(), BUFFER_SIZE)
         .messages_to_broadcast_sender;
-    messages_to_broadcast_sender.try_send(message.clone()).unwrap();
+    messages_to_broadcast_sender.send(message.clone()).await.unwrap();
 
     tokio::select! {
         _ = network_manager.run() => panic!("network manager ended"),
@@ -479,7 +479,7 @@ async fn receive_broadcasted_message() {
         GenericNetworkManager::generic_new(mock_swarm, mock_db_executor, BUFFER_SIZE);
 
     let mut broadcasted_messages_receiver = network_manager
-        .register_broadcast_subscriber(topic.clone(), BUFFER_SIZE)
+        .register_broadcast_subscriber::<Bytes>(topic.clone(), BUFFER_SIZE)
         .broadcasted_messages_receiver;
 
     tokio::select! {
@@ -488,7 +488,7 @@ async fn receive_broadcasted_message() {
             TIMEOUT, broadcasted_messages_receiver.next()
         ) => {
             let (actual_message, _report_callback) = result.unwrap().unwrap();
-            assert_eq!(message, actual_message);
+            assert_eq!(message, actual_message.unwrap());
             // TODO(shahak): Call the report callback once it's implemented.
         }
     }


### PR DESCRIPTION
- refactor(network): mixed event contains the outputting behaviour instead of notified behaviour
- feat(network): add broadcast behaviour with unimplemented
- feat(network): connect broadcast behaviour to mixed behaviour
- feat(network): add register_broadcast_subscribers without connecting to behaviour
- refactor(network): move code
- refactor(network): make StreamHashMap usable in source code (not tests only)
- feat(network): connect broadcast subscribers to behaviour
- test(network): add tests for broadcast subscriber in network manager
- fix(network): report callback reports the originating peer
- feat(network): register_broadcast_subscriber receives any type with TryFrom/Into<Bytes>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/2001)
<!-- Reviewable:end -->
