### PR TITLE
refactor(consensus): change the broadcast fn in context to take 'ref mut self'

### DIFF
--- a/crates/sequencing/papyrus_consensus/src/lib.rs
+++ b/crates/sequencing/papyrus_consensus/src/lib.rs
@@ -36,7 +36,7 @@ use futures::StreamExt;
 #[instrument(skip(context, validator_id, network_receiver, cached_messages), level = "info")]
 #[allow(missing_docs)]
 async fn run_height<BlockT: ConsensusBlock, ContextT: ConsensusContext<Block = BlockT>>(
-    context: &ContextT,
+    context: &mut ContextT,
     height: BlockNumber,
     validator_id: ValidatorId,
     network_receiver: &mut BroadcastSubscriberReceiver<ConsensusMessage>,
@@ -103,7 +103,7 @@ where
 #[instrument(skip(context, start_height, network_receiver), level = "info")]
 #[allow(missing_docs)]
 pub async fn run_consensus<BlockT: ConsensusBlock, ContextT: ConsensusContext<Block = BlockT>>(
-    context: ContextT,
+    mut context: ContextT,
     start_height: BlockNumber,
     validator_id: ValidatorId,
     mut network_receiver: BroadcastSubscriberReceiver<ConsensusMessage>,
@@ -116,7 +116,7 @@ where
     let mut future_messages = Vec::new();
     loop {
         let decision = run_height(
-            &context,
+            &mut context,
             current_height,
             validator_id,
             &mut network_receiver,

--- a/crates/sequencing/papyrus_consensus/src/single_height_consensus.rs
+++ b/crates/sequencing/papyrus_consensus/src/single_height_consensus.rs
@@ -54,7 +54,7 @@ impl<BlockT: ConsensusBlock> SingleHeightConsensus<BlockT> {
     #[instrument(skip_all, fields(height=self.height.0), level = "debug")]
     pub(crate) async fn start<ContextT: ConsensusContext<Block = BlockT>>(
         &mut self,
-        context: &ContextT,
+        context: &mut ContextT,
     ) -> Result<Option<Decision<BlockT>>, ConsensusError> {
         info!("Starting consensus with validators {:?}", self.validators);
         let events = self.state_machine.start();
@@ -70,7 +70,7 @@ impl<BlockT: ConsensusBlock> SingleHeightConsensus<BlockT> {
     )]
     pub(crate) async fn handle_proposal<ContextT: ConsensusContext<Block = BlockT>>(
         &mut self,
-        context: &ContextT,
+        context: &mut ContextT,
         init: ProposalInit,
         p2p_messages_receiver: mpsc::Receiver<<BlockT as ConsensusBlock>::ProposalChunk>,
         fin_receiver: oneshot::Receiver<BlockHash>,
@@ -126,7 +126,7 @@ impl<BlockT: ConsensusBlock> SingleHeightConsensus<BlockT> {
     #[instrument(skip_all)]
     pub(crate) async fn handle_message<ContextT: ConsensusContext<Block = BlockT>>(
         &mut self,
-        context: &ContextT,
+        context: &mut ContextT,
         message: ConsensusMessage,
     ) -> Result<Option<Decision<BlockT>>, ConsensusError> {
         debug!("Received message: {:?}", message);
@@ -141,7 +141,7 @@ impl<BlockT: ConsensusBlock> SingleHeightConsensus<BlockT> {
     #[instrument(skip_all)]
     async fn handle_vote<ContextT: ConsensusContext<Block = BlockT>>(
         &mut self,
-        context: &ContextT,
+        context: &mut ContextT,
         vote: Vote,
     ) -> Result<Option<Decision<BlockT>>, ConsensusError> {
         let (votes, sm_vote) = match vote.vote_type {
@@ -174,7 +174,7 @@ impl<BlockT: ConsensusBlock> SingleHeightConsensus<BlockT> {
     #[instrument(skip_all)]
     async fn handle_state_machine_events<ContextT: ConsensusContext<Block = BlockT>>(
         &mut self,
-        context: &ContextT,
+        context: &mut ContextT,
         mut events: VecDeque<StateMachineEvent>,
     ) -> Result<Option<Decision<BlockT>>, ConsensusError> {
         while let Some(event) = events.pop_front() {
@@ -210,7 +210,7 @@ impl<BlockT: ConsensusBlock> SingleHeightConsensus<BlockT> {
     #[instrument(skip(self, context), level = "debug")]
     async fn handle_state_machine_start_round<ContextT: ConsensusContext<Block = BlockT>>(
         &mut self,
-        context: &ContextT,
+        context: &mut ContextT,
         block_hash: Option<BlockHash>,
         round: Round,
     ) -> VecDeque<StateMachineEvent> {
@@ -249,7 +249,7 @@ impl<BlockT: ConsensusBlock> SingleHeightConsensus<BlockT> {
     #[instrument(skip_all)]
     async fn handle_state_machine_vote<ContextT: ConsensusContext<Block = BlockT>>(
         &mut self,
-        context: &ContextT,
+        context: &mut ContextT,
         block_hash: BlockHash,
         round: Round,
         vote_type: VoteType,

--- a/crates/sequencing/papyrus_consensus/src/test_utils.rs
+++ b/crates/sequencing/papyrus_consensus/src/test_utils.rs
@@ -49,7 +49,7 @@ mock! {
 
         fn proposer(&self, validators: &[ValidatorId], height: BlockNumber) -> ValidatorId;
 
-        async fn broadcast(&self, message: ConsensusMessage) -> Result<(), ConsensusError>;
+        async fn broadcast(&mut self, message: ConsensusMessage) -> Result<(), ConsensusError>;
 
         async fn propose(
             &self,

--- a/crates/sequencing/papyrus_consensus/src/types.rs
+++ b/crates/sequencing/papyrus_consensus/src/types.rs
@@ -123,7 +123,7 @@ pub trait ConsensusContext {
     /// Calculates the ID of the Proposer based on the inputs.
     fn proposer(&self, validators: &[ValidatorId], height: BlockNumber) -> ValidatorId;
 
-    async fn broadcast(&self, message: ConsensusMessage) -> Result<(), ConsensusError>;
+    async fn broadcast(&mut self, message: ConsensusMessage) -> Result<(), ConsensusError>;
 
     /// This should be non-blocking. Meaning it returns immediately and waits to receive from the
     /// input channels in parallel (ie on a separate task).


### PR DESCRIPTION
This allows us to remove the Arc<Mutex> and also avoid cloning the sender on every call.
The cost is that we leak the fact that futures Sender requires .

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/papyrus/2241)
<!-- Reviewable:end -->
