### PR TITLE
fix(network): replace panic with error in unexpected swarm event

### DIFF
--- a/crates/papyrus_network/src/network_manager/mod.rs
+++ b/crates/papyrus_network/src/network_manager/mod.rs
@@ -260,7 +260,7 @@ impl<SwarmT: SwarmTrait> GenericNetworkManager<SwarmT> {
             | SwarmEvent::Dialing { .. }
             | SwarmEvent::NewExternalAddrCandidate { .. } => {}
             _ => {
-                panic!("Unexpected event {event:?}");
+                error!("Unexpected event {event:?}");
             }
         }
     }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/2208)
<!-- Reviewable:end -->
