### PR TITLE
fix: put none in commitments if they come from a deprecated formula

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8384,8 +8384,9 @@ dependencies = [
 
 [[package]]
 name = "starknet_api"
-version = "0.13.0-dev.8"
-source = "git+https://github.com/starkware-libs/starknet-api?rev=f76fe54#f76fe54efa11d4d4933a3c192156327251d9516c"
+version = "0.13.0-dev.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66a6dc6b4f77fff0f28894cc36d5a691784550054d06c6850e901278aed2c7e6"
 dependencies = [
  "bitvec",
  "cairo-lang-starknet-classes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ serde_repr = "0.1"
 serde_yaml = "0.9.16"
 sha3 = "0.10.8"
 simple_logger = "4.0.0"
-starknet_api = "0.13.0-dev.6"
+starknet_api = "0.13.0-dev.9"
 starknet-core = "0.6.0"
 starknet-crypto = "0.5.1"
 starknet-types-core = "0.1.2"
@@ -151,6 +151,3 @@ url = "2.2.2"
 validator = "0.12"
 void = "1.0.2"
 zstd = "0.13.1"
-
-[patch.crates-io]
-starknet_api = { git = "https://github.com/starkware-libs/starknet-api", rev = "f76fe54" }

--- a/crates/papyrus_storage/src/header.rs
+++ b/crates/papyrus_storage/src/header.rs
@@ -75,7 +75,7 @@ pub(crate) struct StorageBlockHeader {
     pub sequencer: SequencerContractAddress,
     pub timestamp: BlockTimestamp,
     pub l1_da_mode: L1DataAvailabilityMode,
-    pub state_diff_commitment: StateDiffCommitment,
+    pub state_diff_commitment: Option<StateDiffCommitment>,
     pub transaction_commitment: Option<TransactionCommitment>,
     pub event_commitment: Option<EventCommitment>,
     pub receipt_commitment: Option<ReceiptCommitment>,

--- a/crates/papyrus_storage/src/serialization/serializers.rs
+++ b/crates/papyrus_storage/src/serialization/serializers.rs
@@ -160,7 +160,7 @@ auto_storage_serde! {
         pub sequencer: SequencerContractAddress,
         pub timestamp: BlockTimestamp,
         pub l1_da_mode: L1DataAvailabilityMode,
-        pub state_diff_commitment: StateDiffCommitment,
+        pub state_diff_commitment: Option<StateDiffCommitment>,
         pub transaction_commitment: Option<TransactionCommitment>,
         pub event_commitment: Option<EventCommitment>,
         pub receipt_commitment: Option<ReceiptCommitment>,

--- a/crates/papyrus_storage/src/test_instances.rs
+++ b/crates/papyrus_storage/src/test_instances.rs
@@ -34,7 +34,7 @@ auto_impl_get_test_instance! {
         pub sequencer: SequencerContractAddress,
         pub timestamp: BlockTimestamp,
         pub l1_da_mode: L1DataAvailabilityMode,
-        pub state_diff_commitment: StateDiffCommitment,
+        pub state_diff_commitment: Option<StateDiffCommitment>,
         pub transaction_commitment: Option<TransactionCommitment>,
         pub event_commitment: Option<EventCommitment>,
         pub receipt_commitment: Option<ReceiptCommitment>,

--- a/crates/test_utils/src/lib.rs
+++ b/crates/test_utils/src/lib.rs
@@ -433,7 +433,7 @@ auto_impl_get_test_instance! {
         pub sequencer: SequencerContractAddress,
         pub timestamp: BlockTimestamp,
         pub l1_da_mode: L1DataAvailabilityMode,
-        pub state_diff_commitment: StateDiffCommitment,
+        pub state_diff_commitment: Option<StateDiffCommitment>,
         pub transaction_commitment: Option<TransactionCommitment>,
         pub event_commitment: Option<EventCommitment>,
         pub receipt_commitment: Option<ReceiptCommitment>,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/2180)
<!-- Reviewable:end -->
