### PR TITLE
refactor(network): register_sqmr_subscriber is generic on query type

### DIFF
--- a/crates/papyrus_network/src/network_manager/test.rs
+++ b/crates/papyrus_network/src/network_manager/test.rs
@@ -1,3 +1,5 @@
+// TODO(shahak): Remove protobuf from these tests.
+
 use std::collections::{HashMap, HashSet};
 use std::pin::Pin;
 use std::sync::Arc;
@@ -16,7 +18,14 @@ use libp2p::gossipsub::{SubscriptionError, TopicHash};
 use libp2p::swarm::ConnectionId;
 use libp2p::{Multiaddr, PeerId};
 use papyrus_protobuf::protobuf;
-use papyrus_protobuf::sync::{BlockHashOrNumber, DataOrFin, Direction, Query, SignedBlockHeader};
+use papyrus_protobuf::sync::{
+    BlockHashOrNumber,
+    DataOrFin,
+    Direction,
+    HeaderQuery,
+    Query,
+    SignedBlockHeader,
+};
 use prost::Message;
 use starknet_api::block::{BlockHeader, BlockNumber};
 use tokio::select;
@@ -285,7 +294,7 @@ async fn register_subscriber_and_use_channels() {
 
     // register subscriber and send query
     let SqmrSubscriberChannels { mut query_sender, response_receiver } = network_manager
-        .register_sqmr_subscriber::<DataOrFin<SignedBlockHeader>>(
+        .register_sqmr_subscriber::<HeaderQuery, DataOrFin<SignedBlockHeader>>(
             crate::Protocol::SignedBlockHeader,
         );
 
@@ -306,7 +315,7 @@ async fn register_subscriber_and_use_channels() {
     tokio::select! {
         _ = network_manager.run() => panic!("network manager ended"),
         _ = poll_fn(|cx| event_listner.poll_unpin(cx)).then(|_| async move {
-            query_sender.send(query).await.unwrap()})
+            query_sender.send(HeaderQuery(query)).await.unwrap()})
             .then(|_| async move {
                 *cloned_response_receiver_length.lock().await = response_receiver_collector.await.len();
             }) => {},

--- a/crates/papyrus_node/src/main.rs
+++ b/crates/papyrus_node/src/main.rs
@@ -22,7 +22,7 @@ use papyrus_network::{network_manager, NetworkConfig, Protocol};
 use papyrus_node::config::NodeConfig;
 use papyrus_node::version::VERSION_FULL;
 use papyrus_p2p_sync::{P2PSync, P2PSyncConfig, P2PSyncError};
-use papyrus_protobuf::sync::{DataOrFin, SignedBlockHeader};
+use papyrus_protobuf::sync::{DataOrFin, HeaderQuery, SignedBlockHeader, StateDiffQuery};
 #[cfg(feature = "rpc")]
 use papyrus_rpc::run_server;
 use papyrus_storage::{open_storage, update_storage_metrics, StorageReader, StorageWriter};
@@ -228,8 +228,8 @@ async fn run_threads(config: NodeConfig) -> anyhow::Result<()> {
         p2p_sync_config: P2PSyncConfig,
         storage_reader: StorageReader,
         storage_writer: StorageWriter,
-        header_channels: SqmrSubscriberChannels<DataOrFin<SignedBlockHeader>>,
-        state_diff_channels: SqmrSubscriberChannels<DataOrFin<ThinStateDiff>>,
+        header_channels: SqmrSubscriberChannels<HeaderQuery, DataOrFin<SignedBlockHeader>>,
+        state_diff_channels: SqmrSubscriberChannels<StateDiffQuery, DataOrFin<ThinStateDiff>>,
     ) -> Result<(), P2PSyncError> {
         let sync = P2PSync::new(
             p2p_sync_config,
@@ -247,8 +247,8 @@ async fn run_threads(config: NodeConfig) -> anyhow::Result<()> {
 type NetworkRunReturn = (
     BoxFuture<'static, Result<(), NetworkError>>,
     Option<(
-        SqmrSubscriberChannels<DataOrFin<SignedBlockHeader>>,
-        SqmrSubscriberChannels<DataOrFin<ThinStateDiff>>,
+        SqmrSubscriberChannels<HeaderQuery, DataOrFin<SignedBlockHeader>>,
+        SqmrSubscriberChannels<StateDiffQuery, DataOrFin<ThinStateDiff>>,
     )>,
     String,
 );

--- a/crates/papyrus_p2p_sync/src/header_test.rs
+++ b/crates/papyrus_p2p_sync/src/header_test.rs
@@ -1,5 +1,12 @@
 use futures::{SinkExt, StreamExt};
-use papyrus_protobuf::sync::{BlockHashOrNumber, DataOrFin, Direction, Query, SignedBlockHeader};
+use papyrus_protobuf::sync::{
+    BlockHashOrNumber,
+    DataOrFin,
+    Direction,
+    HeaderQuery,
+    Query,
+    SignedBlockHeader,
+};
 use papyrus_storage::header::HeaderStorageReader;
 use starknet_api::block::{BlockHeader, BlockNumber};
 use tokio::time::timeout;
@@ -39,12 +46,12 @@ async fn signed_headers_basic_flow() {
             let query = header_query_receiver.next().await.unwrap();
             assert_eq!(
                 query,
-                Query {
+                HeaderQuery(Query {
                     start_block: BlockHashOrNumber::Number(BlockNumber(start_block_number)),
                     direction: Direction::Forward,
                     limit: HEADER_QUERY_LENGTH,
                     step: 1,
-                }
+                })
             );
 
             for (i, (block_hash, block_signature)) in block_hashes_and_signatures
@@ -146,12 +153,12 @@ async fn sync_sends_new_header_query_if_it_got_partial_responses() {
 
         assert_eq!(
             query,
-            Query {
+            HeaderQuery(Query {
                 start_block: BlockHashOrNumber::Number(BlockNumber(NUM_ACTUAL_RESPONSES.into())),
                 direction: Direction::Forward,
                 limit: HEADER_QUERY_LENGTH,
                 step: 1,
-            }
+            })
         );
     };
 

--- a/crates/papyrus_p2p_sync/src/state_diff_test.rs
+++ b/crates/papyrus_p2p_sync/src/state_diff_test.rs
@@ -22,7 +22,7 @@ use crate::test_utils::{
     SLEEP_DURATION_TO_LET_SYNC_ADVANCE,
     STATE_DIFF_QUERY_LENGTH,
 };
-use crate::P2PSyncError;
+use crate::{P2PSyncError, StateDiffQuery};
 
 const TIMEOUT_FOR_TEST: Duration = Duration::from_secs(5);
 
@@ -123,12 +123,12 @@ async fn state_diff_basic_flow() {
             let query = state_diff_query_receiver.next().await.unwrap();
             assert_eq!(
                 query,
-                Query {
+                StateDiffQuery(Query {
                     start_block: BlockHashOrNumber::Number(BlockNumber(start_block_number)),
                     direction: Direction::Forward,
                     limit: num_blocks,
                     step: 1,
-                }
+                })
             );
 
             for block_number in start_block_number..(start_block_number + num_blocks) {
@@ -213,12 +213,12 @@ async fn validate_state_diff_fails(
         let query = state_diff_query_receiver.next().await.unwrap();
         assert_eq!(
             query,
-            Query {
+            StateDiffQuery(Query {
                 start_block: BlockHashOrNumber::Number(BlockNumber(0)),
                 direction: Direction::Forward,
                 limit: 1,
                 step: 1,
-            }
+            })
         );
 
         // Send state diffs.

--- a/crates/papyrus_p2p_sync/src/test_utils.rs
+++ b/crates/papyrus_p2p_sync/src/test_utils.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use futures::channel::mpsc::{Receiver, Sender};
 use lazy_static::lazy_static;
-use papyrus_protobuf::sync::{Query, SignedBlockHeader};
+use papyrus_protobuf::sync::{HeaderQuery, SignedBlockHeader, StateDiffQuery};
 use papyrus_storage::test_utils::get_test_storage;
 use papyrus_storage::StorageReader;
 use starknet_api::block::{BlockHash, BlockSignature};
@@ -34,14 +34,14 @@ lazy_static! {
 pub struct TestArgs {
     #[allow(clippy::type_complexity)]
     pub p2p_sync: P2PSync<
-        Sender<Query>,
+        Sender<HeaderQuery>,
         Receiver<Response<SignedBlockHeader>>,
-        Sender<Query>,
+        Sender<StateDiffQuery>,
         Receiver<Response<ThinStateDiff>>,
     >,
     pub storage_reader: StorageReader,
-    pub header_query_receiver: Receiver<Query>,
-    pub state_diff_query_receiver: Receiver<Query>,
+    pub header_query_receiver: Receiver<HeaderQuery>,
+    pub state_diff_query_receiver: Receiver<StateDiffQuery>,
     pub headers_sender: Sender<Response<SignedBlockHeader>>,
     pub state_diffs_sender: Sender<Response<ThinStateDiff>>,
 }


### PR DESCRIPTION
- refactor(network): register_sqmr_subscriber receives one protocol and is generic on response type
- refactor(network): register_sqmr_subscriber is generic on query type

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/2086)
<!-- Reviewable:end -->
