### PR TITLE
revert(network): revert sending length prefixed data

### DIFF
--- a/crates/papyrus_network/src/bin/streamed_bytes_benchmark.rs
+++ b/crates/papyrus_network/src/bin/streamed_bytes_benchmark.rs
@@ -6,30 +6,8 @@ use futures::StreamExt;
 use libp2p::swarm::SwarmEvent;
 use libp2p::{PeerId, StreamProtocol, Swarm};
 use papyrus_network::bin_utils::{build_swarm, dial};
-<<<<<<< HEAD
 use papyrus_network::sqmr::behaviour::{Behaviour, Event, ExternalEvent, SessionError};
-use papyrus_network::sqmr::messages::with_length_prefix;
 use papyrus_network::sqmr::{Bytes, Config, InboundSessionId, OutboundSessionId, SessionId};
-||||||| ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
-use papyrus_network::streamed_bytes::behaviour::{Behaviour, Event, SessionError};
-use papyrus_network::streamed_bytes::messages::with_length_prefix;
-use papyrus_network::streamed_bytes::{
-    Bytes,
-    Config,
-    InboundSessionId,
-    OutboundSessionId,
-    SessionId,
-};
-=======
-use papyrus_network::streamed_bytes::behaviour::{Behaviour, Event, SessionError};
-use papyrus_network::streamed_bytes::{
-    Bytes,
-    Config,
-    InboundSessionId,
-    OutboundSessionId,
-    SessionId,
-};
->>>>>>> parent of ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
 
 const PROTOCOL_NAME: StreamProtocol = StreamProtocol::new("/papyrus/bench/1");
 const CONST_BYTE: u8 = 1;

