### PR TITLE
feat(consensus): consensus network buffer size uses the default value

### DIFF
--- a/crates/papyrus_node/src/main.rs
+++ b/crates/papyrus_node/src/main.rs
@@ -375,7 +375,8 @@ fn run_network(
 
     let consensus_channels = match consensus_config {
         Some(consensus_config) => Some(
-            network_manager.register_broadcast_topic(Topic::new(consensus_config.topic), 100)?,
+            network_manager
+                .register_broadcast_topic(Topic::new(consensus_config.topic), BUFFER_SIZE)?,
         ),
         None => None,
     };


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/2223)
<!-- Reviewable:end -->
