### PR TITLE
feat(consensus): change the channel type for Peering to SingleHeightConsensus messages

### DIFF
--- a/crates/sequencing/papyrus_consensus/src/single_height_consensus_test.rs
+++ b/crates/sequencing/papyrus_consensus/src/single_height_consensus_test.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::sync::Arc;
 
 use futures::channel::{mpsc, oneshot};
@@ -52,7 +53,7 @@ impl TestSetup {
             Arc::new(self.context),
             id,
             self.shc_to_peering_sender,
-            self.peering_to_shc_receiver,
+            RefCell::new(self.peering_to_shc_receiver),
         )
         .await;
         (shc, self.shc_to_peering_receiver, self.peering_to_shc_sender)


### PR DESCRIPTION
This is because SHC is dropped after each height, and async_channel allows cloning the Receiver.
So the manager can hold a Receiver and clone a new one to pass to SHC for each height.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/2069)
<!-- Reviewable:end -->
