### PR TITLE
test(network): return network manager tests

### DIFF
--- a/crates/papyrus_network/src/network_manager/mod.rs
+++ b/crates/papyrus_network/src/network_manager/mod.rs
@@ -1,8 +1,7 @@
 mod swarm_trait;
 
-// TODO(shahak): Uncomment
-// #[cfg(test)]
-// mod test;
+#[cfg(test)]
+mod test;
 
 use std::collections::HashMap;
 

--- a/crates/papyrus_network/src/network_manager/test.rs
+++ b/crates/papyrus_network/src/network_manager/test.rs
@@ -5,30 +5,23 @@ use std::task::{Context, Poll};
 use std::time::Duration;
 use std::vec;
 
-use async_trait::async_trait;
 use deadqueue::unlimited::Queue;
-use futures::channel::mpsc::{unbounded, Sender, UnboundedSender};
+use futures::channel::mpsc::{unbounded, UnboundedSender};
 use futures::channel::oneshot;
-use futures::future::{pending, poll_fn, FutureExt};
-use futures::stream::{FuturesUnordered, Stream};
+use futures::future::{poll_fn, FutureExt};
+use futures::stream::Stream;
 use futures::{pin_mut, Future, SinkExt, StreamExt};
 use lazy_static::lazy_static;
 use libp2p::core::ConnectedPoint;
 use libp2p::gossipsub::{SubscriptionError, TopicHash};
 use libp2p::swarm::ConnectionId;
 use libp2p::{Multiaddr, PeerId};
-use papyrus_protobuf::protobuf;
-use papyrus_protobuf::sync::{BlockHashOrNumber, DataOrFin, Direction, Query, SignedBlockHeader};
-use prost::Message;
-use starknet_api::block::{BlockHeader, BlockNumber};
 use tokio::select;
 use tokio::sync::Mutex;
-use tokio::task::JoinHandle;
 use tokio::time::sleep;
 
 use super::swarm_trait::{Event, SwarmTrait};
 use super::{GenericNetworkManager, SqmrSubscriberChannels};
-use crate::db_executor::{DBExecutorError, DBExecutorTrait, Data, FetchBlockDataFromDb};
 use crate::gossipsub_impl::{self, Topic};
 use crate::mixed_behaviour;
 use crate::sqmr::behaviour::{PeerNotConnected, SessionIdNotFoundError};
@@ -36,16 +29,21 @@ use crate::sqmr::{Bytes, GenericEvent, InboundSessionId, OutboundSessionId};
 
 const TIMEOUT: Duration = Duration::from_secs(1);
 
