### PR TITLE
refactor(network): db executor is removed from NetworkManager and runs in a separate task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6032,7 +6032,6 @@ version = "0.4.0-dev.3"
 dependencies = [
  "assert_matches",
  "async-stream",
- "async-trait",
  "bytes",
  "chrono",
  "clap",

--- a/crates/papyrus_network/Cargo.toml
+++ b/crates/papyrus_network/Cargo.toml
@@ -48,7 +48,6 @@ thiserror.workspace = true
 tokio = { workspace = true, features = ["full", "sync"] }
 tracing.workspace = true
 unsigned-varint = { workspace = true, features = ["std"] }
-async-trait.workspace = true
 validator = { workspace = true, features = ["derive"] }
 
 # Binaries dependencies

--- a/crates/papyrus_network/src/db_executor/mod.rs
+++ b/crates/papyrus_network/src/db_executor/mod.rs
@@ -1,8 +1,8 @@
 use std::vec;
 
-use async_trait::async_trait;
-use futures::future::pending;
-use futures::{FutureExt, Sink, SinkExt, StreamExt};
+use futures::channel::mpsc::SendError;
+use futures::{Sink, SinkExt, Stream, StreamExt};
+use papyrus_protobuf::converters::ProtobufConversionError;
 use papyrus_protobuf::sync::{
     BlockHashOrNumber,
     ContractDiff,
@@ -21,8 +21,6 @@ use papyrus_storage::{db, StorageReader, StorageTxn};
 use starknet_api::block::BlockNumber;
 use starknet_api::state::ThinStateDiff;
 use tracing::error;
-
-use crate::network_manager::SqmrQueryReceiver;
 
 #[cfg(test)]
 mod test;
@@ -61,78 +59,41 @@ impl DBExecutorError {
 }
 
 /// A DBExecutor receives inbound queries and returns their corresponding data.
-#[async_trait]
-pub trait DBExecutorTrait {
-    fn set_header_queries_receiver(
-        &mut self,
-        receiver: SqmrQueryReceiver<HeaderQuery, DataOrFin<SignedBlockHeader>>,
-    );
-
-    fn set_state_diff_queries_receiver(
-        &mut self,
-        receiver: SqmrQueryReceiver<StateDiffQuery, DataOrFin<StateDiffChunk>>,
-    );
-
-    /// Polls incoming queries.
-    // TODO(shahak): Consume self.
-    async fn run(&mut self);
-}
-
-pub struct DBExecutor {
+pub struct DBExecutor<HeaderQueryReceiver, StateDiffQueryReceiver> {
     storage_reader: StorageReader,
-    // TODO(shahak): Make this non-option.
-    header_queries_receiver: Option<SqmrQueryReceiver<HeaderQuery, DataOrFin<SignedBlockHeader>>>,
-    // TODO(shahak): Make this non-option.
-    state_diff_queries_receiver:
-        Option<SqmrQueryReceiver<StateDiffQuery, DataOrFin<StateDiffChunk>>>,
+    header_queries_receiver: HeaderQueryReceiver,
+    state_diff_queries_receiver: StateDiffQueryReceiver,
 }
 
-#[async_trait]
-impl DBExecutorTrait for DBExecutor {
-    fn set_header_queries_receiver(
-        &mut self,
-        receiver: SqmrQueryReceiver<HeaderQuery, DataOrFin<SignedBlockHeader>>,
-    ) {
-        self.header_queries_receiver = Some(receiver);
-    }
-
-    fn set_state_diff_queries_receiver(
-        &mut self,
-        receiver: SqmrQueryReceiver<StateDiffQuery, DataOrFin<StateDiffChunk>>,
-    ) {
-        self.state_diff_queries_receiver = Some(receiver);
-    }
-
-    async fn run(&mut self) {
+impl<HeaderQueryReceiver, StateDiffQueryReceiver, HeaderResponsesSender, StateDiffResponsesSender>
+    DBExecutor<HeaderQueryReceiver, StateDiffQueryReceiver>
+where
+    HeaderQueryReceiver: Stream<Item = (Result<HeaderQuery, ProtobufConversionError>, HeaderResponsesSender)>
+        + Unpin,
+    HeaderResponsesSender:
+        Sink<DataOrFin<SignedBlockHeader>, Error = SendError> + Unpin + Send + 'static,
+    StateDiffQueryReceiver: Stream<Item = (Result<StateDiffQuery, ProtobufConversionError>, StateDiffResponsesSender)>
+        + Unpin,
+    StateDiffResponsesSender:
+        Sink<DataOrFin<StateDiffChunk>, Error = SendError> + Unpin + Send + 'static,
+{
+    pub async fn run(mut self) {
         loop {
-            let header_queries_receiver_future =
-                if let Some(header_queries_receiver) = self.header_queries_receiver.as_mut() {
-                    header_queries_receiver.next().boxed()
-                } else {
-                    pending().boxed()
-                };
-            let state_diff_queries_receiver_future = if let Some(state_diff_queries_receiver) =
-                self.state_diff_queries_receiver.as_mut()
-            {
-                state_diff_queries_receiver.next().boxed()
-            } else {
-                pending().boxed()
-            };
-
             tokio::select! {
-                result = header_queries_receiver_future => {
+                result = self.header_queries_receiver.next() => {
                     let (query_result, response_sender) = result.expect(
                         "Header queries sender was unexpectedly dropped."
                     );
-                // TODO(shahak): Report if query_result is Err.
+                    // TODO(shahak): Report if query_result is Err.
                     if let Ok(query) = query_result {
                         self.register_query(query.0, response_sender);
                     }
                 }
-                result = state_diff_queries_receiver_future => {
+                result = self.state_diff_queries_receiver.next() => {
                     let (query_result, response_sender) = result.expect(
                         "State diff queries sender was unexpectedly dropped."
                     );
+                    // TODO(shahak): Report if query_result is Err.
                     if let Ok(query) = query_result {
                         self.register_query(query.0, response_sender);
                     }
@@ -140,11 +101,13 @@ impl DBExecutorTrait for DBExecutor {
             };
         }
     }
-}
 
-impl DBExecutor {
-    pub fn new(storage_reader: StorageReader) -> Self {
-        Self { storage_reader, header_queries_receiver: None, state_diff_queries_receiver: None }
+    pub fn new(
+        storage_reader: StorageReader,
+        header_queries_receiver: HeaderQueryReceiver,
+        state_diff_queries_receiver: StateDiffQueryReceiver,
+    ) -> Self {
+        Self { storage_reader, header_queries_receiver, state_diff_queries_receiver }
     }
 
     fn register_query<Data, Sender>(&self, query: Query, sender: Sender)

--- a/crates/papyrus_network/src/db_executor/test.rs
+++ b/crates/papyrus_network/src/db_executor/test.rs
@@ -1,23 +1,40 @@
+use futures::channel::mpsc::{Receiver, Sender};
 use futures::StreamExt;
 use papyrus_common::state::create_random_state_diff;
-use papyrus_protobuf::sync::{BlockHashOrNumber, DataOrFin, Direction, Query, SignedBlockHeader};
+use papyrus_protobuf::converters::ProtobufConversionError;
+use papyrus_protobuf::sync::{
+    BlockHashOrNumber,
+    DataOrFin,
+    Direction,
+    HeaderQuery,
+    Query,
+    SignedBlockHeader,
+    StateDiffChunk,
+    StateDiffQuery,
+};
 use papyrus_storage::header::{HeaderStorageReader, HeaderStorageWriter};
 use papyrus_storage::state::StateStorageWriter;
 use papyrus_storage::test_utils::get_test_storage;
-use papyrus_storage::StorageWriter;
+use papyrus_storage::{StorageReader, StorageWriter};
 use rand::random;
 use starknet_api::block::{BlockHash, BlockHeader, BlockNumber, BlockSignature};
 use test_utils::get_rng;
 
-use crate::db_executor::DBExecutorTrait;
+use super::DBExecutor;
 
 const BUFFER_SIZE: usize = 10;
 
 // TODO(shahak): Add test for state_diff_query_positive_flow.
+// TODO(shahak): Change tests to use channels and not register_query
 #[tokio::test]
 async fn header_query_positive_flow() {
-    let ((storage_reader, mut storage_writer), _temp_dir) = get_test_storage();
-    let mut db_executor = super::DBExecutor::new(storage_reader);
+    let (
+        db_executor,
+        _storage_reader,
+        mut storage_writer,
+        _header_queries_sender,
+        _state_diff_queries_sender,
+    ) = setup();
 
     // put some data in the storage.
     const NUM_OF_BLOCKS: u64 = 10;
@@ -53,7 +70,13 @@ async fn header_query_positive_flow() {
 
 #[tokio::test]
 async fn header_query_start_block_given_by_hash() {
-    let ((storage_reader, mut storage_writer), _temp_dir) = get_test_storage();
+    let (
+        db_executor,
+        storage_reader,
+        mut storage_writer,
+        _header_queries_sender,
+        _state_diff_queries_sender,
+    ) = setup();
 
     // put some data in the storage.
     const NUM_OF_BLOCKS: u64 = 10;
@@ -66,8 +89,6 @@ async fn header_query_start_block_given_by_hash() {
         .unwrap()
         .unwrap()
         .block_hash;
-
-    let mut db_executor = super::DBExecutor::new(storage_reader);
 
     // register a query.
     let (sender, receiver) = futures::channel::mpsc::channel(BUFFER_SIZE);
@@ -101,8 +122,13 @@ async fn header_query_start_block_given_by_hash() {
 
 #[tokio::test]
 async fn header_query_some_blocks_are_missing() {
-    let ((storage_reader, mut storage_writer), _temp_dir) = get_test_storage();
-    let mut db_executor = super::DBExecutor::new(storage_reader);
+    let (
+        db_executor,
+        _storage_reader,
+        mut storage_writer,
+        _header_queries_sender,
+        _state_diff_queries_sender,
+    ) = setup();
 
     const NUM_OF_BLOCKS: u64 = 15;
     insert_to_storage_test_blocks_up_to(NUM_OF_BLOCKS, &mut storage_writer);
@@ -129,6 +155,39 @@ async fn header_query_some_blocks_are_missing() {
             }
         }
     }
+}
+
+#[allow(clippy::type_complexity)]
+fn setup() -> (
+    DBExecutor<
+        Receiver<(
+            Result<HeaderQuery, ProtobufConversionError>,
+            Sender<DataOrFin<SignedBlockHeader>>,
+        )>,
+        Receiver<(
+            Result<StateDiffQuery, ProtobufConversionError>,
+            Sender<DataOrFin<StateDiffChunk>>,
+        )>,
+    >,
+    StorageReader,
+    StorageWriter,
+    Sender<(Result<HeaderQuery, ProtobufConversionError>, Sender<DataOrFin<SignedBlockHeader>>)>,
+    Sender<(Result<StateDiffQuery, ProtobufConversionError>, Sender<DataOrFin<StateDiffChunk>>)>,
+) {
+    let ((storage_reader, storage_writer), _temp_dir) = get_test_storage();
+    let (header_queries_sender, header_queries_receiver) = futures::channel::mpsc::channel::<(
+        Result<HeaderQuery, ProtobufConversionError>,
+        Sender<DataOrFin<SignedBlockHeader>>,
+    )>(BUFFER_SIZE);
+    let (state_diff_queries_sender, state_diff_queries_receiver) = futures::channel::mpsc::channel::<
+        (Result<StateDiffQuery, ProtobufConversionError>, Sender<DataOrFin<StateDiffChunk>>),
+    >(BUFFER_SIZE);
+    let db_executor = super::DBExecutor::new(
+        storage_reader.clone(),
+        header_queries_receiver,
+        state_diff_queries_receiver,
+    );
+    (db_executor, storage_reader, storage_writer, header_queries_sender, state_diff_queries_sender)
 }
 
 fn insert_to_storage_test_blocks_up_to(num_of_blocks: u64, storage_writer: &mut StorageWriter) {

--- a/crates/papyrus_network/src/lib.rs
+++ b/crates/papyrus_network/src/lib.rs
@@ -3,7 +3,7 @@
 ///
 /// [`Starknet p2p specs`]: https://github.com/starknet-io/starknet-p2p-specs/
 pub mod bin_utils;
-mod db_executor;
+pub mod db_executor;
 mod discovery;
 pub mod gossipsub_impl;
 pub mod mixed_behaviour;

--- a/crates/papyrus_network/src/network_manager/mod.rs
+++ b/crates/papyrus_network/src/network_manager/mod.rs
@@ -1,8 +1,7 @@
 mod swarm_trait;
 
-// TODO(shahak): Uncomment
-// #[cfg(test)]
-// mod test;
+#[cfg(test)]
+mod test;
 
 use std::collections::HashMap;
 

--- a/crates/papyrus_network/src/network_manager/mod.rs
+++ b/crates/papyrus_network/src/network_manager/mod.rs
@@ -16,20 +16,11 @@ use libp2p::swarm::SwarmEvent;
 use libp2p::{PeerId, Swarm};
 use metrics::gauge;
 use papyrus_common::metrics as papyrus_metrics;
-use papyrus_protobuf::sync::{
-    DataOrFin,
-    HeaderQuery,
-    SignedBlockHeader,
-    StateDiffChunk,
-    StateDiffQuery,
-};
-use papyrus_storage::StorageReader;
 use sqmr::Bytes;
 use tracing::{debug, error, info, trace};
 
 use self::swarm_trait::SwarmTrait;
 use crate::bin_utils::build_swarm;
-use crate::db_executor::{DBExecutor, DBExecutorTrait};
 use crate::gossipsub_impl::Topic;
 use crate::mixed_behaviour::{self, BridgedBehaviour};
 use crate::sqmr::{self, InboundSessionId, OutboundSessionId, SessionId};
@@ -42,9 +33,8 @@ pub enum NetworkError {
     DialError(#[from] libp2p::swarm::DialError),
 }
 
-pub struct GenericNetworkManager<DBExecutorT: DBExecutorTrait, SwarmT: SwarmTrait> {
+pub struct GenericNetworkManager<SwarmT: SwarmTrait> {
     swarm: SwarmT,
-    db_executor: DBExecutorT,
     header_buffer_size: usize,
     sqmr_inbound_response_receivers:
         StreamHashMap<InboundSessionId, BoxStream<'static, Option<Bytes>>>,
@@ -68,24 +58,11 @@ pub struct GenericNetworkManager<DBExecutorT: DBExecutorTrait, SwarmT: SwarmTrai
     num_active_outbound_sessions: usize,
 }
 
-impl<DBExecutorT: DBExecutorTrait, SwarmT: SwarmTrait> GenericNetworkManager<DBExecutorT, SwarmT> {
+impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
     pub async fn run(mut self) -> Result<(), NetworkError> {
-        // TODO(shahak): Move this logic to register_sqmr_subscriber.
-        let header_db_executor_channel = self
-            .register_protocol_to_db_executor::<HeaderQuery, DataOrFin<SignedBlockHeader>>(
-                Protocol::SignedBlockHeader,
-            );
-        self.db_executor.set_header_queries_receiver(header_db_executor_channel);
-        let state_diff_db_executor_channel = self
-            .register_protocol_to_db_executor::<StateDiffQuery, DataOrFin<StateDiffChunk>>(
-                Protocol::StateDiff,
-            );
-        self.db_executor.set_state_diff_queries_receiver(state_diff_db_executor_channel);
-
         loop {
             tokio::select! {
                 Some(event) = self.swarm.next() => self.handle_swarm_event(event),
-                _ = self.db_executor.run() => panic!("DB executor should never finish."),
                 Some(res) = self.sqmr_inbound_response_receivers.next() => self.handle_response_for_inbound_query(res),
                 Some((protocol, query)) = self.sqmr_outbound_query_receivers.next() => {
                     self.handle_local_sqmr_query(protocol, query)
@@ -98,36 +75,11 @@ impl<DBExecutorT: DBExecutorTrait, SwarmT: SwarmTrait> GenericNetworkManager<DBE
         }
     }
 
-    fn register_protocol_to_db_executor<Query, Response>(
-        &mut self,
-        protocol: Protocol,
-    ) -> SqmrQueryReceiver<Query, Response>
-    where
-        Query: TryFrom<Bytes>,
-        Bytes: From<Response>,
-    {
-        let (inbound_query_sender, inbound_query_receiver) =
-            futures::channel::mpsc::channel(self.header_buffer_size);
-        self.sqmr_inbound_query_senders.insert(protocol, inbound_query_sender);
-
-        inbound_query_receiver.map(|(query_bytes, response_bytes_sender)| {
-            (
-                Query::try_from(query_bytes),
-                response_bytes_sender.with(|response| ready(Ok(Bytes::from(response)))),
-            )
-        })
-    }
-
-    pub(crate) fn generic_new(
-        swarm: SwarmT,
-        db_executor: DBExecutorT,
-        header_buffer_size: usize,
-    ) -> Self {
+    pub(crate) fn generic_new(swarm: SwarmT, header_buffer_size: usize) -> Self {
         gauge!(papyrus_metrics::PAPYRUS_NUM_CONNECTED_PEERS, 0f64);
         let (reported_peer_sender, reported_peer_receiver) = futures::channel::mpsc::unbounded();
         Self {
             swarm,
-            db_executor,
             header_buffer_size,
             sqmr_inbound_response_receivers: StreamHashMap::new(HashMap::new()),
             sqmr_inbound_query_senders: HashMap::new(),
@@ -143,6 +95,30 @@ impl<DBExecutorT: DBExecutorTrait, SwarmT: SwarmTrait> GenericNetworkManager<DBE
         }
     }
 
+    pub fn register_sqmr_protocol_server<Query, Response>(
+        &mut self,
+        protocol: Protocol,
+    ) -> SqmrQueryReceiver<Query, Response>
+    where
+        Bytes: From<Response>,
+        Query: TryFrom<Bytes>,
+    {
+        let (inbound_query_sender, inbound_query_receiver) =
+            futures::channel::mpsc::channel(self.header_buffer_size);
+        let result = self.sqmr_inbound_query_senders.insert(protocol, inbound_query_sender);
+        if result.is_some() {
+            panic!("Protocol '{}' has already been registered as a server.", protocol);
+        }
+
+        inbound_query_receiver.map(|(query_bytes, response_bytes_sender)| {
+            (
+                Query::try_from(query_bytes),
+                response_bytes_sender.with(|response| ready(Ok(Bytes::from(response)))),
+            )
+        })
+    }
+
+    // TODO(shahak): rename to register_sqmr_protocol_client.
     /// Register a new subscriber for sending a single query and receiving multiple responses.
     /// Panics if the given protocol is already subscribed.
     pub fn register_sqmr_subscriber<Query, Response>(
@@ -162,11 +138,11 @@ impl<DBExecutorT: DBExecutorTrait, SwarmT: SwarmTrait> GenericNetworkManager<DBE
 
         let insert_result = self.sqmr_outbound_query_receivers.insert(protocol, query_receiver);
         if insert_result.is_some() {
-            panic!("Protocol '{}' has already been registered.", protocol);
+            panic!("Protocol '{}' has already been registered as a client.", protocol);
         }
         let insert_result = self.sqmr_outbound_response_senders.insert(protocol, response_sender);
         if insert_result.is_some() {
-            panic!("Protocol '{}' has already been registered.", protocol);
+            panic!("Protocol '{}' has already been registered as a client.", protocol);
         }
 
         let query_fn: fn(Query) -> Ready<Result<Bytes, SendError>> =
@@ -507,10 +483,10 @@ impl<DBExecutorT: DBExecutorTrait, SwarmT: SwarmTrait> GenericNetworkManager<DBE
     }
 }
 
-pub type NetworkManager = GenericNetworkManager<DBExecutor, Swarm<mixed_behaviour::MixedBehaviour>>;
+pub type NetworkManager = GenericNetworkManager<Swarm<mixed_behaviour::MixedBehaviour>>;
 
 impl NetworkManager {
-    pub fn new(config: NetworkConfig, storage_reader: StorageReader) -> Self {
+    pub fn new(config: NetworkConfig) -> Self {
         let NetworkConfig {
             tcp_port,
             quic_port: _,
@@ -540,8 +516,7 @@ impl NetworkManager {
             )
         });
 
-        let db_executor = DBExecutor::new(storage_reader);
-        Self::generic_new(swarm, db_executor, header_buffer_size)
+        Self::generic_new(swarm, header_buffer_size)
     }
 
     pub fn get_local_peer_id(&self) -> String {
@@ -602,7 +577,7 @@ pub fn dummy_report_callback() -> ReportCallback {
     Box::new(|| {})
 }
 
-// TODO(shahak): Change to a wrapper of PeerId if Box dyn becomes an overhead.
+// TODO(shahak): Create a custom struct if Box dyn becomes an overhead.
 pub type ReportCallback = Box<dyn Fn() + Send>;
 
 // TODO(shahak): Add report callback.
@@ -622,6 +597,7 @@ pub type SubscriberSender<T> = With<
     fn(T) -> Ready<Result<Bytes, SendError>>,
 >;
 
+// TODO(shahak): rename to ConvertFromBytesReceiver and add an alias called BroadcastReceiver
 pub type SubscriberReceiver<T> =
     Map<Receiver<(Bytes, ReportCallback)>, ReceivedMessagesConverterFn<T>>;
 
@@ -629,8 +605,6 @@ type ReceivedMessagesConverterFn<T> =
     fn((Bytes, ReportCallback)) -> (Result<T, <T as TryFrom<Bytes>>::Error>, ReportCallback);
 
 // TODO(shahak): Unite channels to a Sender of Query and Receiver of Responses.
-// TODO(shahak): Change Query to something generic.
-// TODO(shahak): Add channels for DB executor.
 pub struct SqmrSubscriberChannels<Query: Into<Bytes>, Response: TryFrom<Bytes>> {
     pub query_sender: SubscriberSender<Query>,
     pub response_receiver: SubscriberReceiver<Response>,

--- a/crates/papyrus_network/src/network_manager/test.rs
+++ b/crates/papyrus_network/src/network_manager/test.rs
@@ -5,30 +5,23 @@ use std::task::{Context, Poll};
 use std::time::Duration;
 use std::vec;
 
-use async_trait::async_trait;
 use deadqueue::unlimited::Queue;
-use futures::channel::mpsc::{unbounded, Sender, UnboundedSender};
+use futures::channel::mpsc::{unbounded, UnboundedSender};
 use futures::channel::oneshot;
-use futures::future::{pending, poll_fn, FutureExt};
-use futures::stream::{FuturesUnordered, Stream};
+use futures::future::{poll_fn, FutureExt};
+use futures::stream::Stream;
 use futures::{pin_mut, Future, SinkExt, StreamExt};
 use lazy_static::lazy_static;
 use libp2p::core::ConnectedPoint;
 use libp2p::gossipsub::{SubscriptionError, TopicHash};
 use libp2p::swarm::ConnectionId;
 use libp2p::{Multiaddr, PeerId};
-use papyrus_protobuf::protobuf;
-use papyrus_protobuf::sync::{BlockHashOrNumber, DataOrFin, Direction, Query, SignedBlockHeader};
-use prost::Message;
-use starknet_api::block::{BlockHeader, BlockNumber};
 use tokio::select;
 use tokio::sync::Mutex;
-use tokio::task::JoinHandle;
 use tokio::time::sleep;
 
 use super::swarm_trait::{Event, SwarmTrait};
 use super::{GenericNetworkManager, SqmrSubscriberChannels};
-use crate::db_executor::{DBExecutorError, DBExecutorTrait, Data, FetchBlockDataFromDb};
 use crate::gossipsub_impl::{self, Topic};
 use crate::mixed_behaviour;
 use crate::sqmr::behaviour::{PeerNotConnected, SessionIdNotFoundError};
@@ -36,16 +29,21 @@ use crate::sqmr::{Bytes, GenericEvent, InboundSessionId, OutboundSessionId};
 
 const TIMEOUT: Duration = Duration::from_secs(1);
 
+lazy_static! {
+    static ref VEC1: Vec<u8> = vec![1, 2, 3, 4, 5];
+    static ref VEC2: Vec<u8> = vec![6, 7, 8];
+    static ref VEC3: Vec<u8> = vec![9, 10];
+}
+
 #[derive(Default)]
 struct MockSwarm {
     pub pending_events: Queue<Event>,
     pub subscribed_topics: HashSet<TopicHash>,
     broadcasted_messages_senders: Vec<UnboundedSender<(Bytes, TopicHash)>>,
     reported_peer_senders: Vec<UnboundedSender<PeerId>>,
-    inbound_session_id_to_data_sender: HashMap<InboundSessionId, UnboundedSender<Data>>,
+    inbound_session_id_to_response_sender: HashMap<InboundSessionId, UnboundedSender<Bytes>>,
     next_outbound_session_id: usize,
     first_polled_event_notifier: Option<oneshot::Sender<()>>,
-    inbound_session_closed_notifier: Option<oneshot::Sender<()>>,
 }
 
 impl Stream for MockSwarm {
@@ -68,16 +66,19 @@ impl Stream for MockSwarm {
 }
 
 impl MockSwarm {
-    pub fn get_data_sent_to_inbound_session(
+    pub fn get_responses_sent_to_inbound_session(
         &mut self,
         inbound_session_id: InboundSessionId,
-    ) -> impl Future<Output = Vec<Data>> {
-        let (data_sender, data_receiver) = unbounded();
-        if self.inbound_session_id_to_data_sender.insert(inbound_session_id, data_sender).is_some()
+    ) -> impl Future<Output = Vec<Bytes>> {
+        let (responses_sender, responses_receiver) = unbounded();
+        if self
+            .inbound_session_id_to_response_sender
+            .insert(inbound_session_id, responses_sender)
+            .is_some()
         {
-            panic!("Called get_data_sent_to_inbound_session on {inbound_session_id:?} twice");
+            panic!("Called get_responses_sent_to_inbound_session on {inbound_session_id:?} twice");
         }
-        data_receiver.collect()
+        responses_receiver.collect()
     }
 
     pub fn stream_messages_we_broadcasted(&mut self) -> impl Stream<Item = (Bytes, TopicHash)> {
@@ -116,19 +117,11 @@ impl SwarmTrait for MockSwarm {
         data: Vec<u8>,
         inbound_session_id: InboundSessionId,
     ) -> Result<(), SessionIdNotFoundError> {
-        let data_sender = self
-            .inbound_session_id_to_data_sender
+        let responses_sender = self
+            .inbound_session_id_to_response_sender
             .get(&inbound_session_id)
-            .expect("Called send_data without calling get_data_sent_to_inbound_session first");
-        let data = DataOrFin::<SignedBlockHeader>::try_from(
-            protobuf::BlockHeadersResponse::decode(&data[..]).unwrap(),
-        )
-        .unwrap();
-        let is_fin = data.0.is_none();
-        data_sender.unbounded_send(Data::BlockHeaderAndSignature(data)).unwrap();
-        if is_fin {
-            data_sender.close_channel();
-        }
+            .expect("Called send_data without calling get_responses_sent_to_inbound_session first");
+        responses_sender.unbounded_send(data).unwrap();
         Ok(())
     }
 
@@ -156,11 +149,14 @@ impl SwarmTrait for MockSwarm {
     }
     fn close_inbound_session(
         &mut self,
-        _session_id: InboundSessionId,
+        inbound_session_id: InboundSessionId,
     ) -> Result<(), SessionIdNotFoundError> {
-        if let Some(sender) = self.inbound_session_closed_notifier.take() {
-            sender.send(()).unwrap();
-        }
+        let responses_sender =
+            self.inbound_session_id_to_response_sender.get(&inbound_session_id).expect(
+                "Called close_inbound_session without calling \
+                 get_responses_sent_to_inbound_session first",
+            );
+        responses_sender.close_channel();
         Ok(())
     }
 
@@ -188,50 +184,6 @@ impl SwarmTrait for MockSwarm {
     }
 }
 
-#[derive(Default)]
-struct MockDBExecutor {
-    pub query_to_headers: HashMap<Query, Vec<BlockHeader>>,
-    query_execution_set: FuturesUnordered<JoinHandle<Result<(), DBExecutorError>>>,
-}
-
-#[async_trait]
-impl DBExecutorTrait for MockDBExecutor {
-    // TODO(shahak): Consider fixing code duplication with DBExecutor.
-    fn register_query(
-        &mut self,
-        query: Query,
-        _data_type: impl FetchBlockDataFromDb + Send,
-        mut sender: Sender<Data>,
-    ) {
-        let headers = self.query_to_headers.get(&query).unwrap().clone();
-        self.query_execution_set.push(tokio::task::spawn(async move {
-            {
-                for header in headers.iter().cloned() {
-                    // Using poll_fn because Sender::poll_ready is not a future
-                    if let Ok(()) = poll_fn(|cx| sender.poll_ready(cx)).await {
-                        sender.start_send(Data::BlockHeaderAndSignature(DataOrFin(Some(
-                            SignedBlockHeader { block_header: header, signatures: vec![] },
-                        ))))?;
-                    }
-                }
-                sender.start_send(Data::BlockHeaderAndSignature(DataOrFin(None)))?;
-                Ok(())
-            }
-        }));
-    }
-    async fn run(&mut self) {
-        loop {
-            let result =
-                futures::future::poll_fn(|cx| self.query_execution_set.poll_next_unpin(cx)).await;
-            if result.is_none() {
-                // We assume that if all queries are finished then there won't come any new
-                // queries.
-                return pending().await;
-            }
-        }
-    }
-}
-
 const BUFFER_SIZE: usize = 100;
 
 #[tokio::test]
@@ -244,8 +196,7 @@ async fn register_sqmr_subscriber_and_use_channels() {
     mock_swarm.first_polled_event_notifier = Some(event_notifier);
 
     // network manager to register subscriber and send query
-    let mut network_manager =
-        GenericNetworkManager::generic_new(mock_swarm, MockDBExecutor::default(), BUFFER_SIZE);
+    let mut network_manager = GenericNetworkManager::generic_new(mock_swarm, BUFFER_SIZE);
 
     // register subscriber and send query
     let SqmrSubscriberChannels { mut query_sender, response_receiver } = network_manager
@@ -255,18 +206,18 @@ async fn register_sqmr_subscriber_and_use_channels() {
     let cloned_response_receiver_length = Arc::clone(&response_receiver_length);
     let response_receiver_collector = response_receiver
         .enumerate()
-        .take(VEC.len())
+        .take(VEC1.len())
         .map(|(i, (result, _report_callback))| {
             let result = result.unwrap();
             // this simulates how the mock swarm parses the query and sends responses to it
-            assert_eq!(result, vec![VEC[i]]);
+            assert_eq!(result, vec![VEC1[i]]);
             result
         })
         .collect::<Vec<_>>();
     tokio::select! {
         _ = network_manager.run() => panic!("network manager ended"),
         _ = poll_fn(|cx| event_listner.poll_unpin(cx)).then(|_| async move {
-            query_sender.send(VEC.clone()).await.unwrap()})
+            query_sender.send(VEC1.clone()).await.unwrap()})
             .then(|_| async move {
                 *cloned_response_receiver_length.lock().await = response_receiver_collector.await.len();
             }) => {},
@@ -274,133 +225,51 @@ async fn register_sqmr_subscriber_and_use_channels() {
             panic!("Test timed out");
         }
     }
-    assert_eq!(*response_receiver_length.lock().await, VEC.len());
+    assert_eq!(*response_receiver_length.lock().await, VEC1.len());
 }
 
+// TODO(shahak): Add multiple protocols and multiple queries in the test.
 #[tokio::test]
 async fn process_incoming_query() {
     // Create data for test.
-    const BLOCK_NUM: u64 = 0;
-    let query = Query {
-        start_block: BlockHashOrNumber::Number(BlockNumber(BLOCK_NUM)),
-        direction: Direction::Forward,
-        limit: 5,
-        step: 1,
-    };
-    let headers = (0..5)
-        // TODO(shahak): Remove state_diff_length from here once we correctly deduce if it should
-        // be None or Some.
-        .map(|i| BlockHeader { block_number: BlockNumber(i), state_diff_length: Some(0), ..Default::default() })
-        .collect::<Vec<_>>();
-
-    // Setup mock DB executor and tell it to reply to the query with the given headers.
-    let mut mock_db_executor = MockDBExecutor::default();
-    mock_db_executor.query_to_headers.insert(query.clone(), headers.clone());
+    let query = VEC1.clone();
+    let responses = vec![VEC1.clone(), VEC2.clone(), VEC3.clone()];
+    let protocol = crate::Protocol::SignedBlockHeader;
 
     // Setup mock swarm and tell it to return an event of new inbound query.
     let mut mock_swarm = MockSwarm::default();
     let inbound_session_id = InboundSessionId { value: 0 };
-    let mut query_bytes = vec![];
-    protobuf::BlockHeadersRequest {
-        iteration: Some(protobuf::Iteration {
-            start: Some(protobuf::iteration::Start::BlockNumber(BLOCK_NUM)),
-            direction: protobuf::iteration::Direction::Forward as i32,
-            limit: query.limit,
-            step: query.step,
-        }),
-    }
-    .encode(&mut query_bytes)
-    .unwrap();
     mock_swarm.pending_events.push(Event::Behaviour(mixed_behaviour::Event::ExternalEvent(
         mixed_behaviour::ExternalEvent::Sqmr(GenericEvent::NewInboundSession {
-            query: query_bytes,
+            query: query.clone(),
             inbound_session_id,
             peer_id: PeerId::random(),
-            protocol_name: crate::Protocol::SignedBlockHeader.into(),
+            protocol_name: protocol.into(),
         }),
     )));
 
-    // Create a future that will return when Fin is sent with the data sent on the swarm.
-    let get_data_fut = mock_swarm.get_data_sent_to_inbound_session(inbound_session_id);
+    // Create a future that will return when the session is closed with the data sent on the swarm.
+    let get_responses_fut = mock_swarm.get_responses_sent_to_inbound_session(inbound_session_id);
 
-    let network_manager =
-        GenericNetworkManager::generic_new(mock_swarm, mock_db_executor, BUFFER_SIZE);
+    let mut network_manager = GenericNetworkManager::generic_new(mock_swarm, BUFFER_SIZE);
 
+    let mut inbound_query_receiver =
+        network_manager.register_sqmr_protocol_server::<Vec<u8>, Vec<u8>>(protocol);
+
+    let responses_clone = responses.clone();
     select! {
-        inbound_session_data = get_data_fut => {
-            let mut expected_data = headers
-                .into_iter()
-                .map(|header| {
-                    Data::BlockHeaderAndSignature(DataOrFin(Some(SignedBlockHeader {
-                        block_header: header, signatures: vec![]
-                    })))
-                })
-                .collect::<Vec<_>>();
-            expected_data.push(Data::BlockHeaderAndSignature(DataOrFin(None)));
-            assert_eq!(inbound_session_data, expected_data);
-        }
+        _ = async move {
+            let (query_got, mut responses_sender) = inbound_query_receiver.next().await.unwrap();
+            assert_eq!(query_got.unwrap(), query);
+            for response in responses_clone {
+                responses_sender.feed(response).await.unwrap();
+            }
+            responses_sender.close().await.unwrap();
+            assert_eq!(get_responses_fut.await, responses);
+        } => {}
         _ = network_manager.run() => {
             panic!("GenericNetworkManager::run finished before the session finished");
         }
-        _ = sleep(Duration::from_secs(5)) => {
-            panic!("Test timed out");
-        }
-    }
-}
-
-#[tokio::test]
-async fn close_inbound_session() {
-    // define query
-    let query_limit = 5;
-    let start_block_number = 0;
-    let query = Query {
-        start_block: BlockHashOrNumber::Number(BlockNumber(start_block_number)),
-        direction: Direction::Forward,
-        limit: query_limit,
-        step: 1,
-    };
-
-    // get query bytes
-    let mut query_bytes = vec![];
-    protobuf::BlockHeadersRequest {
-        iteration: Some(protobuf::Iteration {
-            start: Some(protobuf::iteration::Start::BlockNumber(start_block_number)),
-            direction: protobuf::iteration::Direction::Forward as i32,
-            limit: query_limit,
-            step: 1,
-        }),
-    }
-    .encode(&mut query_bytes)
-    .unwrap();
-
-    // Setup mock DB executor and tell it to reply to the query
-    let headers = vec![];
-    let mut mock_db_executor = MockDBExecutor::default();
-    mock_db_executor.query_to_headers.insert(query, headers);
-
-    // Setup mock swarm and tell it to pole an event of new inbound query
-    let mut mock_swarm = MockSwarm::default();
-    let inbound_session_id = InboundSessionId { value: 0 };
-    let _fut = mock_swarm.get_data_sent_to_inbound_session(inbound_session_id);
-    mock_swarm.pending_events.push(Event::Behaviour(mixed_behaviour::Event::ExternalEvent(
-        mixed_behaviour::ExternalEvent::Sqmr(GenericEvent::NewInboundSession {
-            query: query_bytes,
-            inbound_session_id,
-            peer_id: PeerId::random(),
-            protocol_name: crate::Protocol::SignedBlockHeader.into(),
-        }),
-    )));
-
-    // Initiate swarm notifier to notify upon session closed
-    let (inbound_session_closed_notifier, inbound_session_closed_receiver) = oneshot::channel();
-    mock_swarm.inbound_session_closed_notifier = Some(inbound_session_closed_notifier);
-
-    // Create network manager and run it
-    let network_manager =
-        GenericNetworkManager::generic_new(mock_swarm, mock_db_executor, BUFFER_SIZE);
-    tokio::select! {
-        _ = network_manager.run() => panic!("network manager ended"),
-        _ = inbound_session_closed_receiver => {}
         _ = sleep(Duration::from_secs(5)) => {
             panic!("Test timed out");
         }
@@ -415,9 +284,7 @@ async fn broadcast_message() {
     let mut mock_swarm = MockSwarm::default();
     let mut messages_we_broadcasted_stream = mock_swarm.stream_messages_we_broadcasted();
 
-    let mock_db_executor = MockDBExecutor::default();
-    let mut network_manager =
-        GenericNetworkManager::generic_new(mock_swarm, mock_db_executor, BUFFER_SIZE);
+    let mut network_manager = GenericNetworkManager::generic_new(mock_swarm, BUFFER_SIZE);
 
     let mut messages_to_broadcast_sender = network_manager
         .register_broadcast_subscriber(topic.clone(), BUFFER_SIZE)
@@ -453,9 +320,7 @@ async fn receive_broadcasted_message_and_report_it() {
     )));
     let mut reported_peer_receiver = mock_swarm.get_reported_peers_stream();
 
-    let mock_db_executor = MockDBExecutor::default();
-    let mut network_manager =
-        GenericNetworkManager::generic_new(mock_swarm, mock_db_executor, BUFFER_SIZE);
+    let mut network_manager = GenericNetworkManager::generic_new(mock_swarm, BUFFER_SIZE);
 
     let mut broadcasted_messages_receiver = network_manager
         .register_broadcast_subscriber::<Bytes>(topic.clone(), BUFFER_SIZE)
@@ -490,8 +355,4 @@ fn get_test_connection_established_event(mock_peer_id: PeerId) -> Event {
         concurrent_dial_errors: None,
         established_in: Duration::from_secs(0),
     }
-}
-
-lazy_static! {
-    static ref VEC: Vec<u8> = vec![1, 2, 3, 4, 5];
 }

--- a/crates/papyrus_node/src/main.rs
+++ b/crates/papyrus_node/src/main.rs
@@ -19,10 +19,12 @@ use papyrus_config::ConfigError;
 use papyrus_consensus::papyrus_consensus_context::PapyrusConsensusContext;
 use papyrus_consensus::types::ConsensusError;
 use papyrus_monitoring_gateway::MonitoringServer;
+use papyrus_network::db_executor::DBExecutor;
 use papyrus_network::gossipsub_impl::Topic;
 use papyrus_network::network_manager::{
     BroadcastSubscriberChannels,
     NetworkError,
+    SqmrQueryReceiver,
     SqmrSubscriberChannels,
 };
 use papyrus_network::{network_manager, NetworkConfig, Protocol};
@@ -30,7 +32,13 @@ use papyrus_node::config::NodeConfig;
 use papyrus_node::version::VERSION_FULL;
 use papyrus_p2p_sync::{P2PSync, P2PSyncConfig, P2PSyncError};
 use papyrus_protobuf::consensus::ConsensusMessage;
-use papyrus_protobuf::sync::{DataOrFin, HeaderQuery, SignedBlockHeader, StateDiffQuery};
+use papyrus_protobuf::sync::{
+    DataOrFin,
+    HeaderQuery,
+    SignedBlockHeader,
+    StateDiffChunk,
+    StateDiffQuery,
+};
 #[cfg(feature = "rpc")]
 use papyrus_rpc::run_server;
 use papyrus_storage::{open_storage, update_storage_metrics, StorageReader, StorageWriter};
@@ -130,10 +138,11 @@ async fn run_threads(config: NodeConfig) -> anyhow::Result<()> {
     // P2P network.
     let (
         network_future,
-        maybe_p2p_sync_query_sender_and_response_receivers,
+        maybe_sync_client_channels,
+        maybe_sync_server_channels,
         maybe_consensus_channels,
         local_peer_id,
-    ) = run_network(config.network.clone(), storage_reader.clone())?;
+    ) = run_network(config.network.clone())?;
     let network_handle = tokio::spawn(network_future);
 
     // Monitoring server.
@@ -170,8 +179,22 @@ async fn run_threads(config: NodeConfig) -> anyhow::Result<()> {
     )
     .await?;
 
+    // P2P Sync Server task.
+    let p2p_sync_server_future = match maybe_sync_server_channels {
+        Some((header_sync_server_channel, state_diff_sync_server_channel)) => {
+            let db_executor = DBExecutor::new(
+                storage_reader.clone(),
+                header_sync_server_channel,
+                state_diff_sync_server_channel,
+            );
+            db_executor.run().boxed()
+        }
+        None => pending().boxed(),
+    };
+    let p2p_sync_server_handle = tokio::spawn(p2p_sync_server_future);
+
     // Sync task.
-    let (sync_future, p2p_sync_future) = match (config.sync, config.p2p_sync) {
+    let (sync_future, p2p_sync_client_future) = match (config.sync, config.p2p_sync) {
         (Some(_), Some(_)) => {
             panic!("One of --sync.#is_none or --p2p_sync.#is_none must be turned on");
         }
@@ -183,12 +206,11 @@ async fn run_threads(config: NodeConfig) -> anyhow::Result<()> {
             (sync_fut.boxed(), pending().boxed())
         }
         (None, Some(p2p_sync_config)) => {
-            let (query_sender, response_receivers) =
-                maybe_p2p_sync_query_sender_and_response_receivers
-                    .expect("If p2p sync is enabled, network needs to be enabled too");
+            let (query_sender, response_receivers) = maybe_sync_client_channels
+                .expect("If p2p sync is enabled, network needs to be enabled too");
             (
                 pending().boxed(),
-                run_p2p_sync(
+                run_p2p_sync_client(
                     p2p_sync_config,
                     storage_reader.clone(),
                     storage_writer,
@@ -201,7 +223,7 @@ async fn run_threads(config: NodeConfig) -> anyhow::Result<()> {
         (None, None) => (pending().boxed(), pending().boxed()),
     };
     let sync_handle = tokio::spawn(sync_future);
-    let p2p_sync_handle = tokio::spawn(p2p_sync_future);
+    let p2p_sync_client_handle = tokio::spawn(p2p_sync_client_future);
 
     let consensus_handle = if let Some(consensus_channels) = maybe_consensus_channels {
         run_consensus(storage_reader.clone(), consensus_channels)?
@@ -226,9 +248,13 @@ async fn run_threads(config: NodeConfig) -> anyhow::Result<()> {
             error!("Sync stopped.");
             res??
         }
-        res = p2p_sync_handle => {
+        res = p2p_sync_client_handle => {
             error!("P2P Sync stopped.");
             res??
+        }
+        res = p2p_sync_server_handle => {
+            error!("P2P Sync server stopped");
+            res?
         }
         res = network_handle => {
             error!("Network stopped.");
@@ -272,7 +298,7 @@ async fn run_threads(config: NodeConfig) -> anyhow::Result<()> {
         sync.run().await
     }
 
-    async fn run_p2p_sync(
+    async fn run_p2p_sync_client(
         p2p_sync_config: P2PSyncConfig,
         storage_reader: StorageReader,
         storage_writer: StorageWriter,
@@ -298,28 +324,36 @@ type NetworkRunReturn = (
         SqmrSubscriberChannels<HeaderQuery, DataOrFin<SignedBlockHeader>>,
         SqmrSubscriberChannels<StateDiffQuery, DataOrFin<ThinStateDiff>>,
     )>,
+    Option<(
+        SqmrQueryReceiver<HeaderQuery, DataOrFin<SignedBlockHeader>>,
+        SqmrQueryReceiver<StateDiffQuery, DataOrFin<StateDiffChunk>>,
+    )>,
     Option<BroadcastSubscriberChannels<ConsensusMessage>>,
     String,
 );
 
-fn run_network(
-    config: Option<NetworkConfig>,
-    storage_reader: StorageReader,
-) -> anyhow::Result<NetworkRunReturn> {
+fn run_network(config: Option<NetworkConfig>) -> anyhow::Result<NetworkRunReturn> {
     let Some(network_config) = config else {
-        return Ok((pending().boxed(), None, None, "".to_string()));
+        return Ok((pending().boxed(), None, None, None, "".to_string()));
     };
-    let mut network_manager =
-        network_manager::NetworkManager::new(network_config.clone(), storage_reader.clone());
+    let mut network_manager = network_manager::NetworkManager::new(network_config.clone());
     let local_peer_id = network_manager.get_local_peer_id();
-    let header_channels = network_manager.register_sqmr_subscriber(Protocol::SignedBlockHeader);
-    let state_diff_channels = network_manager.register_sqmr_subscriber(Protocol::StateDiff);
+    let header_client_channels =
+        network_manager.register_sqmr_subscriber(Protocol::SignedBlockHeader);
+    let state_diff_client_channels = network_manager.register_sqmr_subscriber(Protocol::StateDiff);
+
+    let header_server_channel =
+        network_manager.register_sqmr_protocol_server(Protocol::SignedBlockHeader);
+    let state_diff_server_channel =
+        network_manager.register_sqmr_protocol_server(Protocol::StateDiff);
+
     let consensus_channels =
         network_manager.register_broadcast_subscriber(Topic::new("consensus"), 100)?;
 
     Ok((
         network_manager.run().boxed(),
-        Some((header_channels, state_diff_channels)),
+        Some((header_client_channels, state_diff_client_channels)),
+        Some((header_server_channel, state_diff_server_channel)),
         Some(consensus_channels),
         local_peer_id,
     ))


### PR DESCRIPTION
- refactor(network): remove Data from db executor
- refactor(network): db executor communicates through channels
- refactor(network): db executor is removed from NetworkManager and runs in a separate task

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/2122)
<!-- Reviewable:end -->
