### PR TITLE
chore(consensus): fix typo in state machine

### DIFF
--- a/crates/sequencing/papyrus_consensus/src/state_machine.rs
+++ b/crates/sequencing/papyrus_consensus/src/state_machine.rs
@@ -97,7 +97,7 @@ impl StateMachine {
 
     /// Process the incoming event.
     ///
-    /// If we are waiting for a a response to `StartRound` all other incoming events are buffered
+    /// If we are waiting for a response to `StartRound` all other incoming events are buffered
     /// until that response arrives.
     ///
     /// Returns a set of events for the caller to handle. The caller should not mirror the output


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/2231)
<!-- Reviewable:end -->