+lazy_static! {
+    static ref VEC1: Vec<u8> = vec![1, 2, 3, 4, 5];
+    static ref VEC2: Vec<u8> = vec![6, 7, 8];
+    static ref VEC3: Vec<u8> = vec![9, 10];
+}
+
 #[derive(Default)]
 struct MockSwarm {
     pub pending_events: Queue<Event>,
     pub subscribed_topics: HashSet<TopicHash>,
     broadcasted_messages_senders: Vec<UnboundedSender<(Bytes, TopicHash)>>,
     reported_peer_senders: Vec<UnboundedSender<PeerId>>,
-    inbound_session_id_to_data_sender: HashMap<InboundSessionId, UnboundedSender<Data>>,
+    inbound_session_id_to_response_sender: HashMap<InboundSessionId, UnboundedSender<Bytes>>,
     next_outbound_session_id: usize,
     first_polled_event_notifier: Option<oneshot::Sender<()>>,
-    inbound_session_closed_notifier: Option<oneshot::Sender<()>>,
 }
 
 impl Stream for MockSwarm {
@@ -68,16 +66,19 @@ impl Stream for MockSwarm {
 }
 
 impl MockSwarm {
-    pub fn get_data_sent_to_inbound_session(
+    pub fn get_responses_sent_to_inbound_session(
         &mut self,
         inbound_session_id: InboundSessionId,
-    ) -> impl Future<Output = Vec<Data>> {
-        let (data_sender, data_receiver) = unbounded();
-        if self.inbound_session_id_to_data_sender.insert(inbound_session_id, data_sender).is_some()
+    ) -> impl Future<Output = Vec<Bytes>> {
+        let (responses_sender, responses_receiver) = unbounded();
+        if self
+            .inbound_session_id_to_response_sender
+            .insert(inbound_session_id, responses_sender)
+            .is_some()
         {
-            panic!("Called get_data_sent_to_inbound_session on {inbound_session_id:?} twice");
+            panic!("Called get_responses_sent_to_inbound_session on {inbound_session_id:?} twice");
         }
-        data_receiver.collect()
+        responses_receiver.collect()
     }
 
     pub fn stream_messages_we_broadcasted(&mut self) -> impl Stream<Item = (Bytes, TopicHash)> {
@@ -116,19 +117,11 @@ impl SwarmTrait for MockSwarm {
         data: Vec<u8>,
         inbound_session_id: InboundSessionId,
     ) -> Result<(), SessionIdNotFoundError> {
-        let data_sender = self
-            .inbound_session_id_to_data_sender
+        let responses_sender = self
+            .inbound_session_id_to_response_sender
             .get(&inbound_session_id)
-            .expect("Called send_data without calling get_data_sent_to_inbound_session first");
-        let data = DataOrFin::<SignedBlockHeader>::try_from(
-            protobuf::BlockHeadersResponse::decode(&data[..]).unwrap(),
-        )
-        .unwrap();
-        let is_fin = data.0.is_none();
-        data_sender.unbounded_send(Data::BlockHeaderAndSignature(data)).unwrap();
-        if is_fin {
-            data_sender.close_channel();
-        }
+            .expect("Called send_data without calling get_responses_sent_to_inbound_session first");
+        responses_sender.unbounded_send(data).unwrap();
         Ok(())
     }
 
@@ -156,11 +149,14 @@ impl SwarmTrait for MockSwarm {
     }
     fn close_inbound_session(
         &mut self,
-        _session_id: InboundSessionId,
+        inbound_session_id: InboundSessionId,
     ) -> Result<(), SessionIdNotFoundError> {
-        if let Some(sender) = self.inbound_session_closed_notifier.take() {
-            sender.send(()).unwrap();
-        }
+        let responses_sender =
+            self.inbound_session_id_to_response_sender.get(&inbound_session_id).expect(
+                "Called close_inbound_session without calling \
+                 get_responses_sent_to_inbound_session first",
+            );
+        responses_sender.close_channel();
         Ok(())
     }
 
@@ -188,50 +184,6 @@ impl SwarmTrait for MockSwarm {
     }
 }
 
-#[derive(Default)]
-struct MockDBExecutor {
-    pub query_to_headers: HashMap<Query, Vec<BlockHeader>>,
-    query_execution_set: FuturesUnordered<JoinHandle<Result<(), DBExecutorError>>>,
-}
-
-#[async_trait]
-impl DBExecutorTrait for MockDBExecutor {
-    // TODO(shahak): Consider fixing code duplication with DBExecutor.
-    fn register_query(
-        &mut self,
-        query: Query,
-        _data_type: impl FetchBlockDataFromDb + Send,
-        mut sender: Sender<Data>,
-    ) {
-        let headers = self.query_to_headers.get(&query).unwrap().clone();
-        self.query_execution_set.push(tokio::task::spawn(async move {
-            {
-                for header in headers.iter().cloned() {
-                    // Using poll_fn because Sender::poll_ready is not a future
-                    if let Ok(()) = poll_fn(|cx| sender.poll_ready(cx)).await {
-                        sender.start_send(Data::BlockHeaderAndSignature(DataOrFin(Some(
-                            SignedBlockHeader { block_header: header, signatures: vec![] },
-                        ))))?;
-                    }
-                }
-                sender.start_send(Data::BlockHeaderAndSignature(DataOrFin(None)))?;
-                Ok(())
-            }
-        }));
-    }
-    async fn run(&mut self) {
-        loop {
-            let result =
-                futures::future::poll_fn(|cx| self.query_execution_set.poll_next_unpin(cx)).await;
-            if result.is_none() {
-                // We assume that if all queries are finished then there won't come any new
-                // queries.
-                return pending().await;
-            }
-        }
-    }
-}
-
 const BUFFER_SIZE: usize = 100;
 
 #[tokio::test]
@@ -244,8 +196,7 @@ async fn register_sqmr_subscriber_and_use_channels() {
     mock_swarm.first_polled_event_notifier = Some(event_notifier);
 
     // network manager to register subscriber and send query
-    let mut network_manager =
-        GenericNetworkManager::generic_new(mock_swarm, MockDBExecutor::default(), BUFFER_SIZE);
+    let mut network_manager = GenericNetworkManager::generic_new(mock_swarm, BUFFER_SIZE);
 
     // register subscriber and send query
     let SqmrSubscriberChannels { mut query_sender, response_receiver } = network_manager
@@ -255,18 +206,18 @@ async fn register_sqmr_subscriber_and_use_channels() {
     let cloned_response_receiver_length = Arc::clone(&response_receiver_length);
     let response_receiver_collector = response_receiver
         .enumerate()
-        .take(VEC.len())
+        .take(VEC1.len())
         .map(|(i, (result, _report_callback))| {
             let result = result.unwrap();
             // this simulates how the mock swarm parses the query and sends responses to it
-            assert_eq!(result, vec![VEC[i]]);
+            assert_eq!(result, vec![VEC1[i]]);
             result
         })
         .collect::<Vec<_>>();
     tokio::select! {
         _ = network_manager.run() => panic!("network manager ended"),
         _ = poll_fn(|cx| event_listner.poll_unpin(cx)).then(|_| async move {
-            query_sender.send(VEC.clone()).await.unwrap()})
+            query_sender.send(VEC1.clone()).await.unwrap()})
             .then(|_| async move {
                 *cloned_response_receiver_length.lock().await = response_receiver_collector.await.len();
             }) => {},
@@ -274,133 +225,51 @@ async fn register_sqmr_subscriber_and_use_channels() {
             panic!("Test timed out");
         }
     }
-    assert_eq!(*response_receiver_length.lock().await, VEC.len());
+    assert_eq!(*response_receiver_length.lock().await, VEC1.len());
 }
 
+// TODO(shahak): Add multiple protocols and multiple queries in the test.
 #[tokio::test]
 async fn process_incoming_query() {
     // Create data for test.
-    const BLOCK_NUM: u64 = 0;
-    let query = Query {
-        start_block: BlockHashOrNumber::Number(BlockNumber(BLOCK_NUM)),
-        direction: Direction::Forward,
-        limit: 5,
-        step: 1,
-    };
-    let headers = (0..5)
-        // TODO(shahak): Remove state_diff_length from here once we correctly deduce if it should
-        // be None or Some.
-        .map(|i| BlockHeader { block_number: BlockNumber(i), state_diff_length: Some(0), ..Default::default() })
-        .collect::<Vec<_>>();
-
-    // Setup mock DB executor and tell it to reply to the query with the given headers.
-    let mut mock_db_executor = MockDBExecutor::default();
-    mock_db_executor.query_to_headers.insert(query.clone(), headers.clone());
+    let query = VEC1.clone();
+    let responses = vec![VEC1.clone(), VEC2.clone(), VEC3.clone()];
+    let protocol = crate::Protocol::SignedBlockHeader;
 
     // Setup mock swarm and tell it to return an event of new inbound query.
     let mut mock_swarm = MockSwarm::default();
     let inbound_session_id = InboundSessionId { value: 0 };
-    let mut query_bytes = vec![];
-    protobuf::BlockHeadersRequest {
-        iteration: Some(protobuf::Iteration {
-            start: Some(protobuf::iteration::Start::BlockNumber(BLOCK_NUM)),
-            direction: protobuf::iteration::Direction::Forward as i32,
-            limit: query.limit,
-            step: query.step,
-        }),
-    }
-    .encode(&mut query_bytes)
-    .unwrap();
     mock_swarm.pending_events.push(Event::Behaviour(mixed_behaviour::Event::ExternalEvent(
         mixed_behaviour::ExternalEvent::Sqmr(GenericEvent::NewInboundSession {
-            query: query_bytes,
+            query: query.clone(),
             inbound_session_id,
             peer_id: PeerId::random(),
-            protocol_name: crate::Protocol::SignedBlockHeader.into(),
+            protocol_name: protocol.into(),
         }),
     )));
 
-    // Create a future that will return when Fin is sent with the data sent on the swarm.
-    let get_data_fut = mock_swarm.get_data_sent_to_inbound_session(inbound_session_id);
+    // Create a future that will return when the session is closed with the data sent on the swarm.
+    let get_responses_fut = mock_swarm.get_responses_sent_to_inbound_session(inbound_session_id);
 
-    let network_manager =
-        GenericNetworkManager::generic_new(mock_swarm, mock_db_executor, BUFFER_SIZE);
+    let mut network_manager = GenericNetworkManager::generic_new(mock_swarm, BUFFER_SIZE);
 
+    let mut inbound_query_receiver =
+        network_manager.register_sqmr_protocol_server::<Vec<u8>, Vec<u8>>(protocol);
+
+    let responses_clone = responses.clone();
     select! {
-        inbound_session_data = get_data_fut => {
-            let mut expected_data = headers
-                .into_iter()
-                .map(|header| {
-                    Data::BlockHeaderAndSignature(DataOrFin(Some(SignedBlockHeader {
-                        block_header: header, signatures: vec![]
-                    })))
-                })
-                .collect::<Vec<_>>();
-            expected_data.push(Data::BlockHeaderAndSignature(DataOrFin(None)));
-            assert_eq!(inbound_session_data, expected_data);
-        }
+        _ = async move {
+            let (query_got, mut responses_sender) = inbound_query_receiver.next().await.unwrap();
+            assert_eq!(query_got.unwrap(), query);
+            for response in responses_clone {
+                responses_sender.feed(response).await.unwrap();
+            }
+            responses_sender.close().await.unwrap();
+            assert_eq!(get_responses_fut.await, responses);
+        } => {}
         _ = network_manager.run() => {
             panic!("GenericNetworkManager::run finished before the session finished");
         }
-        _ = sleep(Duration::from_secs(5)) => {
-            panic!("Test timed out");
-        }
-    }
-}
-
-#[tokio::test]
-async fn close_inbound_session() {
-    // define query
-    let query_limit = 5;
-    let start_block_number = 0;
-    let query = Query {
-        start_block: BlockHashOrNumber::Number(BlockNumber(start_block_number)),
-        direction: Direction::Forward,
-        limit: query_limit,
-        step: 1,
-    };
-
-    // get query bytes
-    let mut query_bytes = vec![];
-    protobuf::BlockHeadersRequest {
-        iteration: Some(protobuf::Iteration {
-            start: Some(protobuf::iteration::Start::BlockNumber(start_block_number)),
-            direction: protobuf::iteration::Direction::Forward as i32,
-            limit: query_limit,
-            step: 1,
-        }),
-    }
-    .encode(&mut query_bytes)
-    .unwrap();
-
-    // Setup mock DB executor and tell it to reply to the query
-    let headers = vec![];
-    let mut mock_db_executor = MockDBExecutor::default();
-    mock_db_executor.query_to_headers.insert(query, headers);
-
-    // Setup mock swarm and tell it to pole an event of new inbound query
-    let mut mock_swarm = MockSwarm::default();
-    let inbound_session_id = InboundSessionId { value: 0 };
-    let _fut = mock_swarm.get_data_sent_to_inbound_session(inbound_session_id);
-    mock_swarm.pending_events.push(Event::Behaviour(mixed_behaviour::Event::ExternalEvent(
-        mixed_behaviour::ExternalEvent::Sqmr(GenericEvent::NewInboundSession {
-            query: query_bytes,
-            inbound_session_id,
-            peer_id: PeerId::random(),
-            protocol_name: crate::Protocol::SignedBlockHeader.into(),
-        }),
-    )));
-
-    // Initiate swarm notifier to notify upon session closed
-    let (inbound_session_closed_notifier, inbound_session_closed_receiver) = oneshot::channel();
-    mock_swarm.inbound_session_closed_notifier = Some(inbound_session_closed_notifier);
-
-    // Create network manager and run it
-    let network_manager =
-        GenericNetworkManager::generic_new(mock_swarm, mock_db_executor, BUFFER_SIZE);
-    tokio::select! {
-        _ = network_manager.run() => panic!("network manager ended"),
-        _ = inbound_session_closed_receiver => {}
         _ = sleep(Duration::from_secs(5)) => {
             panic!("Test timed out");
         }
@@ -415,9 +284,7 @@ async fn broadcast_message() {
     let mut mock_swarm = MockSwarm::default();
     let mut messages_we_broadcasted_stream = mock_swarm.stream_messages_we_broadcasted();
 
-    let mock_db_executor = MockDBExecutor::default();
-    let mut network_manager =
-        GenericNetworkManager::generic_new(mock_swarm, mock_db_executor, BUFFER_SIZE);
+    let mut network_manager = GenericNetworkManager::generic_new(mock_swarm, BUFFER_SIZE);
 
     let mut messages_to_broadcast_sender = network_manager
         .register_broadcast_subscriber(topic.clone(), BUFFER_SIZE)
@@ -453,9 +320,7 @@ async fn receive_broadcasted_message_and_report_it() {
     )));
     let mut reported_peer_receiver = mock_swarm.get_reported_peers_stream();
 
-    let mock_db_executor = MockDBExecutor::default();
-    let mut network_manager =
-        GenericNetworkManager::generic_new(mock_swarm, mock_db_executor, BUFFER_SIZE);
+    let mut network_manager = GenericNetworkManager::generic_new(mock_swarm, BUFFER_SIZE);
 
     let mut broadcasted_messages_receiver = network_manager
         .register_broadcast_subscriber::<Bytes>(topic.clone(), BUFFER_SIZE)
@@ -490,8 +355,4 @@ fn get_test_connection_established_event(mock_peer_id: PeerId) -> Event {
         concurrent_dial_errors: None,
         established_in: Duration::from_secs(0),
     }
-}
-
-lazy_static! {
-    static ref VEC: Vec<u8> = vec![1, 2, 3, 4, 5];
 }


### PR DESCRIPTION
- refactor(network): remove Data from db executor
- refactor(network): db executor communicates through channels
- refactor(network): db executor is removed from NetworkManager and runs in a separate task
- WIP
- test(network): return network manager tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/2124)
<!-- Reviewable:end -->
