### PR TITLE
refactor(network): remove return value from assign_peer_to_session

### DIFF
--- a/crates/papyrus_network/src/peer_manager/mod.rs
+++ b/crates/papyrus_network/src/peer_manager/mod.rs
@@ -99,14 +99,13 @@ where
         self.peers.get_mut(&peer_id)
     }
 
-    // TODO(shahak): Remove return value and use events in tests.
-    fn assign_peer_to_session(&mut self, outbound_session_id: OutboundSessionId) -> Option<PeerId> {
+    fn assign_peer_to_session(&mut self, outbound_session_id: OutboundSessionId) {
         // TODO: consider moving this logic to be async (on a different tokio task)
         // until then we can return the assignment even if we use events for the notification.
         if self.peers.is_empty() {
             info!("No peers. Waiting for a new peer to be connected for {outbound_session_id:?}");
             self.sessions_received_when_no_peers.push(outbound_session_id);
-            return None;
+            return;
         }
         let peer = self
             .peers
@@ -132,42 +131,41 @@ where
                 .expect("min should not return None on a non-empty iterator");
             self.sleep_waiting_for_unblocked_peer =
                 Some(tokio::time::sleep_until(sleep_deadline.into()).boxed());
-            return None;
+            return;
         }
-        peer.map(|(peer_id, peer)| {
-            // TODO: consider not allowing reassignment of the same session
-            self.session_to_peer_map.insert(outbound_session_id, *peer_id);
-            let peer_connection_ids = peer.connection_ids();
-            if !peer_connection_ids.is_empty() {
-                let connection_id = peer_connection_ids[0];
-                info!(
-                    "Session {:?} assigned to peer {:?} with connection id: {:?}",
-                    outbound_session_id, peer_id, connection_id
-                );
-                self.pending_events.push(ToSwarm::GenerateEvent(
-                    ToOtherBehaviourEvent::SessionAssigned {
-                        outbound_session_id,
-                        peer_id: *peer_id,
-                        connection_id,
-                    },
-                ));
+        let Some((peer_id, peer)) = peer else {
+            return;
+        };
+        // TODO: consider not allowing reassignment of the same session
+        self.session_to_peer_map.insert(outbound_session_id, *peer_id);
+        let peer_connection_ids = peer.connection_ids();
+        if !peer_connection_ids.is_empty() {
+            let connection_id = peer_connection_ids[0];
+            info!(
+                "Session {:?} assigned to peer {:?} with connection id: {:?}",
+                outbound_session_id, peer_id, connection_id
+            );
+            self.pending_events.push(ToSwarm::GenerateEvent(
+                ToOtherBehaviourEvent::SessionAssigned {
+                    outbound_session_id,
+                    peer_id: *peer_id,
+                    connection_id,
+                },
+            ));
+        } else {
+            // In case we have a race condition where the connection is closed after we added to
+            // the pending list, the reciever will get an error and will need to ask for
+            // re-assignment
+            if let Some(sessions) = self.peers_pending_dial_with_sessions.get_mut(peer_id) {
+                sessions.push(outbound_session_id);
             } else {
-                // In case we have a race condition where the connection is closed after we added to
-                // the pending list, the reciever will get an error and will need to ask for
-                // re-assignment
-                if let Some(sessions) = self.peers_pending_dial_with_sessions.get_mut(peer_id) {
-                    sessions.push(outbound_session_id);
-                } else {
-                    self.peers_pending_dial_with_sessions
-                        .insert(*peer_id, vec![outbound_session_id]);
-                }
-                info!("Dialing peer {:?} with multiaddr {:?}", peer_id, peer.multiaddr());
-                self.pending_events.push(ToSwarm::Dial {
-                    opts: DialOpts::peer_id(*peer_id).addresses(vec![peer.multiaddr()]).build(),
-                });
+                self.peers_pending_dial_with_sessions.insert(*peer_id, vec![outbound_session_id]);
             }
-            *peer_id
-        })
+            info!("Dialing peer {:?} with multiaddr {:?}", peer_id, peer.multiaddr());
+            self.pending_events.push(ToSwarm::Dial {
+                opts: DialOpts::peer_id(*peer_id).addresses(vec![peer.multiaddr()]).build(),
+            });
+        }
     }
 
     fn report_peer(

--- a/crates/papyrus_network/src/peer_manager/test.rs
+++ b/crates/papyrus_network/src/peer_manager/test.rs
@@ -51,27 +51,11 @@ fn peer_assignment_round_robin() {
     let session3 = OutboundSessionId { value: 3 };
 
     // Assign peers to the queries in a round-robin fashion
-    let res1 = peer_manager.assign_peer_to_session(session1);
-    let res2 = peer_manager.assign_peer_to_session(session2);
-    let res3 = peer_manager.assign_peer_to_session(session3);
+    peer_manager.assign_peer_to_session(session1);
+    peer_manager.assign_peer_to_session(session2);
+    peer_manager.assign_peer_to_session(session3);
 
-    // Verify that the peers are assigned in a round-robin fashion
-    let is_peer1_first: bool;
-    match res1.unwrap() {
-        peer_id if peer_id == peer1.peer_id() => {
-            is_peer1_first = true;
-            assert_eq!(res2.unwrap(), peer2.peer_id());
-            assert_eq!(res3.unwrap(), peer1.peer_id());
-        }
-        peer_id if peer_id == peer2.peer_id() => {
-            is_peer1_first = false;
-            assert_eq!(res2.unwrap(), peer1.peer_id());
-            assert_eq!(res3.unwrap(), peer2.peer_id());
-        }
-        peer_id => panic!("Unexpected peer_id: {:?}", peer_id),
-    }
-
-    // check assignment events
+    // check assignment events and verify that the peers are assigned in a round-robin fashion
     for event in peer_manager.pending_events {
         let ToSwarm::GenerateEvent(ToOtherBehaviourEvent::SessionAssigned {
             outbound_session_id,
@@ -81,6 +65,14 @@ fn peer_assignment_round_robin() {
         else {
             continue;
         };
+
+        assert!(
+            peer_id == peer1.peer_id() || peer_id == peer2.peer_id(),
+            "Unexpected peer_id: {:?}",
+            peer_id
+        );
+        let is_peer1_first = peer_id == peer1.peer_id();
+
         if is_peer1_first {
             match outbound_session_id {
                 OutboundSessionId { value: 1 } => {
@@ -127,7 +119,8 @@ async fn peer_assignment_no_peers() {
     let outbound_session_id = OutboundSessionId { value: 1 };
 
     // Assign a peer to the session
-    assert_matches!(peer_manager.assign_peer_to_session(outbound_session_id), None);
+    peer_manager.assign_peer_to_session(outbound_session_id);
+    assert_eq!(*peer_manager.sessions_received_when_no_peers.last().unwrap(), outbound_session_id);
     assert!(peer_manager.next().now_or_never().is_none());
 
     // Now the peer manager finds a new peer and can assign the session.
@@ -172,7 +165,8 @@ async fn peer_assignment_no_unblocked_peers() {
     peer_manager.report_peer(peer_id, ReputationModifier::Bad {}).unwrap();
 
     // Assign a peer to the session
-    assert_matches!(peer_manager.assign_peer_to_session(outbound_session_id), None);
+    peer_manager.assign_peer_to_session(outbound_session_id);
+    assert_eq!(*peer_manager.sessions_received_when_no_peers.last().unwrap(), outbound_session_id);
     assert!(peer_manager.next().now_or_never().is_none());
 
     // After BLOCKED_UNTIL has passed, the peer manager can assign the session.
@@ -260,8 +254,8 @@ fn report_session_calls_update_reputation() {
     let outbound_session_id = OutboundSessionId { value: 1 };
 
     // Assign peer to the session
-    let res_peer_id = peer_manager.assign_peer_to_session(outbound_session_id).unwrap();
-    assert_eq!(res_peer_id, peer_id);
+    peer_manager.assign_peer_to_session(outbound_session_id);
+    assert_eq!(*peer_manager.session_to_peer_map.get(&outbound_session_id).unwrap(), peer_id);
 
     // Call the report_peer function on the peer manager
     peer_manager.report_session(outbound_session_id, ReputationModifier::Bad {}).unwrap();
@@ -324,7 +318,8 @@ async fn timed_out_peer_not_assignable_to_queries() {
     let outbound_session_id = OutboundSessionId { value: 1 };
 
     // Assign peer to the session
-    assert_matches!(peer_manager.assign_peer_to_session(outbound_session_id), None);
+    peer_manager.assign_peer_to_session(outbound_session_id);
+    assert_eq!(*peer_manager.sessions_received_when_no_peers.last().unwrap(), outbound_session_id);
 }
 
 #[test]
@@ -357,8 +352,11 @@ fn wrap_around_in_peer_assignment() {
 
     // Assign peer to the session - since we don't know what is the order of the peers in the
     // HashMap, we need to assign twice to make sure we wrap around
-    assert_matches!(peer_manager.assign_peer_to_session(outbound_session_id), Some(peer_id) if peer_id == peer_id2);
-    assert_matches!(peer_manager.assign_peer_to_session(outbound_session_id), Some(peer_id) if peer_id == peer_id2);
+    peer_manager.assign_peer_to_session(outbound_session_id);
+    assert_eq!(*peer_manager.session_to_peer_map.get(&outbound_session_id).unwrap(), peer_id2);
+
+    peer_manager.assign_peer_to_session(outbound_session_id);
+    assert_eq!(*peer_manager.session_to_peer_map.get(&outbound_session_id).unwrap(), peer_id2);
 }
 
 fn create_mock_peer(
@@ -434,7 +432,7 @@ fn assign_non_connected_peer_raises_dial_event() {
     let mut peer_manager: PeerManager<MockPeerTrait> = PeerManager::new(config.clone());
 
     // Create a mock peer
-    let (mut peer, _) = create_mock_peer(config.blacklist_timeout, false, None);
+    let (mut peer, peer_id) = create_mock_peer(config.blacklist_timeout, false, None);
     peer.expect_is_blocked().times(1).return_const(false);
     peer.expect_multiaddr().return_const(Multiaddr::empty());
 
@@ -445,11 +443,11 @@ fn assign_non_connected_peer_raises_dial_event() {
     let outbound_session_id = OutboundSessionId { value: 1 };
 
     // Assign peer to the session
-    let res_peer_id = peer_manager.assign_peer_to_session(outbound_session_id).unwrap();
+    peer_manager.assign_peer_to_session(outbound_session_id);
 
     // check events
     for event in peer_manager.pending_events {
-        assert_matches!(event, ToSwarm::Dial {opts} if opts.get_peer_id() == Some(res_peer_id));
+        assert_matches!(event, ToSwarm::Dial {opts} if opts.get_peer_id() == Some(peer_id));
     }
 }
 
@@ -472,8 +470,8 @@ async fn flow_test_assign_non_connected_peer() {
     let outbound_session_id = OutboundSessionId { value: 1 };
 
     // Assign peer to the session
-    let res_peer_id = peer_manager.assign_peer_to_session(outbound_session_id).unwrap();
-    assert_eq!(res_peer_id, peer_id);
+    peer_manager.assign_peer_to_session(outbound_session_id);
+    assert_eq!(*peer_manager.session_to_peer_map.get(&outbound_session_id).unwrap(), peer_id);
 
     // Expect dial event
     assert_matches!(poll_fn(|cx| peer_manager.poll(cx)).await, ToSwarm::Dial{opts} if opts.get_peer_id() == Some(peer_id));


### PR DESCRIPTION
refactor(network): remove return value from assign_peer_to_session

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/2031)
<!-- Reviewable:end -->
