### PR TITLE
feat(consensus): add broadcast method to Context trait for any ConsensusMessage

### DIFF
--- a/crates/sequencing/papyrus_consensus/src/papyrus_consensus_context.rs
+++ b/crates/sequencing/papyrus_consensus/src/papyrus_consensus_context.rs
@@ -165,6 +165,12 @@ impl ConsensusContext for PapyrusConsensusContext {
         (height.0 % 2).into()
     }
 
+    async fn broadcast(&self, message: ConsensusMessage) -> Result<(), ConsensusError> {
+        debug!("Broadcasting message: {message:?}");
+        self.broadcast_sender.lock().await.send(message).await?;
+        Ok(())
+    }
+
     async fn propose(
         &self,
         init: ProposalInit,
@@ -187,6 +193,7 @@ impl ConsensusContext for PapyrusConsensusContext {
                 transactions,
                 block_hash,
             };
+            debug!("Sending proposal: {proposal:?}");
 
             broadcast_sender
                 .lock()

--- a/crates/sequencing/papyrus_consensus/src/test_utils.rs
+++ b/crates/sequencing/papyrus_consensus/src/test_utils.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use futures::channel::{mpsc, oneshot};
 use mockall::mock;
+use papyrus_protobuf::consensus::ConsensusMessage;
 use starknet_api::block::{BlockHash, BlockNumber};
 
 use crate::types::{ConsensusBlock, ConsensusContext, ConsensusError, ProposalInit, ValidatorId};
@@ -47,6 +48,8 @@ mock! {
         async fn validators(&self, height: BlockNumber) -> Vec<ValidatorId>;
 
         fn proposer(&self, validators: &[ValidatorId], height: BlockNumber) -> ValidatorId;
+
+        async fn broadcast(&self, message: ConsensusMessage) -> Result<(), ConsensusError>;
 
         async fn propose(
             &self,

--- a/crates/sequencing/papyrus_consensus/src/types.rs
+++ b/crates/sequencing/papyrus_consensus/src/types.rs
@@ -4,6 +4,7 @@ mod types_test;
 
 use async_trait::async_trait;
 use futures::channel::{mpsc, oneshot};
+use papyrus_protobuf::consensus::ConsensusMessage;
 use starknet_api::block::{BlockHash, BlockNumber};
 use starknet_api::core::ContractAddress;
 
@@ -130,6 +131,8 @@ pub trait ConsensusContext: Send + Sync {
     /// Calculates the ID of the Proposer based on the inputs.
     fn proposer(&self, validators: &[ValidatorId], height: BlockNumber) -> ValidatorId;
 
+    async fn broadcast(&self, message: ConsensusMessage) -> Result<(), ConsensusError>;
+
     /// This should be non-blocking. Meaning it returns immediately and waits to receive from the
     /// input channels in parallel (ie on a separate task).
     // TODO(matan): change to just be a generic broadcast function.
@@ -153,4 +156,6 @@ pub enum ConsensusError {
     Canceled(#[from] oneshot::Canceled),
     #[error("Invalid proposal sent by peer {0:?} at height {1}: {2}")]
     InvalidProposal(ValidatorId, BlockNumber, String),
+    #[error(transparent)]
+    SendError(#[from] mpsc::SendError),
 }


### PR DESCRIPTION
This is separate from  since propose should eventually be streamed on the network.
Therefore we mock that via a specialized fn in Context.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/2169)
<!-- Reviewable:end -->