--- a/crates/papyrus_network/src/db_executor/mod.rs
+++ b/crates/papyrus_network/src/db_executor/mod.rs
@@ -54,78 +54,19 @@ impl Default for Data {
 }
 
 impl Data {
-<<<<<<< HEAD
-    fn encode_template<B>(
-        self,
-        buf: &mut B,
-        encode_with_length_prefix_flag: bool,
-    ) -> Result<(), DataEncodingError>
-||||||| ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
-    pub fn encode_with_length_prefix<B>(self, buf: &mut B) -> Result<(), DataEncodingError>
-=======
     pub fn encode<B>(self, buf: &mut B) -> Result<(), DataEncodingError>
->>>>>>> parent of ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
     where
         B: BufMut,
     {
         match self {
-<<<<<<< HEAD
             Data::BlockHeaderAndSignature(signed_block_header) => {
                 let data: protobuf::BlockHeadersResponse = Some(signed_block_header).into();
-                match encode_with_length_prefix_flag {
-                    true => data.encode_length_delimited(buf).map_err(|_| DataEncodingError),
-                    false => data.encode(buf).map_err(|_| DataEncodingError),
-||||||| ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
-            Data::BlockHeaderAndSignature { .. } => self
-                .try_into()
-                .map(|data: protobuf::BlockHeadersResponse| {
-                    data.encode_length_delimited(buf).map_err(|_| DataEncodingError)
-                })
-                .map_err(|_| DataEncodingError)?,
-            Data::StateDiff { state_diff } => {
-                let state_diffs_response_vec = Into::<StateDiffsResponseVec>::into(state_diff);
-                let res = state_diffs_response_vec
-                    .0
-                    .iter()
-                    .map(|data| {
-                        let mut buf = vec![];
-                        data.encode_length_delimited(&mut buf)
-                            .map_err(|_| DataEncodingError)
-                            .map(|_| buf)
-                    })
-                    .collect::<Result<Vec<_>, _>>()?;
-                for byte in res.iter().flatten() {
-                    buf.put_u8(*byte);
-=======
-            Data::BlockHeaderAndSignature { .. } => self
-                .try_into()
-                .map(|data: protobuf::BlockHeadersResponse| {
-                    data.encode(buf).map_err(|_| DataEncodingError)
-                })
-                .map_err(|_| DataEncodingError)?,
-            Data::StateDiff { state_diff } => {
-                let state_diffs_response_vec = Into::<StateDiffsResponseVec>::into(state_diff);
-                let res = state_diffs_response_vec
-                    .0
-                    .iter()
-                    .map(|data| {
-                        let mut buf = vec![];
-                        data.encode(&mut buf).map_err(|_| DataEncodingError).map(|_| buf)
-                    })
-                    .collect::<Result<Vec<_>, _>>()?;
-                for byte in res.iter().flatten() {
-                    buf.put_u8(*byte);
->>>>>>> parent of ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
-                }
+                data.encode(buf).map_err(|_| DataEncodingError)
             }
             Data::StateDiffChunk(state_diff) => {
                 let state_diff_chunk = DataOrFin(Some(state_diff));
                 let state_diffs_response = protobuf::StateDiffsResponse::from(state_diff_chunk);
-                match encode_with_length_prefix_flag {
-                    true => state_diffs_response.encode_length_delimited(buf),
-                    false => state_diffs_response.encode(buf),
-                }
-                .map_err(|_| DataEncodingError)
+                state_diffs_response.encode(buf).map_err(|_| DataEncodingError)
             }
             Data::Fin(data_type) => match data_type {
                 DataType::SignedBlockHeader => {
@@ -134,62 +75,18 @@ impl Data {
                             protobuf::Fin {},
                         )),
                     };
-                    match encode_with_length_prefix_flag {
-                        true => block_header_response.encode_length_delimited(buf),
-                        false => block_header_response.encode(buf),
-                    }
-                    .map_err(|_| DataEncodingError)
+                    block_header_response.encode(buf).map_err(|_| DataEncodingError)
                 }
-<<<<<<< HEAD
                 DataType::StateDiff => {
                     let state_diff_response = protobuf::StateDiffsResponse {
                         state_diff_message: Some(
                             protobuf::state_diffs_response::StateDiffMessage::Fin(protobuf::Fin {}),
                         ),
                     };
-                    match encode_with_length_prefix_flag {
-                        true => state_diff_response.encode_length_delimited(buf),
-                        false => state_diff_response.encode(buf),
-                    }
-                    .map_err(|_| DataEncodingError)
-||||||| ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
-                .encode_length_delimited(buf)
-                .map_err(|_| DataEncodingError),
-                DataType::StateDiff => protobuf::StateDiffsResponse {
-                    state_diff_message: Some(
-                        protobuf::state_diffs_response::StateDiffMessage::Fin(protobuf::Fin {}),
-                    ),
-=======
-                .encode(buf)
-                .map_err(|_| DataEncodingError),
-                DataType::StateDiff => protobuf::StateDiffsResponse {
-                    state_diff_message: Some(
-                        protobuf::state_diffs_response::StateDiffMessage::Fin(protobuf::Fin {}),
-                    ),
->>>>>>> parent of ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
+                    state_diff_response.encode(buf).map_err(|_| DataEncodingError)
                 }
-<<<<<<< HEAD
-||||||| ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
-                .encode_length_delimited(buf)
-                .map_err(|_| DataEncodingError),
-=======
-                .encode(buf)
-                .map_err(|_| DataEncodingError),
->>>>>>> parent of ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
             },
         }
-    }
-    pub fn encode_with_length_prefix<B>(self, buf: &mut B) -> Result<(), DataEncodingError>
-    where
-        B: BufMut,
-    {
-        self.encode_template(buf, true)
-    }
-    pub fn encode_without_length_prefix<B>(self, buf: &mut B) -> Result<(), DataEncodingError>
-    where
-        B: BufMut,
-    {
-        self.encode_template(buf, false)
     }
 }
 

--- a/crates/papyrus_network/src/db_executor/mod.rs
+++ b/crates/papyrus_network/src/db_executor/mod.rs
@@ -54,20 +54,68 @@ impl Default for Data {
 }
 
 impl Data {
+<<<<<<< HEAD
     fn encode_template<B>(
         self,
         buf: &mut B,
         encode_with_length_prefix_flag: bool,
     ) -> Result<(), DataEncodingError>
+||||||| ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
+    pub fn encode_with_length_prefix<B>(self, buf: &mut B) -> Result<(), DataEncodingError>
+=======
+    pub fn encode<B>(self, buf: &mut B) -> Result<(), DataEncodingError>
+>>>>>>> parent of ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
     where
         B: BufMut,
     {
         match self {
+<<<<<<< HEAD
             Data::BlockHeaderAndSignature(signed_block_header) => {
                 let data: protobuf::BlockHeadersResponse = Some(signed_block_header).into();
                 match encode_with_length_prefix_flag {
                     true => data.encode_length_delimited(buf).map_err(|_| DataEncodingError),
                     false => data.encode(buf).map_err(|_| DataEncodingError),
+||||||| ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
+            Data::BlockHeaderAndSignature { .. } => self
+                .try_into()
+                .map(|data: protobuf::BlockHeadersResponse| {
+                    data.encode_length_delimited(buf).map_err(|_| DataEncodingError)
+                })
+                .map_err(|_| DataEncodingError)?,
+            Data::StateDiff { state_diff } => {
+                let state_diffs_response_vec = Into::<StateDiffsResponseVec>::into(state_diff);
+                let res = state_diffs_response_vec
+                    .0
+                    .iter()
+                    .map(|data| {
+                        let mut buf = vec![];
+                        data.encode_length_delimited(&mut buf)
+                            .map_err(|_| DataEncodingError)
+                            .map(|_| buf)
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                for byte in res.iter().flatten() {
+                    buf.put_u8(*byte);
+=======
+            Data::BlockHeaderAndSignature { .. } => self
+                .try_into()
+                .map(|data: protobuf::BlockHeadersResponse| {
+                    data.encode(buf).map_err(|_| DataEncodingError)
+                })
+                .map_err(|_| DataEncodingError)?,
+            Data::StateDiff { state_diff } => {
+                let state_diffs_response_vec = Into::<StateDiffsResponseVec>::into(state_diff);
+                let res = state_diffs_response_vec
+                    .0
+                    .iter()
+                    .map(|data| {
+                        let mut buf = vec![];
+                        data.encode(&mut buf).map_err(|_| DataEncodingError).map(|_| buf)
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                for byte in res.iter().flatten() {
+                    buf.put_u8(*byte);
+>>>>>>> parent of ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
                 }
             }
             Data::StateDiffChunk(state_diff) => {
@@ -92,6 +140,7 @@ impl Data {
                     }
                     .map_err(|_| DataEncodingError)
                 }
+<<<<<<< HEAD
                 DataType::StateDiff => {
                     let state_diff_response = protobuf::StateDiffsResponse {
                         state_diff_message: Some(
@@ -103,7 +152,30 @@ impl Data {
                         false => state_diff_response.encode(buf),
                     }
                     .map_err(|_| DataEncodingError)
+||||||| ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
+                .encode_length_delimited(buf)
+                .map_err(|_| DataEncodingError),
+                DataType::StateDiff => protobuf::StateDiffsResponse {
+                    state_diff_message: Some(
+                        protobuf::state_diffs_response::StateDiffMessage::Fin(protobuf::Fin {}),
+                    ),
+=======
+                .encode(buf)
+                .map_err(|_| DataEncodingError),
+                DataType::StateDiff => protobuf::StateDiffsResponse {
+                    state_diff_message: Some(
+                        protobuf::state_diffs_response::StateDiffMessage::Fin(protobuf::Fin {}),
+                    ),
+>>>>>>> parent of ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
                 }
+<<<<<<< HEAD
+||||||| ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
+                .encode_length_delimited(buf)
+                .map_err(|_| DataEncodingError),
+=======
+                .encode(buf)
+                .map_err(|_| DataEncodingError),
+>>>>>>> parent of ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
             },
         }
     }

--- a/crates/papyrus_network/src/network_manager/mod.rs
+++ b/crates/papyrus_network/src/network_manager/mod.rs
@@ -398,6 +398,7 @@ impl<DBExecutorT: DBExecutorTrait, SwarmT: SwarmTrait> GenericNetworkManager<DBE
         let (data, inbound_session_id) = res;
         let is_fin = matches!(data, Data::Fin(_));
         let mut data_bytes = vec![];
+<<<<<<< HEAD
         data.encode_with_length_prefix(&mut data_bytes).expect("failed to encode data");
         self.swarm.send_length_prefixed_data(data_bytes, inbound_session_id).unwrap_or_else(|e| {
             error!(
@@ -413,6 +414,17 @@ impl<DBExecutorT: DBExecutorTrait, SwarmT: SwarmTrait> GenericNetworkManager<DBE
                 )
             });
         }
+||||||| ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
+        data.encode_with_length_prefix(&mut data_bytes).expect("failed to encode data");
+        self.swarm.send_length_prefixed_data(data_bytes, inbound_session_id).unwrap_or_else(|e| {
+            error!("Failed to send data to peer. Session id not found error: {e:?}");
+        })
+=======
+        data.encode(&mut data_bytes).expect("failed to encode data");
+        self.swarm.send_data(data_bytes, inbound_session_id).unwrap_or_else(|e| {
+            error!("Failed to send data to peer. Session id not found error: {e:?}");
+        })
+>>>>>>> parent of ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
     }
 
     fn handle_local_sqmr_query(&mut self, protocol: Protocol, query: Bytes) {

--- a/crates/papyrus_network/src/network_manager/mod.rs
+++ b/crates/papyrus_network/src/network_manager/mod.rs
@@ -398,9 +398,8 @@ impl<DBExecutorT: DBExecutorTrait, SwarmT: SwarmTrait> GenericNetworkManager<DBE
         let (data, inbound_session_id) = res;
         let is_fin = matches!(data, Data::Fin(_));
         let mut data_bytes = vec![];
-<<<<<<< HEAD
-        data.encode_with_length_prefix(&mut data_bytes).expect("failed to encode data");
-        self.swarm.send_length_prefixed_data(data_bytes, inbound_session_id).unwrap_or_else(|e| {
+        data.encode(&mut data_bytes).expect("failed to encode data");
+        self.swarm.send_data(data_bytes, inbound_session_id).unwrap_or_else(|e| {
             error!(
                 "Failed to send data to peer. Session id: {inbound_session_id:?} not found error: \
                  {e:?}"
@@ -414,17 +413,6 @@ impl<DBExecutorT: DBExecutorTrait, SwarmT: SwarmTrait> GenericNetworkManager<DBE
                 )
             });
         }
-||||||| ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
-        data.encode_with_length_prefix(&mut data_bytes).expect("failed to encode data");
-        self.swarm.send_length_prefixed_data(data_bytes, inbound_session_id).unwrap_or_else(|e| {
-            error!("Failed to send data to peer. Session id not found error: {e:?}");
-        })
-=======
-        data.encode(&mut data_bytes).expect("failed to encode data");
-        self.swarm.send_data(data_bytes, inbound_session_id).unwrap_or_else(|e| {
-            error!("Failed to send data to peer. Session id not found error: {e:?}");
-        })
->>>>>>> parent of ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
     }
 
     fn handle_local_sqmr_query(&mut self, protocol: Protocol, query: Bytes) {

--- a/crates/papyrus_network/src/network_manager/swarm_trait.rs
+++ b/crates/papyrus_network/src/network_manager/swarm_trait.rs
@@ -14,7 +14,7 @@ use crate::{mixed_behaviour, Protocol};
 pub type Event = SwarmEvent<<mixed_behaviour::MixedBehaviour as NetworkBehaviour>::ToSwarm>;
 
 pub trait SwarmTrait: Stream<Item = Event> + Unpin {
-    fn send_length_prefixed_data(
+    fn send_data(
         &mut self,
         data: Vec<u8>,
         inbound_session_id: InboundSessionId,
@@ -47,13 +47,27 @@ pub trait SwarmTrait: Stream<Item = Event> + Unpin {
     fn report_peer(&mut self, peer_id: PeerId);
 }
 
+<<<<<<< HEAD
 impl SwarmTrait for Swarm<mixed_behaviour::MixedBehaviour> {
     fn send_length_prefixed_data(
+||||||| ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
+impl SwarmTrait for Swarm<Behaviour> {
+    fn send_length_prefixed_data(
+=======
+impl SwarmTrait for Swarm<Behaviour> {
+    fn send_data(
+>>>>>>> parent of ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
         &mut self,
         data: Vec<u8>,
         inbound_session_id: InboundSessionId,
     ) -> Result<(), SessionIdNotFoundError> {
+<<<<<<< HEAD
         self.behaviour_mut().sqmr.send_length_prefixed_data(data, inbound_session_id)
+||||||| ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
+        self.behaviour_mut().send_length_prefixed_data(data, inbound_session_id)
+=======
+        self.behaviour_mut().send_data(data, inbound_session_id)
+>>>>>>> parent of ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
     }
 
     // TODO: change this function signature

--- a/crates/papyrus_network/src/network_manager/swarm_trait.rs
+++ b/crates/papyrus_network/src/network_manager/swarm_trait.rs
@@ -47,27 +47,13 @@ pub trait SwarmTrait: Stream<Item = Event> + Unpin {
     fn report_peer(&mut self, peer_id: PeerId);
 }
 
-<<<<<<< HEAD
 impl SwarmTrait for Swarm<mixed_behaviour::MixedBehaviour> {
-    fn send_length_prefixed_data(
-||||||| ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
-impl SwarmTrait for Swarm<Behaviour> {
-    fn send_length_prefixed_data(
-=======
-impl SwarmTrait for Swarm<Behaviour> {
     fn send_data(
->>>>>>> parent of ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
         &mut self,
         data: Vec<u8>,
         inbound_session_id: InboundSessionId,
     ) -> Result<(), SessionIdNotFoundError> {
-<<<<<<< HEAD
-        self.behaviour_mut().sqmr.send_length_prefixed_data(data, inbound_session_id)
-||||||| ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
-        self.behaviour_mut().send_length_prefixed_data(data, inbound_session_id)
-=======
-        self.behaviour_mut().send_data(data, inbound_session_id)
->>>>>>> parent of ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
+        self.behaviour_mut().sqmr.send_data(data, inbound_session_id)
     }
 
     // TODO: change this function signature

--- a/crates/papyrus_network/src/network_manager/test.rs
+++ b/crates/papyrus_network/src/network_manager/test.rs
@@ -133,11 +133,12 @@ impl MockSwarm {
 }
 
 impl SwarmTrait for MockSwarm {
-    fn send_length_prefixed_data(
+    fn send_data(
         &mut self,
         data: Vec<u8>,
         inbound_session_id: InboundSessionId,
     ) -> Result<(), SessionIdNotFoundError> {
+<<<<<<< HEAD
         let data_sender = self.inbound_session_id_to_data_sender.get(&inbound_session_id).expect(
             "Called send_length_prefixed_data without calling get_data_sent_to_inbound_session \
              first",
@@ -153,6 +154,25 @@ impl SwarmTrait for MockSwarm {
             }
             None => (Data::Fin(DataType::SignedBlockHeader), true),
         };
+||||||| ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
+        let data_sender = self.inbound_session_id_to_data_sender.get(&inbound_session_id).expect(
+            "Called send_length_prefixed_data without calling get_data_sent_to_inbound_session \
+             first",
+        );
+        // TODO(shahak): Add tests for state diff.
+        let data = protobuf::BlockHeadersResponse::decode_length_delimited(&data[..])
+            .unwrap()
+            .try_into()
+            .unwrap();
+        let is_fin = matches!(data, Data::Fin(DataType::SignedBlockHeader));
+=======
+        let data_sender = self
+            .inbound_session_id_to_data_sender
+            .get(&inbound_session_id)
+            .expect("Called send_data without calling get_data_sent_to_inbound_session first");
+        let data = protobuf::BlockHeadersResponse::decode(&data[..]).unwrap().try_into().unwrap();
+        let is_fin = matches!(data, Data::Fin(DataType::SignedBlockHeader));
+>>>>>>> parent of ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
         data_sender.unbounded_send(data).unwrap();
         if is_fin {
             data_sender.close_channel();

--- a/crates/papyrus_network/src/network_manager/test.rs
+++ b/crates/papyrus_network/src/network_manager/test.rs
@@ -138,41 +138,18 @@ impl SwarmTrait for MockSwarm {
         data: Vec<u8>,
         inbound_session_id: InboundSessionId,
     ) -> Result<(), SessionIdNotFoundError> {
-<<<<<<< HEAD
-        let data_sender = self.inbound_session_id_to_data_sender.get(&inbound_session_id).expect(
-            "Called send_length_prefixed_data without calling get_data_sent_to_inbound_session \
-             first",
-        );
-        let decoded_data = protobuf::BlockHeadersResponse::decode_length_delimited(&data[..])
-            .unwrap()
-            .try_into()
-            .unwrap();
-        // TODO(shahak): Add tests for state diff.
+        let data_sender = self
+            .inbound_session_id_to_data_sender
+            .get(&inbound_session_id)
+            .expect("Called send_data without calling get_data_sent_to_inbound_session first");
+        let decoded_data =
+            protobuf::BlockHeadersResponse::decode(&data[..]).unwrap().try_into().unwrap();
         let (data, is_fin) = match decoded_data {
             Some(signed_block_header) => {
                 (Data::BlockHeaderAndSignature(signed_block_header), false)
             }
             None => (Data::Fin(DataType::SignedBlockHeader), true),
         };
-||||||| ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
-        let data_sender = self.inbound_session_id_to_data_sender.get(&inbound_session_id).expect(
-            "Called send_length_prefixed_data without calling get_data_sent_to_inbound_session \
-             first",
-        );
-        // TODO(shahak): Add tests for state diff.
-        let data = protobuf::BlockHeadersResponse::decode_length_delimited(&data[..])
-            .unwrap()
-            .try_into()
-            .unwrap();
-        let is_fin = matches!(data, Data::Fin(DataType::SignedBlockHeader));
-=======
-        let data_sender = self
-            .inbound_session_id_to_data_sender
-            .get(&inbound_session_id)
-            .expect("Called send_data without calling get_data_sent_to_inbound_session first");
-        let data = protobuf::BlockHeadersResponse::decode(&data[..]).unwrap().try_into().unwrap();
-        let is_fin = matches!(data, Data::Fin(DataType::SignedBlockHeader));
->>>>>>> parent of ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824))
         data_sender.unbounded_send(data).unwrap();
         if is_fin {
             data_sender.close_channel();

--- a/crates/papyrus_network/src/sqmr/behaviour.rs
+++ b/crates/papyrus_network/src/sqmr/behaviour.rs
@@ -186,7 +186,7 @@ impl Behaviour {
     }
 
     /// Send a data message to an open inbound session.
-    pub fn send_length_prefixed_data(
+    pub fn send_data(
         &mut self,
         data: Bytes,
         inbound_session_id: InboundSessionId,

--- a/crates/papyrus_network/src/sqmr/behaviour_test.rs
+++ b/crates/papyrus_network/src/sqmr/behaviour_test.rs
@@ -19,7 +19,6 @@ use libp2p::swarm::{
 use libp2p::{Multiaddr, PeerId};
 
 use super::super::handler::{RequestFromBehaviourEvent, RequestToBehaviourEvent};
-use super::super::messages::with_length_prefix;
 use super::super::{Bytes, Config, GenericEvent, InboundSessionId, OutboundSessionId, SessionId};
 use super::{Behaviour, Event, ExternalEvent, SessionError};
 use crate::test_utils::dummy_data;
@@ -294,7 +293,7 @@ async fn process_inbound_session() {
 
     let dummy_data_vec = dummy_data();
     for data in &dummy_data_vec {
-        behaviour.send_length_prefixed_data(data.clone(), inbound_session_id).unwrap();
+        behaviour.send_data(data.clone(), inbound_session_id).unwrap();
     }
 
     for data in &dummy_data_vec {
@@ -461,10 +460,8 @@ fn close_non_existing_session_fails() {
 #[test]
 fn send_data_non_existing_session_fails() {
     let mut behaviour = Behaviour::new(Config::get_test_config());
-    for data in &dummy_data() {
-        behaviour
-            .send_length_prefixed_data(with_length_prefix(data), InboundSessionId::default())
-            .unwrap_err();
+    for data in dummy_data() {
+        behaviour.send_data(data, InboundSessionId::default()).unwrap_err();
     }
 }
 

--- a/crates/papyrus_network/src/sqmr/flow_test.rs
+++ b/crates/papyrus_network/src/sqmr/flow_test.rs
@@ -8,8 +8,15 @@ use futures::StreamExt;
 use libp2p::swarm::{NetworkBehaviour, StreamProtocol, SwarmEvent};
 use libp2p::{PeerId, Swarm};
 
+<<<<<<< HEAD:crates/papyrus_network/src/sqmr/flow_test.rs
 use super::behaviour::{Behaviour, Event, ExternalEvent};
 use super::messages::with_length_prefix;
+||||||| ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824)):crates/papyrus_network/src/streamed_bytes/flow_test.rs
+use super::behaviour::{Behaviour, Event};
+use super::messages::with_length_prefix;
+=======
+use super::behaviour::{Behaviour, Event};
+>>>>>>> parent of ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824)):crates/papyrus_network/src/streamed_bytes/flow_test.rs
 use super::{Bytes, Config, InboundSessionId, OutboundSessionId, SessionId};
 use crate::test_utils::create_fully_connected_swarms_stream;
 use crate::utils::StreamHashMap;
@@ -86,12 +93,8 @@ fn send_data(
     for i in 0..NUM_MESSAGES_PER_SESSION {
         inbound_swarm
             .behaviour_mut()
-            .send_length_prefixed_data(
-                with_length_prefix(&get_bytes_from_data_indices(
-                    inbound_peer_id,
-                    outbound_peer_id,
-                    i,
-                )),
+            .send_data(
+                get_bytes_from_data_indices(inbound_peer_id, outbound_peer_id, i),
                 inbound_session_ids[&(inbound_peer_id, outbound_peer_id)],
             )
             .unwrap();

--- a/crates/papyrus_network/src/sqmr/flow_test.rs
+++ b/crates/papyrus_network/src/sqmr/flow_test.rs
@@ -8,15 +8,7 @@ use futures::StreamExt;
 use libp2p::swarm::{NetworkBehaviour, StreamProtocol, SwarmEvent};
 use libp2p::{PeerId, Swarm};
 
-<<<<<<< HEAD:crates/papyrus_network/src/sqmr/flow_test.rs
 use super::behaviour::{Behaviour, Event, ExternalEvent};
-use super::messages::with_length_prefix;
-||||||| ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824)):crates/papyrus_network/src/streamed_bytes/flow_test.rs
-use super::behaviour::{Behaviour, Event};
-use super::messages::with_length_prefix;
-=======
-use super::behaviour::{Behaviour, Event};
->>>>>>> parent of ad8e8f65 (fix(network): add prefix to data in network manager instead of behaviour (#1824)):crates/papyrus_network/src/streamed_bytes/flow_test.rs
 use super::{Bytes, Config, InboundSessionId, OutboundSessionId, SessionId};
 use crate::test_utils::create_fully_connected_swarms_stream;
 use crate::utils::StreamHashMap;

--- a/crates/papyrus_network/src/sqmr/handler/inbound_session.rs
+++ b/crates/papyrus_network/src/sqmr/handler/inbound_session.rs
@@ -10,7 +10,7 @@ use futures::{AsyncWriteExt, FutureExt};
 use libp2p::swarm::Stream;
 use replace_with::replace_with_or_abort;
 
-use super::super::messages::write_length_prefixed_message;
+use super::super::messages::write_message;
 use super::super::Bytes;
 
 pub(super) struct InboundSession {
@@ -68,7 +68,7 @@ impl InboundSession {
                 };
                 WriteMessageTask::Running(
                     async move {
-                        write_length_prefixed_message(&data, &mut write_stream).await?;
+                        write_message(&data, &mut write_stream).await?;
                         Ok(write_stream)
                     }
                     .boxed(),

--- a/crates/papyrus_network/src/sqmr/handler_test.rs
+++ b/crates/papyrus_network/src/sqmr/handler_test.rs
@@ -23,7 +23,7 @@ use libp2p::swarm::{
 };
 use libp2p::PeerId;
 
-use super::super::messages::{read_message, with_length_prefix, write_length_prefixed_message};
+use super::super::messages::{read_message, write_message};
 use super::super::{Bytes, Config, GenericEvent, InboundSessionId, OutboundSessionId, SessionId};
 use super::{
     Handler,
@@ -256,11 +256,7 @@ async fn process_inbound_session() {
     validate_new_inbound_session_event(&mut handler, &QUERY, inbound_session_id).await;
     let dummy_data_vec = dummy_data();
     for data in &dummy_data_vec {
-        simulate_request_to_send_data_from_swarm(
-            &mut handler,
-            with_length_prefix(data),
-            inbound_session_id,
-        );
+        simulate_request_to_send_data_from_swarm(&mut handler, data.clone(), inbound_session_id);
     }
 
     let data_received = read_messages(handler, &mut outbound_stream, dummy_data_vec.len()).await;
@@ -343,9 +339,7 @@ async fn process_outbound_session() {
 
     let dummy_data_vec = dummy_data();
     for data in &dummy_data_vec {
-        write_length_prefixed_message(&with_length_prefix(data), &mut inbound_stream)
-            .await
-            .unwrap();
+        write_message(data, &mut inbound_stream).await.unwrap();
     }
 
     for data in &dummy_data_vec {
@@ -445,12 +439,7 @@ async fn outbound_session_dropped_after_negotiation() {
     // Need to sleep to make sure the dropping occurs on the other stream.
     tokio::time::sleep(std::time::Duration::from_millis(10)).await;
 
-    write_length_prefixed_message(
-        &with_length_prefix(dummy_data().first().unwrap()),
-        &mut inbound_stream,
-    )
-    .await
-    .unwrap_err();
+    write_message(dummy_data().first().unwrap(), &mut inbound_stream).await.unwrap_err();
 
     // Need to sleep to make sure that if we did send a message the stream inside the handle will
     // receive it
@@ -483,12 +472,7 @@ async fn outbound_session_dropped_before_negotiation() {
     // Need to sleep to make sure the dropping occurs on the other stream.
     tokio::time::sleep(std::time::Duration::from_millis(10)).await;
 
-    write_length_prefixed_message(
-        &with_length_prefix(dummy_data().first().unwrap()),
-        &mut inbound_stream,
-    )
-    .await
-    .unwrap_err();
+    write_message(&dummy_data().first().unwrap().clone(), &mut inbound_stream).await.unwrap_err();
 
     // Need to sleep to make sure that if we did send a message the stream inside the handle will
     // receive it

--- a/crates/papyrus_network/src/sqmr/messages_test.rs
+++ b/crates/papyrus_network/src/sqmr/messages_test.rs
@@ -6,8 +6,7 @@ use pretty_assertions::assert_eq;
 use super::{
     read_message,
     read_message_without_length_prefix,
-    with_length_prefix,
-    write_length_prefixed_message,
+    write_message,
     write_message_without_length_prefix,
 };
 use crate::test_utils::{dummy_data, get_connected_streams};
@@ -17,7 +16,7 @@ async fn read_write_positive_flow() {
     let (mut stream1, mut stream2, _) = get_connected_streams().await;
     let messages = dummy_data();
     for message in &messages {
-        write_length_prefixed_message(&with_length_prefix(message), &mut stream1).await.unwrap();
+        write_message(message, &mut stream1).await.unwrap();
     }
     for expected_message in &messages {
         assert_eq!(*expected_message, read_message(&mut stream2).await.unwrap().unwrap());

--- a/crates/papyrus_network/src/sqmr/mod.rs
+++ b/crates/papyrus_network/src/sqmr/mod.rs
@@ -1,6 +1,6 @@
 pub mod behaviour;
 pub mod handler;
-pub mod messages;
+mod messages;
 pub mod protocol;
 
 #[cfg(test)]

--- a/crates/papyrus_network/src/sqmr/protocol_test.rs
+++ b/crates/papyrus_network/src/sqmr/protocol_test.rs
@@ -3,7 +3,7 @@ use libp2p::core::UpgradeInfo;
 use libp2p::swarm::StreamProtocol;
 use pretty_assertions::assert_eq;
 
-use super::super::messages::{read_message, with_length_prefix, write_length_prefixed_message};
+use super::super::messages::{read_message, write_message};
 use super::{InboundProtocol, OutboundProtocol};
 use crate::test_utils::{dummy_data, get_connected_streams};
 
@@ -37,10 +37,8 @@ async fn positive_flow() {
                 inbound_protocol.upgrade_inbound(inbound_stream, PROTOCOL_NAME).await.unwrap();
             assert_eq!(query, received_query);
             assert_eq!(protocol_name, PROTOCOL_NAME);
-            for response in &dummy_data() {
-                write_length_prefixed_message(&with_length_prefix(response), &mut stream)
-                    .await
-                    .unwrap();
+            for response in dummy_data() {
+                write_message(&response, &mut stream).await.unwrap();
             }
         },
         async move {


### PR DESCRIPTION
- feat(network): remove stream in DBExecutorTrait
- refactor(network): remove QueryId from db executor
- revert(network): revert sending length prefixed data (with conflicts)
- revert(network): resolve conflicts

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/2096)
<!-- Reviewable:end -->
